### PR TITLE
Fix loop to iterate over arrayInput instead of items

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix bug when setting array input with more array items than previous state (pull request #29)
+
 ## v0.4.0 (September 22, 2025)
 
 - Add new `initialElements` state to `InternalBaseStore` interface and update `initializeFieldStore`

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -88,8 +88,12 @@ function setNestedInput(
     }
 
     // Set input for each array item
-    // @ts-expect-error
-    for (let index = 0; index < arrayInput.length; index++) {
+    for (
+      let index = 0;
+      // @ts-expect-error
+      index < arrayInput.length;
+      index++
+    ) {
       // Recursively set nested input
       setNestedInput(
         internalFieldStore.children[index],


### PR DESCRIPTION
This PR fixes a bug when using `setInput` to set arrays.