### PR TITLE
Add agent-skill to installation pages and llms.txt

### DIFF
--- a/website/src/routes/(docs)/preact/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(get-started)/installation/index.mdx
@@ -4,6 +4,7 @@ description: >-
   In this guide you will learn how to add Formisch to your project.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # Installation
@@ -57,11 +58,10 @@ import { … } from '@formisch/preact';
 
 ## For AI Agents
 
-Formisch includes an agent skill that teaches AI agents the correct patterns for working with Formisch forms. You can install it by running one of the following commands in your terminal:
+We provide agent skills that teach AI agents the correct patterns for working with Valibot and Formisch. You can install them by running the following command in your terminal:
 
 ```bash
 npx skills add open-circle/agent-skills
-npx add-skill open-circle/agent-skills
 ```
 
-[Learn more](https://github.com/open-circle/agent-skills) about the Formisch skill.
+You can learn more about the Valibot and Formisch agent skill [here](https://github.com/open-circle/agent-skills).

--- a/website/src/routes/(docs)/preact/guides/(get-started)/llms-txt/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(get-started)/llms-txt/index.mdx
@@ -5,6 +5,7 @@ description: >-
   files to help the AI better understand the library.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # LLMs.txt
@@ -25,9 +26,11 @@ We provide several LLMs.txt routes. Use the route that works best with your AI t
 - [`llms-preact-guides.txt`](/llms-preact-guides.txt) contains the Markdown content of the Preact guides
 - [`llms-preact-api.txt`](/llms-preact-api.txt) contains the Markdown content of the Preact API reference
 
+> We also provide a Markdown version of every documentation page. You can access it by replacing the trailing slash (`/`) in the URL with `.md`. For example, `/preact/guides/installation/` becomes `/preact/guides/installation.md`.
+
 ## For AI Agents
 
-[`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state
+Our [`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state.
 
 ## How to use it
 

--- a/website/src/routes/(docs)/qwik/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(get-started)/installation/index.mdx
@@ -4,6 +4,7 @@ description: >-
   In this guide you will learn how to add Formisch to your project.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # Installation
@@ -57,11 +58,10 @@ import { … } from '@formisch/qwik';
 
 ## For AI Agents
 
-Formisch includes an agent skill that teaches AI agents the correct patterns for working with Formisch forms. You can install it by running one of the following commands in your terminal:
+We provide agent skills that teach AI agents the correct patterns for working with Valibot and Formisch. You can install them by running the following command in your terminal:
 
 ```bash
 npx skills add open-circle/agent-skills
-npx add-skill open-circle/agent-skills
 ```
 
-[Learn more](https://github.com/open-circle/agent-skills) about the Formisch skill.
+You can learn more about the Valibot and Formisch agent skill [here](https://github.com/open-circle/agent-skills).

--- a/website/src/routes/(docs)/qwik/guides/(get-started)/llms-txt/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(get-started)/llms-txt/index.mdx
@@ -5,6 +5,7 @@ description: >-
   files to help the AI better understand the library.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # LLMs.txt
@@ -25,9 +26,11 @@ We provide several LLMs.txt routes. Use the route that works best with your AI t
 - [`llms-qwik-guides.txt`](/llms-qwik-guides.txt) contains the Markdown content of the Qwik guides
 - [`llms-qwik-api.txt`](/llms-qwik-api.txt) contains the Markdown content of the Qwik API reference
 
+> We also provide a Markdown version of every documentation page. You can access it by replacing the trailing slash (`/`) in the URL with `.md`. For example, `/qwik/guides/installation/` becomes `/qwik/guides/installation.md`.
+
 ## For AI Agents
 
-[`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state
+Our [`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state.
 
 ## How to use it
 

--- a/website/src/routes/(docs)/react/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(get-started)/installation/index.mdx
@@ -4,6 +4,7 @@ description: >-
   In this guide you will learn how to add Formisch to your project.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # Installation
@@ -57,11 +58,10 @@ import { … } from '@formisch/react';
 
 ## For AI Agents
 
-Formisch includes an agent skill that teaches AI agents the correct patterns for working with Formisch forms. You can install it by running one of the following commands in your terminal:
+We provide agent skills that teach AI agents the correct patterns for working with Valibot and Formisch. You can install them by running the following command in your terminal:
 
 ```bash
 npx skills add open-circle/agent-skills
-npx add-skill open-circle/agent-skills
 ```
 
-[Learn more](https://github.com/open-circle/agent-skills) about the Formisch skill.
+You can learn more about the Valibot and Formisch agent skill [here](https://github.com/open-circle/agent-skills).

--- a/website/src/routes/(docs)/react/guides/(get-started)/llms-txt/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(get-started)/llms-txt/index.mdx
@@ -5,6 +5,7 @@ description: >-
   files to help the AI better understand the library.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # LLMs.txt
@@ -25,9 +26,11 @@ We provide several LLMs.txt routes. Use the route that works best with your AI t
 - [`llms-react-guides.txt`](/llms-react-guides.txt) contains the Markdown content of the React guides
 - [`llms-react-api.txt`](/llms-react-api.txt) contains the Markdown content of the React API reference
 
+> We also provide a Markdown version of every documentation page. You can access it by replacing the trailing slash (`/`) in the URL with `.md`. For example, `/react/guides/installation/` becomes `/react/guides/installation.md`.
+
 ## For AI Agents
 
-[`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state
+Our [`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state.
 
 ## How to use it
 

--- a/website/src/routes/(docs)/solid/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(get-started)/installation/index.mdx
@@ -4,6 +4,7 @@ description: >-
   In this guide you will learn how to add Formisch to your project.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # Installation
@@ -57,11 +58,10 @@ import { … } from '@formisch/solid';
 
 ## For AI Agents
 
-Formisch includes an agent skill that teaches AI agents the correct patterns for working with Formisch forms. You can install it by running one of the following commands in your terminal:
+We provide agent skills that teach AI agents the correct patterns for working with Valibot and Formisch. You can install them by running the following command in your terminal:
 
 ```bash
 npx skills add open-circle/agent-skills
-npx add-skill open-circle/agent-skills
 ```
 
-[Learn more](https://github.com/open-circle/agent-skills) about the Formisch skill.
+You can learn more about the Valibot and Formisch agent skill [here](https://github.com/open-circle/agent-skills).

--- a/website/src/routes/(docs)/solid/guides/(get-started)/llms-txt/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(get-started)/llms-txt/index.mdx
@@ -5,6 +5,7 @@ description: >-
   files to help the AI better understand the library.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # LLMs.txt
@@ -25,9 +26,11 @@ We provide several LLMs.txt routes. Use the route that works best with your AI t
 - [`llms-solid-guides.txt`](/llms-solid-guides.txt) contains the Markdown content of the SolidJS guides
 - [`llms-solid-api.txt`](/llms-solid-api.txt) contains the Markdown content of the SolidJS API reference
 
+> We also provide a Markdown version of every documentation page. You can access it by replacing the trailing slash (`/`) in the URL with `.md`. For example, `/solid/guides/installation/` becomes `/solid/guides/installation.md`.
+
 ## For AI Agents
 
-[`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state
+Our [`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state.
 
 ## How to use it
 

--- a/website/src/routes/(docs)/svelte/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(get-started)/installation/index.mdx
@@ -4,6 +4,7 @@ description: >-
   In this guide you will learn how to add Formisch to your project.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # Installation
@@ -57,11 +58,10 @@ import { … } from '@formisch/svelte';
 
 ## For AI Agents
 
-Formisch includes an agent skill that teaches AI agents the correct patterns for working with Formisch forms. You can install it by running one of the following commands in your terminal:
+We provide agent skills that teach AI agents the correct patterns for working with Valibot and Formisch. You can install them by running the following command in your terminal:
 
 ```bash
 npx skills add open-circle/agent-skills
-npx add-skill open-circle/agent-skills
 ```
 
-[Learn more](https://github.com/open-circle/agent-skills) about the Formisch skill.
+You can learn more about the Valibot and Formisch agent skill [here](https://github.com/open-circle/agent-skills).

--- a/website/src/routes/(docs)/svelte/guides/(get-started)/llms-txt/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(get-started)/llms-txt/index.mdx
@@ -5,6 +5,7 @@ description: >-
   files to help the AI better understand the library.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # LLMs.txt
@@ -25,9 +26,11 @@ We provide several LLMs.txt routes. Use the route that works best with your AI t
 - [`llms-svelte-guides.txt`](/llms-svelte-guides.txt) contains the Markdown content of the Svelte guides
 - [`llms-svelte-api.txt`](/llms-svelte-api.txt) contains the Markdown content of the Svelte API reference
 
+> We also provide a Markdown version of every documentation page. You can access it by replacing the trailing slash (`/`) in the URL with `.md`. For example, `/svelte/guides/installation/` becomes `/svelte/guides/installation.md`.
+
 ## For AI Agents
 
-[`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state
+Our [`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state.
 
 ## How to use it
 

--- a/website/src/routes/(docs)/vue/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(get-started)/installation/index.mdx
@@ -4,6 +4,7 @@ description: >-
   In this guide you will learn how to add Formisch to your project.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # Installation
@@ -57,11 +58,10 @@ import { … } from '@formisch/vue';
 
 ## For AI Agents
 
-Formisch includes an agent skill that teaches AI agents the correct patterns for working with Formisch. You can install it by running one of the following commands in your terminal:
+We provide agent skills that teach AI agents the correct patterns for working with Valibot and Formisch. You can install them by running the following command in your terminal:
 
 ```bash
 npx skills add open-circle/agent-skills
-npx add-skill open-circle/agent-skills
 ```
 
-[Learn more](https://github.com/open-circle/agent-skills) about the Formisch skill.
+You can learn more about the Valibot and Formisch agent skill [here](https://github.com/open-circle/agent-skills).

--- a/website/src/routes/(docs)/vue/guides/(get-started)/llms-txt/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(get-started)/llms-txt/index.mdx
@@ -5,6 +5,7 @@ description: >-
   files to help the AI better understand the library.
 contributors:
   - fabian-hiller
+  - flySewa
 ---
 
 # LLMs.txt
@@ -25,9 +26,11 @@ We provide several LLMs.txt routes. Use the route that works best with your AI t
 - [`llms-vue-guides.txt`](/llms-vue-guides.txt) contains the Markdown content of the Vue guides
 - [`llms-vue-api.txt`](/llms-vue-api.txt) contains the Markdown content of the Vue API reference
 
+> We also provide a Markdown version of every documentation page. You can access it by replacing the trailing slash (`/`) in the URL with `.md`. For example, `/vue/guides/installation/` becomes `/vue/guides/installation.md`.
+
 ## For AI Agents
 
-[`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state
+Our [`SKILL.md`](https://github.com/open-circle/agent-skills/blob/main/skills/formisch/SKILL.md) contains specialized instructions for AI agents to build forms and manage state.
 
 ## How to use it
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "For AI Agents" subsections to installation guides across frameworks, including agent-skill install instructions and resource links.
  * Added "For AI Agents" entries in LLMs.txt docs with SKILL.md references, examples for forms/state, and a call-to-action to contribute more agent examples.
  * Added contributor "flySewa" to multiple pages and a note about accessing Markdown versions of docs; included a Cursor context tip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->