### PR TITLE
Update README and framework default to React

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Formisch
 
-Formisch is a schema-based, headless form library for JS frameworks. It manages form state and validation. It is type-safe, fast by default and its bundle size is small due to its modular design. Try it out in our [playground](https://stackblitz.com/edit/formisch-playground-solid)!
+Formisch is a schema-based, headless form library for JS frameworks. It manages form state and validation. It is type-safe, fast by default and its bundle size is small due to its modular design. Try it out in our [playground](https://stackblitz.com/edit/formisch-playground-react)!
 
 Supported frameworks: [Preact][formisch-preact], [Qwik][formisch-qwik], [React][formisch-react], [SolidJS][formisch-solid], [Svelte][formisch-svelte] and [Vue][formisch-vue].
 
@@ -15,10 +15,10 @@ Supported frameworks: [Preact][formisch-preact], [Qwik][formisch-qwik], [React][
 
 ## Example
 
-In SolidJS a form starts with the `createForm` primitive. It initializes your form's store based on the provided Valibot schema and infers its types. Next, wrap your form in the `<Form />` component. It's a thin layer around the native `<form />` element that handles form validation and submission. Then, you can access the state of a field with the `useField` primitive or the `<Field />` component to connect your inputs.
+In React a form starts with the `useForm` hook. It initializes your form's store based on the provided Valibot schema and infers its types. Next, wrap your form in the `<Form />` component. It's a thin layer around the native `<form />` element that handles form validation and submission. Then, you can access the state of a field with the `useField` hook or the `<Field />` component to connect your inputs.
 
 ```tsx
-import { createForm, Field, Form } from '@formisch/solid';
+import { Field, Form, useForm } from '@formisch/react';
 import * as v from 'valibot';
 
 const LoginSchema = v.object({
@@ -27,7 +27,7 @@ const LoginSchema = v.object({
 });
 
 export default function LoginPage() {
-  const loginForm = createForm({
+  const loginForm = useForm({
     schema: LoginSchema,
   });
 

--- a/website/src/routes/plugin@framework.ts
+++ b/website/src/routes/plugin@framework.ts
@@ -30,7 +30,7 @@ import {
 } from '~/logos';
 
 const FRAMEWORK_KEY = 'framework';
-export const DEFAULT_FRAMEWORK: Framework = 'solid';
+export const DEFAULT_FRAMEWORK: Framework = 'react';
 
 export type Framework =
   | 'preact'
@@ -95,7 +95,7 @@ const FrameworkContext = createContextId<Signal<Framework>>(FRAMEWORK_KEY);
  *
  * - Tracks the first URL segment when it matches a framework slug.
  * - Otherwise falls back to the user's last choice from `localStorage` once
- *   hydration runs, defaulting to `solid` during SSG.
+ *   hydration runs, defaulting to `react` during SSG.
  */
 export const useFrameworkProvider = () => {
   const location = useLocation();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make React the default framework across docs and the website. README example and playground now use React (`useForm` from `@formisch/react`), and the site’s default framework is set to 'react' for SSG and first-time visits.

<sup>Written for commit 5847f856300c4b4a4c6ad605d70e08068ad2fb62. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/formisch/pull/118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

