### PR TITLE
Update controlled fields documentation for various frameworks

### DIFF
--- a/website/src/routes/(docs)/preact/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -34,24 +34,27 @@ The HTML `<input type="file" />` element is an exception because it cannot be co
 
 ## Numbers and dates
 
-To make the fields of numbers and dates controlled, further steps are required, because the `<input />` element natively understands only strings as value.
+Fields defined with a `v.number()` or `v.date()` schema need extra steps to be controlled, because the `<input />` element natively understands only strings as value.
 
 ### Number input example
 
-Since not every input into an `<input type="number" />` field is a valid number, for example when typing floating numbers, the value may be `NaN` in between. You have to catch this case, otherwise the whole input will be removed when `NaN` is passed. It is best to encapsulate this logic in a separate component as described in the <Link href="/preact/guides/input-components/">input components</Link> guide.
+An `<input type="number" />` only reads and writes strings. So if you spread `field.props` onto it, `field.input` holds a string like `"123"`, even though it is typed as `number`. To store a real number, override the input handler with one that converts the value via `valueAsNumber` and forwards it to `field.onInput`.
+
+You also have to handle `NaN`. While typing a floating point number, the value can briefly be `NaN`, for example right after typing `1.`. If you don't catch this for the displayed value, the input is cleared. It is best to encapsulate both in a separate component as described in the <Link href="/preact/guides/input-components/">input components</Link> guide.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/preact';
 import type { ReadonlySignal } from '@preact/signals';
 import { useSignal, useSignalEffect } from '@preact/signals';
 
-interface NumberInputProps extends FieldElementProps {
+interface NumberInputProps extends Omit<FieldElementProps, 'onInput'> {
   type: 'number';
   label?: string;
   placeholder?: string;
   input: ReadonlySignal<number | undefined>;
   errors: ReadonlySignal<[string, ...string[]] | null>;
   required?: boolean;
+  onInput: (value: number | undefined) => void;
 }
 
 export function NumberInput({
@@ -60,6 +63,7 @@ export function NumberInput({
   errors,
   name,
   required,
+  onInput,
   ...inputProps
 }: NumberInputProps) {
   // Update signal if value is not `NaN`
@@ -79,6 +83,14 @@ export function NumberInput({
         id={name}
         required={required}
         value={signal.value}
+        // Convert string to number before storing
+        onInput={(event) =>
+          onInput(
+            event.currentTarget.value === ''
+              ? undefined
+              : event.currentTarget.valueAsNumber
+          )
+        }
         aria-invalid={!!errors.value}
         aria-errormessage={`${name}-error`}
       />
@@ -88,22 +100,40 @@ export function NumberInput({
 }
 ```
 
+Pass `field.onInput` after spreading `field.props` so it overrides the native handler.
+
+```tsx
+<Field of={form} path={['age']}>
+  {(field) => (
+    <NumberInput
+      {...field.props}
+      type="number"
+      label="Age"
+      input={field.input}
+      errors={field.errors}
+      onInput={field.onInput}
+    />
+  )}
+</Field>
+```
+
 ### Date input example
 
-A date or a number representing a date must be converted to a string before it can be passed to an `<input type="date" />` field. Since it is a calculated value, you can use `useMemo` for this.
+The same applies to dates. An `<input type="date" />` works with `yyyy-mm-dd` strings, while you usually want to store a `Date`. So you convert in both directions: format the `Date` for display, and parse the entered string back with `valueAsDate` before storing it.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/preact';
 import type { ReadonlySignal } from '@preact/signals';
 import { useMemo } from 'preact/hooks';
 
-interface DateInputProps extends FieldElementProps {
+interface DateInputProps extends Omit<FieldElementProps, 'onInput'> {
   type: 'date';
   label?: string;
   placeholder?: string;
-  input: ReadonlySignal<Date | number | undefined>;
+  input: ReadonlySignal<Date | undefined>;
   errors: ReadonlySignal<[string, ...string[]] | null>;
   required?: boolean;
+  onInput: (value: Date | undefined) => void;
 }
 
 export function DateInput({
@@ -112,26 +142,30 @@ export function DateInput({
   errors,
   name,
   required,
+  onInput,
   ...inputProps
 }: DateInputProps) {
-  // Transform date or number to string
+  // Transform date to string
   const getValue = useMemo(() => {
     const value = input.value;
-    return value &&
-      !Number.isNaN(typeof value === 'number' ? value : value.getTime())
-      ? new Date(value).toISOString().split('T', 1)[0]
+    return value && !Number.isNaN(value.getTime())
+      ? value.toISOString().split('T', 1)[0]
       : '';
   }, [input.value]);
 
   return (
     <div>
-      {label && <label for={name}>{name}</label>}
+      {label && <label for={name}>{label}</label>}
       <input
         {...inputProps}
         name={name}
         id={name}
         required={required}
         value={getValue}
+        // Convert string to date before storing
+        onInput={(event) =>
+          onInput(event.currentTarget.valueAsDate ?? undefined)
+        }
         aria-invalid={!!errors.value}
         aria-errormessage={`${name}-error`}
       />
@@ -139,6 +173,23 @@ export function DateInput({
     </div>
   );
 }
+```
+
+As with the number input, pass `field.onInput` after the spread to override the native handler.
+
+```tsx
+<Field of={form} path={['birthday']}>
+  {(field) => (
+    <DateInput
+      {...field.props}
+      type="date"
+      label="Birthday"
+      input={field.input}
+      errors={field.errors}
+      onInput={field.onInput}
+    />
+  )}
+</Field>
 ```
 
 ## Custom inputs and component libraries

--- a/website/src/routes/(docs)/preact/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(main-concepts)/add-form-fields/index.mdx
@@ -52,6 +52,8 @@ export default function App() {
 }
 ```
 
+> **Important:** The event handlers in `field.props` read the value from the DOM as a string. Fields with a non-string schema like `v.number()` or `v.date()` therefore need to be controlled to store the value with the correct type. See the <Link href="/preact/guides/controlled-fields/">controlled fields</Link> guide to learn more.
+
 > **Important:** If you plan to set initial values with `initialInput` or programmatically control field values using methods like <Link href="/methods/api/setInput/">`setInput`</Link> or <Link href="/methods/api/reset/">`reset`</Link>, you must make your fields controlled by setting the appropriate attributes (like `value`, `checked`, or `selected`). See the <Link href="/preact/guides/controlled-fields/">controlled fields</Link> guide to learn more.
 
 ### Headless design

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -63,7 +63,9 @@ interface NumberInputProps extends Omit<FieldElementProps, 'onInput$'> {
 export const NumberInput = component$<NumberInputProps>(
   ({ input, label, errors, name, onInput$, ...inputProps }) => {
     // Update computed value if not NaN
-    const value = useComputed$(() => (!Number.isNaN(input) ? input : undefined));
+    const value = useComputed$(() =>
+      !Number.isNaN(input) ? input : undefined
+    );
 
     return (
       <div>

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -38,31 +38,32 @@ The HTML `<input type="file" />` element is an exception because it cannot be co
 
 ## Numbers and dates
 
-To make the fields of numbers and dates controlled, further steps are required, because the `<input />` element natively understands only strings as value.
+Fields defined with a `v.number()` or `v.date()` schema need extra steps to be controlled, because the `<input />` element natively understands only strings as value.
 
 ### Number input example
 
-Since not every input into an `<input type="number" />` field is a valid number, for example when typing floating numbers, the value may be `NaN` in between. You have to catch this case, otherwise the whole input will be removed when `NaN` is passed. It is best to encapsulate this logic in a separate component as described in the <Link href="/qwik/guides/input-components/">input components</Link> guide.
+An `<input type="number" />` only reads and writes strings. So if you spread `field.props` onto it, `field.input` holds a string like `"123"`, even though it is typed as `number`. To store a real number, override the input handler with one that converts the value via `valueAsNumber` and forwards it to `field.onInput`.
+
+You also have to handle `NaN`. While typing a floating point number, the value can briefly be `NaN`, for example right after typing `1.`. If you don't catch this for the displayed value, the input is cleared. It is best to encapsulate both in a separate component as described in the <Link href="/qwik/guides/input-components/">input components</Link> guide.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/qwik';
-import { component$, useComputed$ } from '@qwik.dev/core';
+import { component$, type QRL, useComputed$ } from '@qwik.dev/core';
 
-interface NumberInputProps extends FieldElementProps {
+interface NumberInputProps extends Omit<FieldElementProps, 'onInput$'> {
   type: 'number';
   label?: string;
   placeholder?: string;
   input: number | undefined;
   errors: [string, ...string[]] | null;
   required?: boolean;
+  onInput$: QRL<(value: number | undefined) => void>;
 }
 
 export const NumberInput = component$<NumberInputProps>(
-  ({ input, label, errors, name, ...inputProps }) => {
+  ({ input, label, errors, name, onInput$, ...inputProps }) => {
     // Update computed value if not NaN
-    const value = useComputed$(() =>
-      !Number.isNaN(input) ? input : undefined
-    );
+    const value = useComputed$(() => (!Number.isNaN(input) ? input : undefined));
 
     return (
       <div>
@@ -73,6 +74,10 @@ export const NumberInput = component$<NumberInputProps>(
           name={name}
           type="number"
           value={value.value}
+          // Convert string to number before storing
+          onInput$={(_, element) =>
+            onInput$(element.value === '' ? undefined : element.valueAsNumber)
+          }
           aria-invalid={!!errors}
           aria-errormessage={`${name}-error`}
         />
@@ -83,42 +88,63 @@ export const NumberInput = component$<NumberInputProps>(
 );
 ```
 
+Pass `field.onInput` after spreading `field.props` so it overrides the native handler.
+
+```tsx
+<Field
+  of={form}
+  path={['age']}
+  render$={(field) => (
+    <NumberInput
+      {...field.props}
+      type="number"
+      label="Age"
+      input={field.input.value}
+      errors={field.errors.value}
+      onInput$={field.onInput}
+    />
+  )}
+/>
+```
+
 ### Date input example
 
-A date or a number representing a date must be converted to a string before it can be passed to an `<input type="date" />` field. Since it is a calculated value, you can use `useComputed$` for this.
+The same applies to dates. An `<input type="date" />` works with `yyyy-mm-dd` strings, while you usually want to store a `Date`. So you convert in both directions: format the `Date` for display, and parse the entered string back with `valueAsDate` before storing it.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/qwik';
-import { component$, useComputed$ } from '@qwik.dev/core';
+import { component$, type QRL, useComputed$ } from '@qwik.dev/core';
 
-interface DateInputProps extends FieldElementProps {
+interface DateInputProps extends Omit<FieldElementProps, 'onInput$'> {
   type: 'date';
   label?: string;
   placeholder?: string;
-  input: Date | number | undefined;
+  input: Date | undefined;
   errors: [string, ...string[]] | null;
   required?: boolean;
+  onInput$: QRL<(value: Date | undefined) => void>;
 }
 
 export const DateInput = component$<DateInputProps>(
-  ({ input, label, errors, name, ...inputProps }) => {
-    // Transform date or number to string
+  ({ input, label, errors, name, onInput$, ...inputProps }) => {
+    // Transform date to string
     const value = useComputed$(() =>
-      input &&
-      !Number.isNaN(typeof input === 'number' ? input : input.getTime())
-        ? new Date(input).toISOString().split('T', 1)[0]
+      input && !Number.isNaN(input.getTime())
+        ? input.toISOString().split('T', 1)[0]
         : ''
     );
 
     return (
       <div>
-        {label && <label for={name}>{name}</label>}
+        {label && <label for={name}>{label}</label>}
         <input
           {...inputProps}
           id={name}
           name={name}
           type="date"
           value={value.value}
+          // Convert string to date before storing
+          onInput$={(_, element) => onInput$(element.valueAsDate ?? undefined)}
           aria-invalid={!!errors}
           aria-errormessage={`${name}-error`}
         />
@@ -127,6 +153,25 @@ export const DateInput = component$<DateInputProps>(
     );
   }
 );
+```
+
+As with the number input, pass `field.onInput` after the spread to override the native handler.
+
+```tsx
+<Field
+  of={form}
+  path={['birthday']}
+  render$={(field) => (
+    <DateInput
+      {...field.props}
+      type="date"
+      label="Birthday"
+      input={field.input.value}
+      errors={field.errors.value}
+      onInput$={field.onInput}
+    />
+  )}
+/>
 ```
 
 ## Custom inputs and component libraries

--- a/website/src/routes/(docs)/qwik/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(main-concepts)/add-form-fields/index.mdx
@@ -59,6 +59,8 @@ export default component$(() => {
 });
 ```
 
+> **Important:** The event handlers in `field.props` read the value from the DOM as a string. Fields with a non-string schema like `v.number()` or `v.date()` therefore need to be controlled to store the value with the correct type. See the <Link href="/qwik/guides/controlled-fields/">controlled fields</Link> guide to learn more.
+
 > **Important:** If you plan to set initial values with `initialInput` or programmatically control field values using methods like <Link href="/methods/api/setInput/">`setInput`</Link> or <Link href="/methods/api/reset/">`reset`</Link>, you must make your fields controlled by setting the appropriate attributes (like `value`, `checked`, or `selected`). See the <Link href="/qwik/guides/controlled-fields/">controlled fields</Link> guide to learn more.
 
 ### Headless design

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -34,22 +34,25 @@ The HTML `<input type="file" />` element is an exception because it cannot be co
 
 ## Numbers and dates
 
-To make the fields of numbers and dates controlled, further steps are required, because the `<input />` element natively understands only strings as value.
+Fields defined with a `v.number()` or `v.date()` schema need extra steps to be controlled, because the `<input />` element natively understands only strings as value.
 
 ### Number input example
 
-Since not every input into an `<input type="number" />` field is a valid number, for example when typing floating numbers, the value may be `NaN` in between. You have to catch this case, otherwise the whole input will be removed when `NaN` is passed. It is best to encapsulate this logic in a separate component as described in the <Link href="/react/guides/input-components/">input components</Link> guide.
+An `<input type="number" />` only reads and writes strings. So if you spread `field.props` onto it, `field.input` holds a string like `"123"`, even though it is typed as `number`. To store a real number, override the change handler with one that converts the value via `valueAsNumber` and forwards it to `field.onChange`.
+
+You also have to handle `NaN`. While typing a floating point number, the value can briefly be `NaN`, for example right after typing `1.`. If you don't catch this for the displayed value, the input is cleared. It is best to encapsulate both in a separate component as described in the <Link href="/react/guides/input-components/">input components</Link> guide.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/react';
 import { useMemo, useRef } from 'react';
 
-interface NumberInputProps extends FieldElementProps {
+interface NumberInputProps extends Omit<FieldElementProps, 'onChange'> {
   label?: string;
   placeholder?: string;
   input: number | undefined;
   errors: [string, ...string[]] | null;
   required?: boolean;
+  onChange: (value: number | undefined) => void;
 }
 
 export function NumberInput({
@@ -57,6 +60,7 @@ export function NumberInput({
   input,
   errors,
   name,
+  onChange,
   ...inputProps
 }: NumberInputProps) {
   const prevValue = useRef<number | undefined>();
@@ -78,7 +82,15 @@ export function NumberInput({
         name={name}
         id={name}
         type="number"
-        value={value}
+        value={value ?? ''}
+        // Convert string to number before storing
+        onChange={(event) =>
+          onChange(
+            event.currentTarget.value === ''
+              ? undefined
+              : event.currentTarget.valueAsNumber
+          )
+        }
         aria-invalid={!!errors}
         aria-errormessage={`${name}-error`}
       />
@@ -88,20 +100,37 @@ export function NumberInput({
 }
 ```
 
+Pass `field.onChange` after spreading `field.props` so it overrides the native handler.
+
+```tsx
+<Field of={form} path={['age']}>
+  {(field) => (
+    <NumberInput
+      {...field.props}
+      label="Age"
+      input={field.input}
+      errors={field.errors}
+      onChange={field.onChange}
+    />
+  )}
+</Field>
+```
+
 ### Date input example
 
-A date or a number representing a date must be converted to a string before it can be passed to an `<input type="date" />` field. Since it is a calculated value, you can use `useMemo` for this.
+The same applies to dates. An `<input type="date" />` works with `yyyy-mm-dd` strings, while you usually want to store a `Date`. So you convert in both directions: format the `Date` for display, and parse the entered string back with `valueAsDate` before storing it.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/react';
 import { useMemo } from 'react';
 
-interface DateInputProps extends FieldElementProps {
+interface DateInputProps extends Omit<FieldElementProps, 'onChange'> {
   label?: string;
   placeholder?: string;
-  input: Date | number | undefined;
+  input: Date | undefined;
   errors: [string, ...string[]] | null;
   required?: boolean;
+  onChange: (value: Date | undefined) => void;
 }
 
 export function DateInput({
@@ -109,25 +138,31 @@ export function DateInput({
   input,
   errors,
   name,
+  onChange,
   ...inputProps
 }: DateInputProps) {
-  // Transform date or number to string
-  const value = useMemo(() => {
-    return input &&
-      !Number.isNaN(typeof input === 'number' ? input : input.getTime())
-      ? new Date(input).toISOString().split('T', 1)[0]
-      : '';
-  }, [input]);
+  // Transform date to string
+  const value = useMemo(
+    () =>
+      input && !Number.isNaN(input.getTime())
+        ? input.toISOString().split('T', 1)[0]
+        : '',
+    [input]
+  );
 
   return (
     <div>
-      {label && <label htmlFor={name}>{name}</label>}
+      {label && <label htmlFor={name}>{label}</label>}
       <input
         {...inputProps}
         name={name}
         id={name}
         type="date"
         value={value}
+        // Convert string to date before storing
+        onChange={(event) =>
+          onChange(event.currentTarget.valueAsDate ?? undefined)
+        }
         aria-invalid={!!errors}
         aria-errormessage={`${name}-error`}
       />
@@ -135,6 +170,22 @@ export function DateInput({
     </div>
   );
 }
+```
+
+As with the number input, pass `field.onChange` after the spread to override the native handler.
+
+```tsx
+<Field of={form} path={['birthday']}>
+  {(field) => (
+    <DateInput
+      {...field.props}
+      label="Birthday"
+      input={field.input}
+      errors={field.errors}
+      onChange={field.onChange}
+    />
+  )}
+</Field>
 ```
 
 ## Custom inputs and component libraries

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/add-form-fields/index.mdx
@@ -52,6 +52,8 @@ export default function App() {
 }
 ```
 
+> **Important:** The event handlers in `field.props` read the value from the DOM as a string. Fields with a non-string schema like `v.number()` or `v.date()` therefore need to be controlled to store the value with the correct type. See the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide to learn more.
+
 > **Important:** If you plan to set initial values with `initialInput` or programmatically control field values using methods like <Link href="/methods/api/setInput/">`setInput`</Link> or <Link href="/methods/api/reset/">`reset`</Link>, you must make your fields controlled by setting the appropriate attributes (like `value`, `checked`, or `selected`). See the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide to learn more.
 
 ### Headless design

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -41,27 +41,35 @@ The HTML `<input type="file" />` element is an exception because it cannot be co
 
 ## Numbers and dates
 
-To make the fields of numbers and dates controlled, further steps are required, because the `<input />` element natively understands only strings as value.
+Fields defined with a `v.number()` or `v.date()` schema need extra steps to be controlled, because the `<input />` element natively understands only strings as value.
 
 ### Number input example
 
-Since not every input into an `<input type="number" />` field is a valid number, for example when typing floating numbers, the value may be `NaN` in between. You have to catch this case, otherwise the whole input will be removed when `NaN` is passed. It is best to encapsulate this logic in a separate component as described in the <Link href="/solid/guides/input-components/">input components</Link> guide.
+An `<input type="number" />` only reads and writes strings. So if you spread `field.props` onto it, `field.input` holds a string like `"123"`, even though it is typed as `number`. To store a real number, override the input handler with one that converts the value via `valueAsNumber` and forwards it to `field.onInput`.
+
+You also have to handle `NaN`. While typing a floating point number, the value can briefly be `NaN`, for example right after typing `1.`. If you don't catch this for the displayed value, the input is cleared. It is best to encapsulate both in a separate component as described in the <Link href="/solid/guides/input-components/">input components</Link> guide.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/solid';
 import { createMemo, splitProps } from 'solid-js';
 
-interface NumberInputProps extends FieldElementProps {
+interface NumberInputProps extends Omit<FieldElementProps, 'onInput'> {
   type: 'number';
   label?: string;
   placeholder?: string;
   input: number | undefined;
   errors: [string, ...string[]] | null;
   required?: boolean;
+  onInput: (value: number | undefined) => void;
 }
 
 export function NumberInput(props: NumberInputProps) {
-  const [, inputProps] = splitProps(props, ['input', 'label', 'errors']);
+  const [, inputProps] = splitProps(props, [
+    'input',
+    'label',
+    'errors',
+    'onInput',
+  ]);
 
   // Update memo if value is not `NaN`
   const getValue = createMemo<number | undefined>(
@@ -76,6 +84,14 @@ export function NumberInput(props: NumberInputProps) {
         {...inputProps}
         id={props.name}
         value={getValue() ?? ''}
+        // Convert string to number before storing
+        onInput={(event) =>
+          props.onInput(
+            event.currentTarget.value === ''
+              ? undefined
+              : event.currentTarget.valueAsNumber
+          )
+        }
         aria-invalid={!!props.errors}
         aria-errormessage={`${props.name}-error`}
       />
@@ -85,43 +101,67 @@ export function NumberInput(props: NumberInputProps) {
 }
 ```
 
+Pass `field.onInput` after spreading `field.props` so it overrides the native handler.
+
+```tsx
+<Field of={form} path={['age']}>
+  {(field) => (
+    <NumberInput
+      {...field.props}
+      type="number"
+      label="Age"
+      input={field.input}
+      errors={field.errors}
+      onInput={field.onInput}
+    />
+  )}
+</Field>
+```
+
 ### Date input example
 
-A date or a number representing a date must be converted to a string before it can be passed to an `<input type="date" />` field. Since it is a calculated value, you can use `createMemo` for this.
+The same applies to dates. An `<input type="date" />` works with `yyyy-mm-dd` strings, while you usually want to store a `Date`. So you convert in both directions: format the `Date` for display, and parse the entered string back with `valueAsDate` before storing it.
 
 ```tsx
 import type { FieldElementProps } from '@formisch/solid';
 import { createMemo, splitProps } from 'solid-js';
 
-interface DateInputProps extends FieldElementProps {
+interface DateInputProps extends Omit<FieldElementProps, 'onInput'> {
   type: 'date';
   label?: string;
   placeholder?: string;
-  input: Date | number | undefined;
+  input: Date | undefined;
   errors: [string, ...string[]] | null;
   required?: boolean;
+  onInput: (value: Date | undefined) => void;
 }
 
 export function DateInput(props: DateInputProps) {
-  const [, inputProps] = splitProps(props, ['input', 'label', 'errors']);
+  const [, inputProps] = splitProps(props, [
+    'input',
+    'label',
+    'errors',
+    'onInput',
+  ]);
 
-  // Transform date or number to string
+  // Transform date to string
   const getValue = createMemo(() =>
-    props.input &&
-    !Number.isNaN(
-      typeof props.input === 'number' ? props.input : props.input.getTime()
-    )
-      ? new Date(props.input).toISOString().split('T', 1)[0]
+    props.input && !Number.isNaN(props.input.getTime())
+      ? props.input.toISOString().split('T', 1)[0]
       : ''
   );
 
   return (
     <div>
-      {props.label && <label for={props.name}>{props.name}</label>}
+      {props.label && <label for={props.name}>{props.label}</label>}
       <input
         {...inputProps}
         id={props.name}
         value={getValue()}
+        // Convert string to date before storing
+        onInput={(event) =>
+          props.onInput(event.currentTarget.valueAsDate ?? undefined)
+        }
         aria-invalid={!!props.errors}
         aria-errormessage={`${props.name}-error`}
       />
@@ -129,6 +169,23 @@ export function DateInput(props: DateInputProps) {
     </div>
   );
 }
+```
+
+As with the number input, pass `field.onInput` after the spread to override the native handler.
+
+```tsx
+<Field of={form} path={['birthday']}>
+  {(field) => (
+    <DateInput
+      {...field.props}
+      type="date"
+      label="Birthday"
+      input={field.input}
+      errors={field.errors}
+      onInput={field.onInput}
+    />
+  )}
+</Field>
 ```
 
 ## Custom inputs and component libraries

--- a/website/src/routes/(docs)/solid/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(main-concepts)/add-form-fields/index.mdx
@@ -52,6 +52,8 @@ export default function App() {
 }
 ```
 
+> **Important:** The event handlers in `field.props` read the value from the DOM as a string. Fields with a non-string schema like `v.number()` or `v.date()` therefore need to be controlled to store the value with the correct type. See the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide to learn more.
+
 > **Important:** If you plan to set initial values with `initialInput` or programmatically control field values using methods like <Link href="/methods/api/setInput/">`setInput`</Link> or <Link href="/methods/api/reset/">`reset`</Link>, you must make your fields controlled by setting the appropriate attributes (like `value`, `checked`, or `selected`). See the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide to learn more.
 
 ### Headless design

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -36,23 +36,26 @@ The HTML `<input type="file" />` element is an exception because it cannot be co
 
 ## Numbers and dates
 
-To make the fields of numbers and dates controlled, further steps are required, because the `<input />` element natively understands only strings as value.
+Fields defined with a `v.number()` or `v.date()` schema need extra steps to be controlled, because the `<input />` element natively understands only strings as value.
 
 ### Number input example
 
-Since not every input into an `<input type="number" />` field is a valid number, for example when typing floating numbers, the value may be `NaN` in between. You have to catch this case, otherwise the whole input will be removed when `NaN` is passed. It is best to encapsulate this logic in a separate component as described in the <Link href="/svelte/guides/input-components/">input components</Link> guide.
+An `<input type="number" />` only reads and writes strings. So if you spread `field.props` onto it, `field.input` holds a string like `"123"`, even though it is typed as `number`. To store a real number, override the input handler with one that converts the value via `valueAsNumber` and forwards it to `field.onInput`.
+
+You also have to handle `NaN`. While typing a floating point number, the value can briefly be `NaN`, for example right after typing `1.`. If you don't catch this for the displayed value, the input is cleared. It is best to encapsulate both in a separate component as described in the <Link href="/svelte/guides/input-components/">input components</Link> guide.
 
 ```svelte
 <script lang="ts">
   import type { FieldElementProps } from '@formisch/svelte';
 
-  interface NumberInputProps extends FieldElementProps {
+  interface NumberInputProps extends Omit<FieldElementProps, 'oninput'> {
     type: 'number';
     label?: string;
     placeholder?: string;
     input: number | undefined;
     errors: [string, ...string[]] | null;
     required?: boolean;
+    oninput: (value: number | undefined) => void;
   }
 
   let {
@@ -86,7 +89,12 @@ Since not every input into an `<input type="number" />` field is a valid number,
     aria-invalid={!!errors}
     aria-errormessage={`${name}-error`}
     {onfocus}
-    {oninput}
+    oninput={(event) =>
+      oninput(
+        event.currentTarget.value === ''
+          ? undefined
+          : event.currentTarget.valueAsNumber
+      )}
     {onchange}
     {onblur}
   />
@@ -96,21 +104,39 @@ Since not every input into an `<input type="number" />` field is a valid number,
 </div>
 ```
 
+Pass `field.onInput` after spreading `field.props` so it overrides the native handler.
+
+```svelte
+<Field of={form} path={['age']}>
+  {#snippet children(field)}
+    <NumberInput
+      {...field.props}
+      type="number"
+      label="Age"
+      input={field.input}
+      errors={field.errors}
+      oninput={field.onInput}
+    />
+  {/snippet}
+</Field>
+```
+
 ### Date input example
 
-A date or a number representing a date must be converted to a string before it can be passed to an `<input type="date" />` field. Since it is a calculated value, you can use a regular function or derived state for this.
+The same applies to dates. An `<input type="date" />` works with `yyyy-mm-dd` strings, while you usually want to store a `Date`. So you convert in both directions: format the `Date` for display, and parse the entered string back with `valueAsDate` before storing it.
 
 ```svelte
 <script lang="ts">
   import type { FieldElementProps } from '@formisch/svelte';
 
-  interface DateInputProps extends FieldElementProps {
+  interface DateInputProps extends Omit<FieldElementProps, 'oninput'> {
     type: 'date';
     label?: string;
     placeholder?: string;
-    input: Date | number | undefined;
+    input: Date | undefined;
     errors: [string, ...string[]] | null;
     required?: boolean;
+    oninput: (value: Date | undefined) => void;
   }
 
   let {
@@ -127,10 +153,10 @@ A date or a number representing a date must be converted to a string before it c
     onblur,
   } = $props<DateInputProps>();
 
-  // Transform date or number to string
+  // Transform date to string
   const getValue = () =>
-    input && !Number.isNaN(typeof input === 'number' ? input : input.getTime())
-      ? new Date(input).toISOString().split('T', 1)[0]
+    input && !Number.isNaN(input.getTime())
+      ? input.toISOString().split('T', 1)[0]
       : '';
 </script>
 
@@ -147,7 +173,7 @@ A date or a number representing a date must be converted to a string before it c
     aria-invalid={!!errors}
     aria-errormessage={`${name}-error`}
     {onfocus}
-    {oninput}
+    oninput={(event) => oninput(event.currentTarget.valueAsDate ?? undefined)}
     {onchange}
     {onblur}
   />
@@ -155,6 +181,23 @@ A date or a number representing a date must be converted to a string before it c
     <div id={`${name}-error`}>{errors[0]}</div>
   {/if}
 </div>
+```
+
+As with the number input, pass `field.onInput` after the spread to override the native handler.
+
+```svelte
+<Field of={form} path={['birthday']}>
+  {#snippet children(field)}
+    <DateInput
+      {...field.props}
+      type="date"
+      label="Birthday"
+      input={field.input}
+      errors={field.errors}
+      oninput={field.onInput}
+    />
+  {/snippet}
+</Field>
 ```
 
 ## Custom inputs and component libraries

--- a/website/src/routes/(docs)/svelte/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(main-concepts)/add-form-fields/index.mdx
@@ -52,6 +52,8 @@ Use Svelte's `{#snippet children(field)}` syntax to define how the field should 
 </Form>
 ```
 
+> **Important:** The event handlers in `field.props` read the value from the DOM as a string. Fields with a non-string schema like `v.number()` or `v.date()` therefore need to be controlled to store the value with the correct type. See the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide to learn more.
+
 > **Important:** If you plan to set initial values with `initialInput` or programmatically control field values using methods like <Link href="/methods/api/setInput/">`setInput`</Link> or <Link href="/methods/api/reset/">`reset`</Link>, you must make your fields controlled by setting the appropriate attributes (like `value`, `checked`, or `selected`). See the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide to learn more.
 
 ### Headless design

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -20,7 +20,7 @@ As soon as your forms become more complex, for example you set initial values or
 
 ## Simple text inputs
 
-For most input types including text, email, number, and date, you simply add the `v-model` directive. Vue automatically handles type conversions for you:
+For a text input you simply add the `v-model` directive:
 
 ```vue
 <template>
@@ -30,21 +30,25 @@ For most input types including text, email, number, and date, you simply add the
 </template>
 ```
 
-### Vue's automatic type handling
+## Numbers and dates
 
-Vue's `v-model` automatically handles different input types without special code:
+In Vue you don't wire up an input handler — `v-model` reads and writes the value through the `field.input` setter. That makes numbers and dates mostly automatic.
 
-**Number inputs** - Vue converts between strings and numbers automatically:
+### Number inputs
+
+For `<input type="number" />`, the `.number` modifier converts the value to a real number that matches a `v.number()` schema. Vue applies it automatically for number inputs, but you can also add it explicitly:
 
 ```vue
 <template>
   <Field :of="form" :path="['age']" v-slot="field">
-    <input v-model="field.input" v-bind="field.props" type="number" />
+    <input v-model.number="field.input" v-bind="field.props" type="number" />
   </Field>
 </template>
 ```
 
-**Date inputs** - Vue handles the date string format automatically:
+### Date inputs
+
+An `<input type="date" />` exposes its value as a `yyyy-mm-dd` string, which `v-model` stores as-is. This pairs directly with a `v.string()` schema:
 
 ```vue
 <template>
@@ -54,7 +58,26 @@ Vue's `v-model` automatically handles different input types without special code
 </template>
 ```
 
-This works seamlessly whether your schema expects strings, numbers, or dates - Vue will handle the conversion.
+If your schema expects a real `Date` (`v.date()`), Vue has no modifier for this, so convert in both directions yourself:
+
+```vue
+<script setup lang="ts">
+function parseDate(event: Event) {
+  return (event.target as HTMLInputElement).valueAsDate ?? undefined;
+}
+</script>
+
+<template>
+  <Field :of="form" :path="['birthday']" v-slot="field">
+    <input
+      v-bind="field.props"
+      type="date"
+      :value="field.input?.toISOString().split('T', 1)[0] ?? ''"
+      @input="field.input = parseDate($event)"
+    />
+  </Field>
+</template>
+```
 
 ## Checkboxes
 


### PR DESCRIPTION
Fix #119


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update “controlled fields” docs for React, Preact, Solid, Svelte, Qwik, and Vue to correctly control number and date inputs, avoid input clearing while typing, and show clear conversion/handler patterns.

- **Documentation**
  - Clarifies that `field.props` handlers read DOM strings; non-string schemas like `v.number()` and `v.date()` must be controlled.
  - Numbers: convert with `valueAsNumber`, guard `NaN` during typing, and forward to `field.onInput`/`field.onChange`. Pass the handler after spreading `field.props` to override the native one.
  - Dates: display `Date` as `yyyy-mm-dd`, parse back with `valueAsDate`, and forward to `field.onInput`/`field.onChange`. Pass the handler after the spread.
  - Vue: use `v-model.number` for numbers; for `v.date()` schemas, add a manual conversion example. `v.string()` date schemas work with plain `v-model`.
  - Adds “Important” notes in each framework’s “Add form fields” guide linking to the controlled fields doc.
  - Refactors NumberInput examples for readability across frameworks (explicit handler props, `value` defaults to `''`, correct label usage).

<sup>Written for commit 17d98df970d3dd31af7f4a9e0bf79958ccf9ff1b. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/formisch/pull/120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



