### PR TITLE
Add Angular framework adapter to core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./angular": {
+      "types": "./dist/index.angular.d.ts",
+      "default": "./dist/index.angular.js"
+    },
     "./preact": {
       "types": "./dist/index.preact.d.ts",
       "default": "./dist/index.preact.js"
@@ -68,6 +72,7 @@
     "build": "tsdown"
   },
   "devDependencies": {
+    "@angular/core": "^21.0.0",
     "@formisch/eslint-config": "workspace:*",
     "@preact/signals": "^2.2.1",
     "@qwik.dev/core": "2.0.0-beta.5",
@@ -86,6 +91,7 @@
     "vue": "^3.5.17"
   },
   "peerDependencies": {
+    "@angular/core": "^17.0.0",
     "@qwik.dev/core": "^2.0.0",
     "solid-js": "^1.6.0",
     "svelte": "^5.29.0",
@@ -94,6 +100,9 @@
     "vue": "^3.3.0"
   },
   "peerDependenciesMeta": {
+    "@angular/core": {
+      "optional": true
+    },
     "@preact/signals": {
       "optional": true
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "vue": "^3.5.17"
   },
   "peerDependencies": {
-    "@angular/core": "^17.0.0",
+    "@angular/core": ">=17.0.0",
     "@qwik.dev/core": "^2.0.0",
     "solid-js": "^1.6.0",
     "svelte": "^5.29.0",

--- a/packages/core/src/framework/index.angular.ts
+++ b/packages/core/src/framework/index.angular.ts
@@ -1,6 +1,8 @@
-import { signal, untracked } from '@angular/core';
+import { signal } from '@angular/core';
 import type { Signal } from '../types/signal/index.ts';
 import type { Framework } from './index.ts';
+
+export { untracked as untrack } from '@angular/core';
 
 /**
  * The current framework being used.
@@ -18,29 +20,20 @@ export function createId(): string {
 }
 
 /**
- * Creates a reactive signal without an initial value.
- *
- * @returns The created signal.
- */
-export function createSignal<T>(): Signal<T | undefined>;
-
-/**
  * Creates a reactive signal with an initial value.
  *
- * @param value The initial value.
+ * @param initialValue The initial value.
  *
  * @returns The created signal.
  */
-export function createSignal<T>(value: T): Signal<T>;
-
 // @__NO_SIDE_EFFECTS__
-export function createSignal(initialValue?: unknown): Signal<unknown> {
+export function createSignal<T>(initialValue: T): Signal<T> {
   const writableSignal = signal(initialValue);
   return {
     get value() {
       return writableSignal();
     },
-    set value(nextValue: unknown) {
+    set value(nextValue: T) {
       writableSignal.set(nextValue);
     },
   };
@@ -56,15 +49,4 @@ export function createSignal(initialValue?: unknown): Signal<unknown> {
  */
 export function batch<T>(fn: () => T): T {
   return fn();
-}
-
-/**
- * Executes a function without tracking reactive dependencies.
- *
- * @param fn The function to execute.
- *
- * @returns The return value of the function.
- */
-export function untrack<T>(fn: () => T): T {
-  return untracked(fn);
 }

--- a/packages/core/src/framework/index.angular.ts
+++ b/packages/core/src/framework/index.angular.ts
@@ -1,23 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable jsdoc/require-returns-check */
-import type { Signal } from '../types/index.ts';
-
-/**
- * Framework type.
- */
-export type Framework =
-  | 'angular'
-  | 'preact'
-  | 'qwik'
-  | 'react'
-  | 'solid'
-  | 'svelte'
-  | 'vue';
+import { signal, untracked } from '@angular/core';
+import type { Signal } from '../types/signal.ts';
+import type { Framework } from './index.ts';
 
 /**
  * The current framework being used.
  */
-export const framework: Framework = '' as Framework;
+export const framework: Framework = 'angular';
 
 /**
  * Creates a unique identifier string.
@@ -26,7 +14,7 @@ export const framework: Framework = '' as Framework;
  */
 // @__NO_SIDE_EFFECTS__
 export function createId(): string {
-  throw new Error('No framework selected');
+  return Math.random().toString(36).slice(2);
 }
 
 /**
@@ -46,28 +34,37 @@ export function createSignal<T>(): Signal<T | undefined>;
 export function createSignal<T>(value: T): Signal<T>;
 
 // @__NO_SIDE_EFFECTS__
-export function createSignal(value?: unknown): Signal<unknown> {
-  throw new Error('No framework selected');
+export function createSignal<T>(initialValue?: T): Signal<T | undefined> {
+  const writableSignal = signal(initialValue);
+  return {
+    get value() {
+      return writableSignal();
+    },
+    set value(nextValue) {
+      writableSignal.set(nextValue);
+    },
+  };
 }
 
 /**
- * Batches multiple signal updates into a single update cycle.
+ * Batches multiple signal updates into a single update cycle. This is a
+ * no-op in Angular as batching is handled automatically.
  *
- * @param fn The function to execute in batch.
+ * @param fn The function to execute.
  *
  * @returns The return value of the function.
  */
 export function batch<T>(fn: () => T): T {
-  throw new Error('No framework selected');
+  return fn();
 }
 
 /**
  * Executes a function without tracking reactive dependencies.
  *
- * @param fn The function to execute without tracking.
+ * @param fn The function to execute.
  *
  * @returns The return value of the function.
  */
 export function untrack<T>(fn: () => T): T {
-  throw new Error('No framework selected');
+  return untracked(fn);
 }

--- a/packages/core/src/framework/index.angular.ts
+++ b/packages/core/src/framework/index.angular.ts
@@ -1,5 +1,5 @@
 import { signal, untracked } from '@angular/core';
-import type { Signal } from '../types/signal.ts';
+import type { Signal } from '../types/signal/index.ts';
 import type { Framework } from './index.ts';
 
 /**
@@ -40,7 +40,7 @@ export function createSignal<T>(initialValue?: T): Signal<T | undefined> {
     get value() {
       return writableSignal();
     },
-    set value(nextValue) {
+    set value(nextValue: T | undefined) {
       writableSignal.set(nextValue);
     },
   };

--- a/packages/core/src/framework/index.angular.ts
+++ b/packages/core/src/framework/index.angular.ts
@@ -34,13 +34,13 @@ export function createSignal<T>(): Signal<T | undefined>;
 export function createSignal<T>(value: T): Signal<T>;
 
 // @__NO_SIDE_EFFECTS__
-export function createSignal<T>(initialValue?: T): Signal<T | undefined> {
+export function createSignal(initialValue?: unknown): Signal<unknown> {
   const writableSignal = signal(initialValue);
   return {
     get value() {
       return writableSignal();
     },
-    set value(nextValue: T | undefined) {
+    set value(nextValue: unknown) {
       writableSignal.set(nextValue);
     },
   };

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { RolldownPluginOption } from 'rolldown';
 import { defineConfig, type UserConfig, type UserConfigFn } from 'tsdown';
 
-type Framework = 'preact' | 'qwik' | 'react' | 'solid' | 'svelte' | 'vue';
+type Framework = 'angular' | 'preact' | 'qwik' | 'react' | 'solid' | 'svelte' | 'vue';
 
 /**
  * Rolldown plugin to rewrite framework-specific imports.
@@ -85,6 +85,7 @@ function defineFrameworkConfig(
   return defineConfig({
     entry: ['./src/index.ts'],
     external: [
+      '@angular/core',
       '@preact/signals',
       '@qwik.dev/core',
       'solid-js',
@@ -115,6 +116,7 @@ function defineFrameworkConfig(
 
 const config: (UserConfig | UserConfigFn)[] = [
   defineFrameworkConfig(null),
+  defineFrameworkConfig('angular'),
   defineFrameworkConfig('preact'),
   defineFrameworkConfig('qwik'),
   defineFrameworkConfig('react'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
 
   packages/core:
     devDependencies:
+      '@angular/core':
+        specifier: ^21.0.0
+        version: 21.2.13(rxjs@7.8.2)
       '@formisch/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -975,6 +978,19 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@angular/core@21.2.13':
+    resolution: {integrity: sha512-23tS4oNL8nvkHcI4l9rbruQs2WS4yqQmBVQxWakqS9cmRpArLGgveR+hKNU5tPXm5EAi8oLO34/Zy7z70jUpCg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@angular/compiler': 21.2.13
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.15.0 || ~0.16.0
+    peerDependenciesMeta:
+      '@angular/compiler':
+        optional: true
+      zone.js:
+        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -10637,6 +10653,11 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@angular/core@21.2.13(rxjs@7.8.2)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:


### PR DESCRIPTION
Adds the Angular framework adapter to core. The adapter wires Angular's `WritableSignal` and `untracked()` to Formisch's framework interface - `createSignal` wraps `WritableSignal<T>` with a `{ value }` getter/setter to match the `Signal<T>` contract, `batch` is a no-op since Angular's scheduler coalesces writes automatically, and `untrack` delegates to `untracked()` from `@angular/core`.

Also adds `'angular'` to the `Framework` type, exports `@formisch/core/angular`, and adds `@angular/core` as an optional peer dependency (>=17, where signals are stable).

This is the foundation for the upcoming `frameworks/angular` package.