### PR TITLE
Add useFormData hook for full-form value reactivity in apps

### DIFF
--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.10.0 (April 22, 2026)
+
+- Add `useFormData` hook for reactive full-form input extraction
+
 ## v0.9.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/preact/package.json
+++ b/frameworks/preact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/preact",
   "description": "The modular and type-safe form library for Preact",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/preact/src/hooks/index.ts
+++ b/frameworks/preact/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useField/index.ts';
 export * from './useFieldArray/index.ts';
 export * from './useForm/index.ts';
+export * from './useFormData/index.ts';

--- a/frameworks/preact/src/hooks/useFormData/index.ts
+++ b/frameworks/preact/src/hooks/useFormData/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormData.ts';

--- a/frameworks/preact/src/hooks/useFormData/useFormData.ts
+++ b/frameworks/preact/src/hooks/useFormData/useFormData.ts
@@ -1,0 +1,23 @@
+import type { PartialValues, Schema } from '@formisch/core/preact';
+import { getInput } from '@formisch/methods/preact';
+import { type ReadonlySignal, useComputed } from '@preact/signals';
+import type * as v from 'valibot';
+import type { FormStore } from '../../types/index.ts';
+
+/**
+ * Returns a reactive signal of the entire form input. The signal value
+ * updates on every change, so it can be used for live previews, debug
+ * panels, or conditional rendering based on multiple fields.
+ *
+ * @param form The form store instance.
+ *
+ * @returns A readonly signal of the current form input.
+ */
+export function useFormData<TSchema extends Schema>(
+  form: FormStore<TSchema>
+): ReadonlySignal<PartialValues<v.InferInput<TSchema>>>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFormData(form: FormStore): ReadonlySignal<unknown> {
+  return useComputed(() => getInput(form));
+}

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.11.0 (April 22, 2026)
+
+- Add `useFormData$` hook for reactive full-form input extraction
+
 ## v0.10.0 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/qwik/package.json
+++ b/frameworks/qwik/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/qwik",
   "description": "The modular and type-safe form library for Qwik",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/qwik/src/hooks/index.ts
+++ b/frameworks/qwik/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useField/index.ts';
 export * from './useFieldArray/index.ts';
 export * from './useForm$/index.ts';
+export * from './useFormData$/index.ts';

--- a/frameworks/qwik/src/hooks/useFormData$/index.ts
+++ b/frameworks/qwik/src/hooks/useFormData$/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormData$.ts';

--- a/frameworks/qwik/src/hooks/useFormData$/useFormData$.ts
+++ b/frameworks/qwik/src/hooks/useFormData$/useFormData$.ts
@@ -1,0 +1,23 @@
+import type { PartialValues, Schema } from '@formisch/core/qwik';
+import { getInput } from '@formisch/methods/qwik';
+import { type ReadonlySignal, useComputed$ } from '@qwik.dev/core';
+import type * as v from 'valibot';
+import type { FormStore } from '../../types/index.ts';
+
+/**
+ * Returns a reactive signal of the entire form input. The signal value
+ * updates on every change, so it can be used for live previews, debug
+ * panels, or conditional rendering based on multiple fields.
+ *
+ * @param form The form store instance.
+ *
+ * @returns A readonly signal of the current form input.
+ */
+export function useFormData$<TSchema extends Schema>(
+  form: FormStore<TSchema>
+): ReadonlySignal<PartialValues<v.InferInput<TSchema>>>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFormData$(form: FormStore): ReadonlySignal<unknown> {
+  return useComputed$(() => getInput(form));
+}

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.4.6 (May 01, 2026)
+
+- Change `@formisch/core` to v0.6.4 (fixes broken React framework build caused by missing `setListener` export)
+
 ## v0.4.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.5.0 (April 22, 2026)
+
+- Add `useFormData` hook for reactive full-form input extraction
+
 ## v0.4.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/react",
   "description": "The modular and type-safe form library for React",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/react",
   "description": "The modular and type-safe form library for React",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/react/src/hooks/index.ts
+++ b/frameworks/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useField/index.ts';
 export * from './useFieldArray/index.ts';
 export * from './useForm/index.ts';
+export * from './useFormData/index.ts';

--- a/frameworks/react/src/hooks/useFormData/index.ts
+++ b/frameworks/react/src/hooks/useFormData/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormData.ts';

--- a/frameworks/react/src/hooks/useFormData/useFormData.ts
+++ b/frameworks/react/src/hooks/useFormData/useFormData.ts
@@ -1,0 +1,24 @@
+import type { PartialValues, Schema } from '@formisch/core/react';
+import { getInput } from '@formisch/methods/react';
+import type * as v from 'valibot';
+import type { FormStore } from '../../types/index.ts';
+import { useSignals } from '../useSignals/index.ts';
+
+/**
+ * Returns a reactive snapshot of the entire form input. The value updates
+ * on every change, so it can be used for live previews, debug panels, or
+ * conditional rendering based on multiple fields.
+ *
+ * @param form The form store instance.
+ *
+ * @returns The current form input as a partial, schema-shaped object.
+ */
+export function useFormData<TSchema extends Schema>(
+  form: FormStore<TSchema>
+): PartialValues<v.InferInput<TSchema>>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFormData(form: FormStore): unknown {
+  useSignals();
+  return getInput(form);
+}

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.10.0 (April 22, 2026)
+
+- Add `useFormData` primitive for reactive full-form input extraction
+
 ## v0.9.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/solid/package.json
+++ b/frameworks/solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/solid",
   "description": "The modular and type-safe form library for SolidJS",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/solid/src/primitives/index.ts
+++ b/frameworks/solid/src/primitives/index.ts
@@ -1,3 +1,4 @@
 export * from './createForm/index.ts';
 export * from './useField/index.ts';
 export * from './useFieldArray/index.ts';
+export * from './useFormData/index.ts';

--- a/frameworks/solid/src/primitives/useFormData/index.ts
+++ b/frameworks/solid/src/primitives/useFormData/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormData.ts';

--- a/frameworks/solid/src/primitives/useFormData/useFormData.ts
+++ b/frameworks/solid/src/primitives/useFormData/useFormData.ts
@@ -1,0 +1,27 @@
+import type { PartialValues, Schema } from '@formisch/core/solid';
+import { getInput } from '@formisch/methods/solid';
+import { type Accessor, createMemo } from 'solid-js';
+import type * as v from 'valibot';
+import type { FormStore, MaybeGetter } from '../../types/index.ts';
+import { unwrap } from '../../utils/index.ts';
+
+/**
+ * Returns a reactive accessor of the entire form input. The value updates
+ * on every change, so it can be used for live previews, debug panels, or
+ * conditional rendering based on multiple fields.
+ *
+ * @param form The form store instance or getter function.
+ *
+ * @returns An accessor for the current form input.
+ */
+export function useFormData<TSchema extends Schema>(
+  form: MaybeGetter<FormStore<TSchema>>
+): Accessor<PartialValues<v.InferInput<TSchema>>>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFormData(
+  form: MaybeGetter<FormStore>
+): Accessor<unknown> {
+  const getFormData = createMemo(() => getInput(unwrap(form)));
+  return getFormData;
+}

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.8.0 (April 22, 2026)
+
+- Add `useFormData` rune for reactive full-form input extraction
+
 ## v0.7.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/svelte/package.json
+++ b/frameworks/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/svelte",
   "description": "The modular and type-safe form library for Svelte",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/svelte/src/runes/index.ts
+++ b/frameworks/svelte/src/runes/index.ts
@@ -1,3 +1,4 @@
 export * from './createForm/index.ts';
 export * from './useField/index.ts';
 export * from './useFieldArray/index.ts';
+export * from './useFormData/index.ts';

--- a/frameworks/svelte/src/runes/useFormData/index.ts
+++ b/frameworks/svelte/src/runes/useFormData/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormData.svelte.ts';

--- a/frameworks/svelte/src/runes/useFormData/useFormData.svelte.ts
+++ b/frameworks/svelte/src/runes/useFormData/useFormData.svelte.ts
@@ -1,0 +1,38 @@
+import type { PartialValues, Schema } from '@formisch/core/svelte';
+import { getInput } from '@formisch/methods/svelte';
+import type * as v from 'valibot';
+import type { FormStore, MaybeGetter } from '../../types/index.ts';
+import { unwrap } from '../../utils/index.ts';
+
+/**
+ * Form data store interface.
+ */
+export interface FormDataStore<TSchema extends Schema = Schema> {
+  /**
+   * The current input values of the form.
+   */
+  readonly current: PartialValues<v.InferInput<TSchema>>;
+}
+
+/**
+ * Returns a reactive store of the entire form input. The `current`
+ * property updates on every change, so it can be used for live previews,
+ * debug panels, or conditional rendering based on multiple fields.
+ *
+ * @param form The form store instance or getter function.
+ *
+ * @returns A reactive store exposing the current form input.
+ */
+export function useFormData<TSchema extends Schema>(
+  form: MaybeGetter<FormStore<TSchema>>
+): FormDataStore<TSchema>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFormData(form: MaybeGetter<FormStore>): { current: unknown } {
+  const current = $derived(getInput(unwrap(form)));
+  return {
+    get current() {
+      return current;
+    },
+  };
+}

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.8.0 (April 22, 2026)
+
+- Add `useFormData` composable for reactive full-form input extraction
+
 ## v0.7.5 (April 16, 2026)
 
 - Change `@formisch/methods` to v0.7.1

--- a/frameworks/vue/package.json
+++ b/frameworks/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/vue",
   "description": "The modular and type-safe form library for Vue",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/vue/src/composables/index.ts
+++ b/frameworks/vue/src/composables/index.ts
@@ -1,3 +1,4 @@
 export * from './useField/index.ts';
 export * from './useFieldArray/index.ts';
 export * from './useForm/index.ts';
+export * from './useFormData/index.ts';

--- a/frameworks/vue/src/composables/useFormData/index.ts
+++ b/frameworks/vue/src/composables/useFormData/index.ts
@@ -1,0 +1,1 @@
+export * from './useFormData.ts';

--- a/frameworks/vue/src/composables/useFormData/useFormData.ts
+++ b/frameworks/vue/src/composables/useFormData/useFormData.ts
@@ -1,0 +1,30 @@
+import type { PartialValues, Schema } from '@formisch/core/vue';
+import { getInput } from '@formisch/methods/vue';
+import type * as v from 'valibot';
+import {
+  computed,
+  type ComputedRef,
+  type MaybeRefOrGetter,
+  toValue,
+} from 'vue';
+import type { FormStore } from '../../types/index.ts';
+
+/**
+ * Returns a reactive computed ref of the entire form input. The value
+ * updates on every change, so it can be used for live previews, debug
+ * panels, or conditional rendering based on multiple fields.
+ *
+ * @param form The form store instance, ref, or getter function.
+ *
+ * @returns A computed ref of the current form input.
+ */
+export function useFormData<TSchema extends Schema>(
+  form: MaybeRefOrGetter<FormStore<TSchema>>
+): ComputedRef<PartialValues<v.InferInput<TSchema>>>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFormData(
+  form: MaybeRefOrGetter<FormStore>
+): ComputedRef<unknown> {
+  return computed(() => getInput(toValue(form)));
+}

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## v0.6.4 (May 01, 2026)
+
+- Fix missing `setListener` export in React core build by adding `Listener` type and `setListener` stub to the framework-agnostic `framework/index.ts`
+
 ## v0.6.3 (March 06, 2026)
 
 - Fix `initializeFieldStore` for nullable and nullish `lazy`, `variant`, `union` and `intersect` schemas (pull request #68)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/core",
   "description": "The modular and type-safe form library for any framework",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/packages/core/src/framework/index.ts
+++ b/packages/core/src/framework/index.ts
@@ -29,6 +29,27 @@ export function createId(): string {
 }
 
 /**
+ * Listener tuple.
+ *
+ * The first element is the execute function, which notifies the listener
+ * about updates.
+ *
+ * The second element is the subscription set, which keeps track
+ * of where the listener is subscribed and is used to clean up subscriptions if
+ * they are no longer needed.
+ */
+export type Listener = [() => void, Set<Set<Listener>>];
+
+/**
+ * Sets the current listener being tracked.
+ *
+ * @param newListener The new listener to set.
+ */
+export function setListener(newListener: Listener | undefined): void {
+  throw new Error('No framework selected');
+}
+
+/**
  * Creates a reactive signal without an initial value.
  *
  * @returns The created signal.

--- a/playgrounds/react/src/routes/login/index.tsx
+++ b/playgrounds/react/src/routes/login/index.tsx
@@ -1,4 +1,4 @@
-import { Field, Form, useForm } from '@formisch/react';
+import { Field, Form, useForm, useFormData } from '@formisch/react';
 import * as v from 'valibot';
 import { FormFooter, FormHeader, TextInput } from '../../components';
 
@@ -21,41 +21,57 @@ export default function LoginPage() {
   });
 
   return (
-    <Form
-      of={loginForm}
-      className="space-y-12 md:space-y-14 lg:space-y-16"
-      onSubmit={(output) => console.log(output)}
-    >
-      <FormHeader of={loginForm} heading="Login form" />
-      <div className="space-y-8 md:space-y-10 lg:space-y-12">
-        <Field of={loginForm} path={['email']}>
-          {(field) => (
-            <TextInput
-              {...field.props}
-              input={field.input}
-              errors={field.errors}
-              type="email"
-              label="Email"
-              placeholder="example@email.com"
-              required
-            />
-          )}
-        </Field>
-        <Field of={loginForm} path={['password']}>
-          {(field) => (
-            <TextInput
-              {...field.props}
-              input={field.input}
-              errors={field.errors}
-              type="password"
-              label="Password"
-              placeholder="********"
-              required
-            />
-          )}
-        </Field>
-      </div>
-      <FormFooter of={loginForm} />
-    </Form>
+    <>
+      <Form
+        of={loginForm}
+        className="space-y-12 md:space-y-14 lg:space-y-16"
+        onSubmit={(output) => console.log(output)}
+      >
+        <FormHeader of={loginForm} heading="Login form" />
+        <div className="space-y-8 md:space-y-10 lg:space-y-12">
+          <Field of={loginForm} path={['email']}>
+            {(field) => (
+              <TextInput
+                {...field.props}
+                input={field.input}
+                errors={field.errors}
+                type="email"
+                label="Email"
+                placeholder="example@email.com"
+                required
+              />
+            )}
+          </Field>
+          <Field of={loginForm} path={['password']}>
+            {(field) => (
+              <TextInput
+                {...field.props}
+                input={field.input}
+                errors={field.errors}
+                type="password"
+                label="Password"
+                placeholder="********"
+                required
+              />
+            )}
+          </Field>
+        </div>
+        <FormFooter of={loginForm} />
+      </Form>
+      <FormDataPreview form={loginForm} />
+    </>
+  );
+}
+
+function FormDataPreview({
+  form,
+}: {
+  form: ReturnType<typeof useForm<typeof LoginSchema>>;
+}) {
+  const formData = useFormData(form);
+  return (
+    <pre className="overflow-auto bg-slate-100 p-4 text-xs dark:bg-slate-800">
+      <code>{JSON.stringify(formData, null, 2)}</code>
+    </pre>
   );
 }

--- a/playgrounds/solid/src/routes/login/index.tsx
+++ b/playgrounds/solid/src/routes/login/index.tsx
@@ -1,4 +1,4 @@
-import { createForm, Field, Form } from '@formisch/solid';
+import { createForm, Field, Form, useFormData } from '@formisch/solid';
 import * as v from 'valibot';
 import { FormFooter, FormHeader, TextInput, Title } from '~/components';
 
@@ -59,6 +59,18 @@ export default function LoginPage() {
         </div>
         <FormFooter of={loginForm} />
       </Form>
+      <FormDataPreview form={loginForm} />
     </>
+  );
+}
+
+function FormDataPreview(props: {
+  form: ReturnType<typeof createForm<typeof LoginSchema>>;
+}) {
+  const formData = useFormData(() => props.form);
+  return (
+    <pre class="overflow-auto bg-slate-100 p-4 text-xs dark:bg-slate-800">
+      <code>{JSON.stringify(formData(), null, 2)}</code>
+    </pre>
   );
 }

--- a/website/src/routes/(docs)/preact/api/(hooks)/useFormData/index.mdx
+++ b/website/src/routes/(docs)/preact/api/(hooks)/useFormData/index.mdx
@@ -1,0 +1,52 @@
+---
+title: useFormData
+description: Creates a reactive signal of the entire form input values.
+source: /frameworks/preact/src/hooks/useFormData/useFormData.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# useFormData
+
+Creates a reactive signal of the entire form input values. The signal updates on every change, so it can be used for live previews, debug panels, or conditional rendering based on multiple fields.
+
+```ts
+const formData = useFormData<TSchema>(form);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `form` <Property {...properties.form} />
+
+### Explanation
+
+With `useFormData` you get a readonly signal that holds the entire form's current input as a schema-shaped object. Read `formData.value` to access the latest value. Rendering `{JSON.stringify(formData.value, null, 2)}` in a `<pre>` gives a live preview that updates on every keystroke.
+
+## Returns
+
+- `formData` <Property {...properties.formData} />
+
+## Related
+
+The following APIs can be combined with `useFormData`.
+
+### Hooks
+
+<ApiList
+  items={[
+    { text: 'useForm', href: '../useForm/' },
+    { text: 'useField', href: '../useField/' },
+    { text: 'useFieldArray', href: '../useFieldArray/' },
+  ]}
+/>
+
+### Methods
+
+<ApiList items={[{ text: 'getInput', href: '/methods/api/getInput/' }]} />

--- a/website/src/routes/(docs)/preact/api/(hooks)/useFormData/properties.ts
+++ b/website/src/routes/(docs)/preact/api/(hooks)/useFormData/properties.ts
@@ -1,0 +1,51 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  form: {
+    type: {
+      type: 'custom',
+      name: 'FormStore',
+      href: '../FormStore/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+      ],
+    },
+  },
+  formData: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: [
+        {
+          type: 'custom',
+          name: 'PartialValues',
+          href: '/core/api/PartialValues/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'v.InferInput',
+              href: 'https://valibot.dev/api/InferInput/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TSchema',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/preact/api/menu.md
+++ b/website/src/routes/(docs)/preact/api/menu.md
@@ -5,6 +5,7 @@
 - [useForm](/preact/api/useForm/)
 - [useField](/preact/api/useField/)
 - [useFieldArray](/preact/api/useFieldArray/)
+- [useFormData](/preact/api/useFormData/)
 
 ## Components
 

--- a/website/src/routes/(docs)/qwik/api/(hooks)/useFormData$/index.mdx
+++ b/website/src/routes/(docs)/qwik/api/(hooks)/useFormData$/index.mdx
@@ -1,0 +1,52 @@
+---
+title: useFormData$
+description: Creates a reactive signal of the entire form input values.
+source: /frameworks/qwik/src/hooks/useFormData$/useFormData$.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# useFormData$
+
+Creates a reactive signal of the entire form input values. The signal updates on every change, so it can be used for live previews, debug panels, or conditional rendering based on multiple fields.
+
+```ts
+const formData = useFormData$<TSchema>(form);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `form` <Property {...properties.form} />
+
+### Explanation
+
+With `useFormData$` you get a readonly signal that holds the entire form's current input as a schema-shaped object. Read `formData.value` to access the latest value. Rendering `{JSON.stringify(formData.value, null, 2)}` in a `<pre>` gives a live preview that updates on every keystroke.
+
+## Returns
+
+- `formData` <Property {...properties.formData} />
+
+## Related
+
+The following APIs can be combined with `useFormData$`.
+
+### Hooks
+
+<ApiList
+  items={[
+    { text: 'useForm$', href: '../useForm$/' },
+    { text: 'useField', href: '../useField/' },
+    { text: 'useFieldArray', href: '../useFieldArray/' },
+  ]}
+/>
+
+### Methods
+
+<ApiList items={[{ text: 'getInput', href: '/methods/api/getInput/' }]} />

--- a/website/src/routes/(docs)/qwik/api/(hooks)/useFormData$/properties.ts
+++ b/website/src/routes/(docs)/qwik/api/(hooks)/useFormData$/properties.ts
@@ -1,0 +1,51 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  form: {
+    type: {
+      type: 'custom',
+      name: 'FormStore',
+      href: '../FormStore/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+      ],
+    },
+  },
+  formData: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: [
+        {
+          type: 'custom',
+          name: 'PartialValues',
+          href: '/core/api/PartialValues/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'v.InferInput',
+              href: 'https://valibot.dev/api/InferInput/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TSchema',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/qwik/api/menu.md
+++ b/website/src/routes/(docs)/qwik/api/menu.md
@@ -5,6 +5,7 @@
 - [useForm$](/qwik/api/useForm$/)
 - [useField](/qwik/api/useField/)
 - [useFieldArray](/qwik/api/useFieldArray/)
+- [useFormData$](/qwik/api/useFormData$/)
 
 ## Components
 

--- a/website/src/routes/(docs)/react/api/(hooks)/useFormData/index.mdx
+++ b/website/src/routes/(docs)/react/api/(hooks)/useFormData/index.mdx
@@ -1,0 +1,52 @@
+---
+title: useFormData
+description: Creates a reactive snapshot of the entire form input values.
+source: /frameworks/react/src/hooks/useFormData/useFormData.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# useFormData
+
+Creates a reactive snapshot of the entire form input values. The returned value updates on every change, so it can be used for live previews, debug panels, or conditional rendering based on multiple fields.
+
+```ts
+const formData = useFormData<TSchema>(form);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `form` <Property {...properties.form} />
+
+### Explanation
+
+With `useFormData` you get a reactive, schema-shaped object of the entire form's current input. The hook re-renders on every form change, so rendering `JSON.stringify(formData, null, 2)` in a `<pre>` gives a live preview that updates on every keystroke.
+
+## Returns
+
+- `formData` <Property {...properties.formData} />
+
+## Related
+
+The following APIs can be combined with `useFormData`.
+
+### Hooks
+
+<ApiList
+  items={[
+    { text: 'useForm', href: '../useForm/' },
+    { text: 'useField', href: '../useField/' },
+    { text: 'useFieldArray', href: '../useFieldArray/' },
+  ]}
+/>
+
+### Methods
+
+<ApiList items={[{ text: 'getInput', href: '/methods/api/getInput/' }]} />

--- a/website/src/routes/(docs)/react/api/(hooks)/useFormData/properties.ts
+++ b/website/src/routes/(docs)/react/api/(hooks)/useFormData/properties.ts
@@ -1,0 +1,45 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  form: {
+    type: {
+      type: 'custom',
+      name: 'FormStore',
+      href: '../FormStore/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+      ],
+    },
+  },
+  formData: {
+    type: {
+      type: 'custom',
+      name: 'PartialValues',
+      href: '/core/api/PartialValues/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'v.InferInput',
+          href: 'https://valibot.dev/api/InferInput/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/react/api/menu.md
+++ b/website/src/routes/(docs)/react/api/menu.md
@@ -5,6 +5,7 @@
 - [useForm](/react/api/useForm/)
 - [useField](/react/api/useField/)
 - [useFieldArray](/react/api/useFieldArray/)
+- [useFormData](/react/api/useFormData/)
 
 ## Components
 

--- a/website/src/routes/(docs)/solid/api/(primitives)/useFormData/index.mdx
+++ b/website/src/routes/(docs)/solid/api/(primitives)/useFormData/index.mdx
@@ -1,0 +1,52 @@
+---
+title: useFormData
+description: Creates a reactive accessor of the entire form input values.
+source: /frameworks/solid/src/primitives/useFormData/useFormData.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# useFormData
+
+Creates a reactive accessor of the entire form input values. The accessor updates on every change, so it can be used for live previews, debug panels, or conditional rendering based on multiple fields.
+
+```ts
+const formData = useFormData<TSchema>(form);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `form` <Property {...properties.form} />
+
+### Explanation
+
+With `useFormData` you get an accessor that returns the entire form's current input as a schema-shaped object. Call `formData()` to read the latest value. Rendering `{JSON.stringify(formData(), null, 2)}` in a `<pre>` gives a live preview that updates on every keystroke.
+
+## Returns
+
+- `formData` <Property {...properties.formData} />
+
+## Related
+
+The following APIs can be combined with `useFormData`.
+
+### Primitives
+
+<ApiList
+  items={[
+    { text: 'createForm', href: '../createForm/' },
+    { text: 'useField', href: '../useField/' },
+    { text: 'useFieldArray', href: '../useFieldArray/' },
+  ]}
+/>
+
+### Methods
+
+<ApiList items={[{ text: 'getInput', href: '/methods/api/getInput/' }]} />

--- a/website/src/routes/(docs)/solid/api/(primitives)/useFormData/properties.ts
+++ b/website/src/routes/(docs)/solid/api/(primitives)/useFormData/properties.ts
@@ -1,0 +1,58 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  form: {
+    type: {
+      type: 'custom',
+      name: 'MaybeGetter',
+      href: '../MaybeGetter/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'FormStore',
+          href: '../FormStore/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  formData: {
+    type: {
+      type: 'custom',
+      name: 'Accessor',
+      generics: [
+        {
+          type: 'custom',
+          name: 'PartialValues',
+          href: '/core/api/PartialValues/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'v.InferInput',
+              href: 'https://valibot.dev/api/InferInput/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TSchema',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/solid/api/menu.md
+++ b/website/src/routes/(docs)/solid/api/menu.md
@@ -5,6 +5,7 @@
 - [createForm](/solid/api/createForm/)
 - [useField](/solid/api/useField/)
 - [useFieldArray](/solid/api/useFieldArray/)
+- [useFormData](/solid/api/useFormData/)
 
 ## Components
 

--- a/website/src/routes/(docs)/svelte/api/(runes)/useFormData/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(runes)/useFormData/index.mdx
@@ -1,0 +1,52 @@
+---
+title: useFormData
+description: Creates a reactive store of the entire form input values.
+source: /frameworks/svelte/src/runes/useFormData/useFormData.svelte.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# useFormData
+
+Creates a reactive store of the entire form input values. The `current` property updates on every change, so it can be used for live previews, debug panels, or conditional rendering based on multiple fields.
+
+```ts
+const formData = useFormData<TSchema>(form);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `form` <Property {...properties.form} />
+
+### Explanation
+
+With `useFormData` you get a reactive store whose `current` property holds the entire form's current input as a schema-shaped object. Rendering `{JSON.stringify(formData.current, null, 2)}` in a `<pre>` gives a live preview that updates on every keystroke.
+
+## Returns
+
+- `formData` <Property {...properties.formData} />
+
+## Related
+
+The following APIs can be combined with `useFormData`.
+
+### Runes
+
+<ApiList
+  items={[
+    { text: 'createForm', href: '../createForm/' },
+    { text: 'useField', href: '../useField/' },
+    { text: 'useFieldArray', href: '../useFieldArray/' },
+  ]}
+/>
+
+### Methods
+
+<ApiList items={[{ text: 'getInput', href: '/methods/api/getInput/' }]} />

--- a/website/src/routes/(docs)/svelte/api/(runes)/useFormData/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(runes)/useFormData/properties.ts
@@ -1,0 +1,45 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  form: {
+    type: {
+      type: 'custom',
+      name: 'MaybeGetter',
+      href: '../MaybeGetter/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'FormStore',
+          href: '../FormStore/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  formData: {
+    type: {
+      type: 'custom',
+      name: 'FormDataStore',
+      href: '../FormDataStore/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/svelte/api/(types)/FormDataStore/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(types)/FormDataStore/index.mdx
@@ -1,0 +1,23 @@
+---
+title: FormDataStore
+description: Reactive store interface exposing the entire form input values.
+source: /frameworks/svelte/src/runes/useFormData/useFormData.svelte.ts
+contributors:
+  - fabian-hiller
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# FormDataStore
+
+Reactive store interface exposing the entire form's current input values.
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Definition
+
+- `FormDataStore`
+  - `current` <Property {...properties.current} />

--- a/website/src/routes/(docs)/svelte/api/(types)/FormDataStore/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(types)/FormDataStore/properties.ts
@@ -1,0 +1,32 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  current: {
+    type: {
+      type: 'custom',
+      name: 'PartialValues',
+      href: '/core/api/PartialValues/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'v.InferInput',
+          href: 'https://valibot.dev/api/InferInput/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/svelte/api/menu.md
+++ b/website/src/routes/(docs)/svelte/api/menu.md
@@ -5,6 +5,7 @@
 - [createForm](/svelte/api/createForm/)
 - [useField](/svelte/api/useField/)
 - [useFieldArray](/svelte/api/useFieldArray/)
+- [useFormData](/svelte/api/useFormData/)
 
 ## Components
 
@@ -39,6 +40,7 @@
 - [FieldStore](/svelte/api/FieldStore/)
 - [FocusFieldConfig](/methods/api/FocusFieldConfig/)
 - [FormConfig](/svelte/api/FormConfig/)
+- [FormDataStore](/svelte/api/FormDataStore/)
 - [FormStore](/svelte/api/FormStore/)
 - [GetFieldErrorsConfig](/methods/api/GetFieldErrorsConfig/)
 - [GetFieldInputConfig](/methods/api/GetFieldInputConfig/)

--- a/website/src/routes/(docs)/vue/api/(composables)/useFormData/index.mdx
+++ b/website/src/routes/(docs)/vue/api/(composables)/useFormData/index.mdx
@@ -1,0 +1,52 @@
+---
+title: useFormData
+description: Creates a reactive computed ref of the entire form input values.
+source: /frameworks/vue/src/composables/useFormData/useFormData.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# useFormData
+
+Creates a reactive computed ref of the entire form input values. The value updates on every change, so it can be used for live previews, debug panels, or conditional rendering based on multiple fields.
+
+```ts
+const formData = useFormData<TSchema>(form);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `form` <Property {...properties.form} />
+
+### Explanation
+
+With `useFormData` you get a computed ref that holds the entire form's current input as a schema-shaped object. In `<script>`, read `formData.value`; in a template, you can read `formData` directly. Rendering `{{ JSON.stringify(formData, null, 2) }}` in a `<pre>` gives a live preview that updates on every keystroke.
+
+## Returns
+
+- `formData` <Property {...properties.formData} />
+
+## Related
+
+The following APIs can be combined with `useFormData`.
+
+### Composables
+
+<ApiList
+  items={[
+    { text: 'useForm', href: '../useForm/' },
+    { text: 'useField', href: '../useField/' },
+    { text: 'useFieldArray', href: '../useFieldArray/' },
+  ]}
+/>
+
+### Methods
+
+<ApiList items={[{ text: 'getInput', href: '/methods/api/getInput/' }]} />

--- a/website/src/routes/(docs)/vue/api/(composables)/useFormData/properties.ts
+++ b/website/src/routes/(docs)/vue/api/(composables)/useFormData/properties.ts
@@ -1,0 +1,57 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Schema',
+      href: '/core/api/Schema/',
+    },
+  },
+  form: {
+    type: {
+      type: 'custom',
+      name: 'MaybeRefOrGetter',
+      generics: [
+        {
+          type: 'custom',
+          name: 'FormStore',
+          href: '../FormStore/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  formData: {
+    type: {
+      type: 'custom',
+      name: 'ComputedRef',
+      generics: [
+        {
+          type: 'custom',
+          name: 'PartialValues',
+          href: '/core/api/PartialValues/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'v.InferInput',
+              href: 'https://valibot.dev/api/InferInput/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TSchema',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/(docs)/vue/api/menu.md
+++ b/website/src/routes/(docs)/vue/api/menu.md
@@ -5,6 +5,7 @@
 - [useForm](/vue/api/useForm/)
 - [useField](/vue/api/useField/)
 - [useFieldArray](/vue/api/useFieldArray/)
+- [useFormData](/vue/api/useFormData/)
 
 ## Components
 


### PR DESCRIPTION
> Publishing as a Draft PR as I haven't had time to fully test it yet.

## Summary

Adds a new `useFormData` hook (or composable / primitive / rune) across all six framework packages. It wraps the existing `getInput(form)` method in each framework's reactive primitive so the full form's input is exposed as a live, schema-shaped object — useful for JSON previews, debug panels, and conditional rendering based on multiple fields.

```tsx
const formData = useFormData(form);
return <pre>{JSON.stringify(formData, null, 2)}</pre>;
// updates on every keystroke, in any field
```

Each framework's return type matches its existing `useField(...).input` convention so users don't have to learn a new pattern:

| Framework | API name        | Return type                          | Read as                  |
|-----------|-----------------|--------------------------------------|--------------------------|
| React     | `useFormData`   | `PartialValues<v.InferInput<T>>`     | `formData.name`          |
| Preact    | `useFormData`   | `ReadonlySignal<PartialValues<…>>`   | `formData.value.name`    |
| Qwik      | `useFormData$`  | `ReadonlySignal<PartialValues<…>>`   | `formData.value.name`    |
| Vue       | `useFormData`   | `ComputedRef<PartialValues<…>>`      | `formData.value.name` (script) / `{{ formData.name }}` (template) |
| Solid     | `useFormData`   | `Accessor<PartialValues<…>>`         | `formData().name`        |
| Svelte    | `useFormData`   | `FormDataStore { current }`          | `formData.current.name`  |

## What's in this PR

- **Implementation** — new file in each framework's hooks/composables/primitives/runes folder (~3-line wrapper over `getInput` + the framework's reactive primitive). Plus a folder-level barrel and an entry added to each framework's existing barrel.
- **Docs** — 6 new `useFormData` (or `useFormData$`) MDX pages + `properties.ts` files under `website/src/routes/(docs)/`. Adds a `FormDataStore` type page for Svelte. Each framework's API menu now lists the new entry.
- **Playground** — Solid and React `login` playgrounds get a `FormDataPreview` component that renders `JSON.stringify(formData, null, 2)` underneath the form for end-to-end reactivity verification.
- **Version bumps** (minor — new public API):
  - `@formisch/preact` 0.9.5 → 0.10.0
  - `@formisch/qwik` 0.10.0 → 0.11.0
  - `@formisch/react` 0.4.5 → 0.5.0
  - `@formisch/solid` 0.9.5 → 0.10.0
  - `@formisch/svelte` 0.7.5 → 0.8.0
  - `@formisch/vue` 0.7.5 → 0.8.0

## Note on the bundled setListener fix

This branch has the React core build fix from #(setListener PR number) merged in, because without it the React playground can't build and the new hook can't be exercised end-to-end. Affects:

- `packages/core/src/framework/index.ts` — adds `Listener` type and `setListener` stub
- `packages/core` 0.6.3 → 0.6.4

If the standalone setListener PR lands first, this branch will need a rebase and the `Change @formisch/core to v0.6.4` bullet under `@formisch/react` v0.5.0 should drop (since the dep change would belong to the v0.4.6 entry that already shipped). Otherwise the two changes ship together as part of the v0.5.0 react release.

## Design rationale

- **No core changes for the feature itself** — `getInput(form)` already walks the signal tree via `getFieldInput(form[INTERNAL])`. When invoked inside a framework's reactive scope, signal reads auto-subscribe and the computation re-runs on any change. The new hook is just `frameworkPrimitive(() => getInput(form))`.
- **Per-framework return shape, not a uniform shape** — matching `useField(...).input`'s convention keeps API surface consistent within each framework.
- **Svelte uses a getter-backed object** because `$derived` can't be returned bare from a `.svelte.ts` function and remain reactive at the call site. The `FormDataStore { readonly current }` shape matches the existing pattern used by `createForm` in the same package.

## Test plan

- [ ] `pnpm -C frameworks/{preact,qwik,react,solid,svelte,vue} build` — all six build clean.
- [ ] `pnpm -C frameworks/{preact,qwik,react,solid,svelte,vue} lint` — all six lint clean.
- [ ] Solid playground: `pnpm -C playgrounds/solid dev` → http://localhost:3000/login. Type "hello" into the email field. The JSON preview below the form must update on **each** of the 5 keystrokes (h → he → hel → hell → hello), not just on blur or after the first keystroke. Repeat for password.
- [ ] React playground: `pnpm -C playgrounds/react dev` → same reactivity check.
- [ ] (Optional) Repeat for Preact, Qwik, Vue, Svelte playgrounds — `useFormData` test scaffolding only added to Solid + React so far; happy to add to the rest if you want spot-checks.
- [ ] `pnpm -C website build` — new MDX pages and updated menus render without errors. (Note: the website build's SSG step has 30 pre-existing Qwik lexical-scope errors in `website/src/routes/playground/*/index.tsx` that are unrelated to this PR — the Vite build itself succeeds.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `useFormData` across React, Preact, Qwik, Vue, Solid, and Svelte to expose the full form input as a live, schema-shaped value for previews and multi-field logic. Includes a small core export fix required for React builds.

- **New Features**
  - New `useFormData` API (`useFormData$` in Qwik) that wraps `getInput(form)` in each framework’s reactive primitive and updates on every keystroke.
  - Return shape matches each framework’s `useField(...).input` convention (signals/computed/accessor/value as appropriate).
  - Docs added for all frameworks; Svelte adds a `FormDataStore` type page.
  - React and Solid playgrounds show a JSON preview using `useFormData` for end-to-end checks.

- **Dependencies**
  - Minor bumps for new public API: `@formisch/react` 0.5.0, `@formisch/preact` 0.10.0, `@formisch/qwik` 0.11.0, `@formisch/solid` 0.10.0, `@formisch/svelte` 0.8.0, `@formisch/vue` 0.8.0.
  - `@formisch/core` to 0.6.4: adds `Listener` type and `setListener` stub so React builds succeed.

<sup>Written for commit 3a0b673eb127df8c66e324dd71f4532bc27133dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

