### PR TITLE
docs(vue): fix code examples

### DIFF
--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -120,12 +120,11 @@ For select elements, you need to bind to the `selected` attribute:
 ```vue
 <template>
   <Field :of="form" :path="['country']" v-slot="field">
-    <select v-bind="field.props">
+    <select v-bind="field.props" v-model="field.input">
       <option
         v-for="option in options"
         :key="option.value"
         :value="option.value"
-        :selected="field.input === option.value"
       >
         {{ option.label }}
       </option>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -88,7 +88,7 @@ For checkboxes, you need to bind to the `checked` attribute and handle both bool
 ```vue
 <template>
   <Field :of="form" :path="['acceptTerms']" v-slot="field">
-    <input v-bind="field.props" type="checkbox" :checked="field.input" />
+    <input type="checkbox" v-bind="field.props" v-model="field.input" />
   </Field>
 </template>
 ```

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -138,12 +138,11 @@ For select elements, you need to bind to the `selected` attribute:
 ```vue
 <template>
   <Field :of="form" :path="['languages']" v-slot="field">
-    <select v-bind="field.props" multiple>
+    <select multiple v-bind="field.props" v-model="field.input">
       <option
         v-for="option in options"
         :key="option.value"
         :value="option.value"
-        :selected="field.input?.includes(option.value)"
       >
         {{ option.label }}
       </option>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -100,10 +100,10 @@ For checkboxes, you need to bind to the `checked` attribute and handle both bool
   <Field :of="form" :path="['interests']" v-slot="field">
     <label v-for="option in options" :key="option.value">
       <input
-        v-bind="field.props"
         type="checkbox"
         :value="option.value"
-        :checked="field.input?.includes(option.value)"
+        v-bind="field.props"
+        v-model="field.input"
       />
       {{ option.label }}
     </label>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
@@ -25,7 +25,7 @@ A simple checkbox represents a boolean and is `true` when checked or `false` oth
 <template>
   <Field :of="form" :path="['cookies']" v-slot="field">
     <label>
-      <input v-bind="field.props" type="checkbox" :checked="field.input" />
+      <input type="checkbox" v-bind="field.props" v-model="field.input" />
       Yes, I want cookies
     </label>
   </Field>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
@@ -91,7 +91,7 @@ An HTML `<select />` element allows you to select a string from a predefined lis
 ```vue
 <template>
   <Field :of="form" :path="['framework']" v-slot="field">
-    <select v-bind="field.props">
+    <select v-bind="field.props" v-model="field.input">
       <option
         v-for="option in [
           { label: 'Preact', value: 'preact' },
@@ -100,7 +100,6 @@ An HTML `<select />` element allows you to select a string from a predefined lis
         ]"
         :key="option.value"
         :value="option.value"
-        :selected="field.input === option.value"
       >
         {{ option.label }}
       </option>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
@@ -46,10 +46,10 @@ However, you can also use multiple checkboxes to represent an array of strings. 
       :key="fruit.value"
     >
       <input
-        v-bind="field.props"
         type="checkbox"
         :value="fruit.value"
-        :checked="field.input?.includes(fruit.value)"
+        v-bind="field.props"
+        v-model="field.input"
       />
       {{ fruit.label }}
     </label>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
@@ -113,7 +113,7 @@ However, if you set the `multiple` attribute, multiple options can be selected m
 ```vue
 <template>
   <Field :of="form" :path="['frameworks']" v-slot="field">
-    <select v-bind="field.props" multiple>
+    <select multiple v-bind="field.props" v-model="field.input">
       <option
         v-for="option in [
           { label: 'Preact', value: 'preact' },
@@ -122,7 +122,6 @@ However, if you set the `multiple` attribute, multiple options can be selected m
         ]"
         :key="option.value"
         :value="option.value"
-        :selected="field.input?.includes(option.value)"
       >
         {{ option.label }}
       </option>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/special-inputs/index.mdx
@@ -73,10 +73,10 @@ A group of radio buttons, while similar to an array of checkboxes, will only all
       :key="color.value"
     >
       <input
-        v-bind="field.props"
         type="radio"
         :value="color.value"
-        :checked="field.input === color.value"
+        v-bind="field.props"
+        v-model="field.input"
       />
       {{ color.label }}
     </label>


### PR DESCRIPTION
Fix Vue code examples in the following guides:
* https://formisch.dev/vue/guides/special-inputs/
* https://formisch.dev/vue/guides/controlled-fields/

Replace the `:checked="..."` attribute with `v-model="field.input"`.
The `:selected="..."` attribute is actually not needed because the selection is already handled by `v-model`.

Here is the Vue documentation for reference: https://vuejs.org/guide/essentials/forms.html#checkbox

I also adjusted the order of the attributes a bit (from native HTML attributes to Vue and Formisch related attributes).
I put the `multiple` attribute first (`<select multiple ...`), so you automatically read: "select multiple"
If you prefer a different order, you can change it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Vue docs examples in “Controlled fields” and “Special inputs” by switching checkboxes, radio buttons, and selects to `v-model` with `field.input`. Removed redundant `:checked`/`:selected` bindings and placed the `multiple` attribute first for clearer, idiomatic Vue.

<sup>Written for commit a908a53cb3bbe63d3dfb453b325b116a5a2714b3. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/formisch/pull/121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

