### PR TITLE
Fix missing setListener export in React core build

### DIFF
--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.4.6 (May 01, 2026)
+
+- Change `@formisch/core` to v0.6.4 (fixes broken React framework build caused by missing `setListener` export)
+
 ## v0.4.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/react",
   "description": "The modular and type-safe form library for React",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.6.4 (May 01, 2026)
+
+- Fix missing `setListener` export in React core build by adding `Listener` type and `setListener` stub to the framework-agnostic `framework/index.ts`
+
 ## v0.6.3 (March 06, 2026)
 
 - Fix `initializeFieldStore` for nullable and nullish `lazy`, `variant`, `union` and `intersect` schemas (pull request #68)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/core",
   "description": "The modular and type-safe form library for any framework",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/packages/core/src/framework/index.ts
+++ b/packages/core/src/framework/index.ts
@@ -29,6 +29,27 @@ export function createId(): string {
 }
 
 /**
+ * Listener tuple.
+ *
+ * The first element is the execute function, which notifies the listener
+ * about updates.
+ *
+ * The second element is the subscription set, which keeps track
+ * of where the listener is subscribed and is used to clean up subscriptions if
+ * they are no longer needed.
+ */
+export type Listener = [() => void, Set<Set<Listener>>];
+
+/**
+ * Sets the current listener being tracked.
+ *
+ * @param newListener The new listener to set.
+ */
+export function setListener(newListener: Listener | undefined): void {
+  throw new Error('No framework selected');
+}
+
+/**
  * Creates a reactive signal without an initial value.
  *
  * @returns The created signal.


### PR DESCRIPTION
## Summary

- The framework-agnostic `packages/core/src/framework/index.ts` doesn't declare `Listener` or `setListener`, but `index.react.ts` does. The bundler's `export *` re-export forwards only names visible on the base module's analysis, so `setListener` was silently dropped from `packages/core/dist/index.react.js`.
- This broke `@formisch/react`'s build — `frameworks/react/src/hooks/useSignals/useSignals.ts` imports `setListener` from `@formisch/core/react` and `tsdown` errors with `"setListener" is not exported by "../../packages/core/dist/index.react.js"`.
- Adds `Listener` type and `setListener` stub to the base `index.ts`, matching the existing `"No framework selected"` stub pattern used for `createId`, `createSignal`, `batch`, and `untrack`. React picks up the real implementation from `index.react.ts`; the other five frameworks pick up the throwing stub but never call it.
- Patch-bumps the two affected packages: `@formisch/core` 0.6.3 → 0.6.4 and `@formisch/react` 0.4.5 → 0.4.6.

## Audit

I checked every `*.{framework}.ts` file in `packages/core/src/framework/`, `packages/core/src/types/`, and `packages/methods/src/` for the same bug pattern. Only React's `Listener` / `setListener` were missing from base — every other framework variant either redeclares the same names as its base or explicitly re-exports them (e.g. `field.qwik.ts` re-exports `FieldElement`, `form.qwik.ts` re-exports `ValidationMode/SubmitHandler/SubmitEventHandler`).

After the fix, all six framework cores' dist files have an identical 22-symbol export list, and `pnpm -C frameworks/react build` succeeds.

## Note on the other 5 framework packages

I only bumped `@formisch/react` since it was the only framework with a broken build. The other five (preact, qwik, solid, svelte, vue) don't import `setListener`, so they're unaffected at the source level — but they will pick up the new `setListener` stub in their core dists when they next rebuild. If you'd prefer to also bump those five to follow the "bump-frameworks-with-deps" convention used in the v0.4.5 release, happy to add that as a follow-up commit.

## Test plan

- [ ] `pnpm -C packages/core build` succeeds.
- [ ] `pnpm -C packages/methods build` succeeds.
- [ ] `pnpm -C frameworks/react build` succeeds (previously failed with `MISSING_EXPORT setListener`).
- [ ] `pnpm -C frameworks/{preact,qwik,solid,svelte,vue} build` all succeed (no regressions).
- [ ] Inspect `packages/core/dist/index.{preact,qwik,react,solid,svelte,vue}.js` — all six should list `setListener` in the final `export { ... }` line.
- [ ] `pnpm -C playgrounds/react dev` starts without `Failed to resolve entry for package "@formisch/react"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)