### PR TITLE
Implement decodeFormData function and associated tests

### DIFF
--- a/packages/core/src/form/decodeFormData/decodeFormData.test.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.test.ts
@@ -1,0 +1,749 @@
+import * as v from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { decodeFormData } from './decodeFormData.ts';
+
+// Creates form data object from list of entries
+function createFormData(entries: [string, string | File][]): FormData {
+  const formData = new FormData();
+  for (const [key, value] of entries) {
+    formData.append(key, value);
+  }
+  return formData;
+}
+
+describe('decodeFormData', () => {
+  describe('value decoding', () => {
+    test('should keep strings as strings', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([['["name"]', 'Jane']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ name: 'Jane' });
+    });
+
+    test('should decode numbers', () => {
+      const schema = v.object({
+        int: v.number(),
+        float: v.number(),
+        negative: v.number(),
+        positive: v.number(),
+        leadingDot: v.number(),
+        scientific: v.number(),
+        scientificNegative: v.number(),
+      });
+      const formData = createFormData([
+        ['["int"]', '42'],
+        ['["float"]', '3.14'],
+        ['["negative"]', '-7'],
+        ['["positive"]', '+5'],
+        ['["leadingDot"]', '.5'],
+        ['["scientific"]', '1.5e3'],
+        ['["scientificNegative"]', '2e-2'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        int: 42,
+        float: 3.14,
+        negative: -7,
+        positive: 5,
+        leadingDot: 0.5,
+        scientific: 1500,
+        scientificNegative: 0.02,
+      });
+    });
+
+    test('should decode empty number to null', () => {
+      const schema = v.object({ age: v.number() });
+      const formData = createFormData([['["age"]', '']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ age: null });
+    });
+
+    test('should decode "null" and "undefined" numbers', () => {
+      const schema = v.object({ a: v.number(), b: v.number() });
+      const formData = createFormData([
+        ['["a"]', 'null'],
+        ['["b"]', 'undefined'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        a: null,
+        b: undefined,
+      });
+    });
+
+    test('should decode non-numeric number values to NaN', () => {
+      const schema = v.object({ value: v.number() });
+      const formData = createFormData([['["value"]', 'not-a-number']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ value: NaN });
+    });
+
+    test('should decode booleans', () => {
+      const schema = v.object({
+        on: v.boolean(),
+        truthy: v.boolean(),
+        one: v.boolean(),
+        off: v.boolean(),
+        falsy: v.boolean(),
+        zero: v.boolean(),
+      });
+      const formData = createFormData([
+        ['["on"]', 'on'],
+        ['["truthy"]', 'true'],
+        ['["one"]', '1'],
+        ['["off"]', 'off'],
+        ['["falsy"]', 'false'],
+        ['["zero"]', '0'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        on: true,
+        truthy: true,
+        one: true,
+        off: false,
+        falsy: false,
+        zero: false,
+      });
+    });
+
+    test('should resolve "null" and "undefined" booleans to false', () => {
+      // Boolean fields always resolve to true or false (checkbox semantics), so
+      // nullish branches of boolean decoding are overridden by default filling
+      const schema = v.object({ a: v.boolean(), b: v.boolean() });
+      const formData = createFormData([
+        ['["a"]', 'null'],
+        ['["b"]', 'undefined'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        a: false,
+        b: false,
+      });
+    });
+
+    test('should decode the common date and date-time formats', () => {
+      const schema = v.object({
+        date: v.date(),
+        month: v.date(),
+        dateTime: v.date(),
+        dateTimeSecond: v.date(),
+        dateTimeMs: v.date(),
+        timestamp: v.date(),
+      });
+      const formData = createFormData([
+        ['["date"]', '2023-06-15'],
+        ['["month"]', '2023-06'],
+        ['["dateTime"]', '2023-06-15T14:30'],
+        ['["dateTimeSecond"]', '2023-06-15T14:30:45'],
+        ['["dateTimeMs"]', '2023-06-15T14:30:45.123'],
+        ['["timestamp"]', '2023-06-15T14:30:00.000Z'],
+      ]);
+      const result = decodeFormData(schema, formData) as Record<string, Date>;
+      // Dates, months and full timestamps are parsed as UTC by `new Date`
+      expect(result.date.toISOString()).toBe('2023-06-15T00:00:00.000Z');
+      expect(result.month.toISOString()).toBe('2023-06-01T00:00:00.000Z');
+      expect(result.timestamp.toISOString()).toBe('2023-06-15T14:30:00.000Z');
+      // Timezone-less date-times are forced to UTC, with or without seconds and
+      // fractional seconds
+      expect(result.dateTime.toISOString()).toBe('2023-06-15T14:30:00.000Z');
+      expect(result.dateTimeSecond.toISOString()).toBe(
+        '2023-06-15T14:30:45.000Z'
+      );
+      expect(result.dateTimeMs.toISOString()).toBe('2023-06-15T14:30:45.123Z');
+    });
+
+    test('should decode empty, "null" and "undefined" dates', () => {
+      const schema = v.object({
+        a: v.date(),
+        b: v.date(),
+        c: v.date(),
+      });
+      const formData = createFormData([
+        ['["a"]', ''],
+        ['["b"]', 'null'],
+        ['["c"]', 'undefined'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        a: null,
+        b: null,
+        c: undefined,
+      });
+    });
+
+    test('should decode bigints', () => {
+      const schema = v.object({
+        valid: v.bigint(),
+        invalid: v.bigint(),
+        empty: v.bigint(),
+        nullish: v.bigint(),
+        undef: v.bigint(),
+      });
+      const formData = createFormData([
+        ['["valid"]', '9007199254740993'],
+        ['["invalid"]', 'not-a-bigint'],
+        ['["empty"]', ''],
+        ['["nullish"]', 'null'],
+        ['["undef"]', 'undefined'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        valid: 9007199254740993n,
+        invalid: 'not-a-bigint',
+        empty: null,
+        nullish: null,
+        undef: undefined,
+      });
+    });
+
+    test('should keep enum, picklist and literal values as strings', () => {
+      const schema = v.object({
+        enum: v.enum({ Light: 'light', Dark: 'dark' }),
+        picklist: v.picklist(['a', 'b']),
+        literal: v.literal('x'),
+      });
+      const formData = createFormData([
+        ['["enum"]', 'dark'],
+        ['["picklist"]', 'b'],
+        ['["literal"]', 'x'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        enum: 'dark',
+        picklist: 'b',
+        literal: 'x',
+      });
+    });
+  });
+
+  describe('files', () => {
+    test('should keep selected files unchanged', () => {
+      const schema = v.object({ avatar: v.file() });
+      const file = new File(['content'], 'avatar.png', { type: 'image/png' });
+      const formData = createFormData([['["avatar"]', file]]);
+      const result = decodeFormData(schema, formData) as { avatar: File };
+      expect(result.avatar).toBe(file);
+    });
+
+    test('should keep files for non-file schemas unchanged', () => {
+      const schema = v.object({ data: v.string() });
+      const file = new File(['content'], 'data.bin');
+      const formData = createFormData([['["data"]', file]]);
+      const result = decodeFormData(schema, formData) as { data: File };
+      expect(result.data).toBe(file);
+    });
+
+    test('should skip empty file inputs of unselected files', () => {
+      const schema = v.object({ avatar: v.file() });
+      const emptyFile = new File([], '');
+      const formData = createFormData([['["avatar"]', emptyFile]]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({});
+    });
+
+    test('should keep empty files that have a name', () => {
+      const schema = v.object({ avatar: v.file() });
+      const namedEmptyFile = new File([], 'empty.txt');
+      const formData = createFormData([['["avatar"]', namedEmptyFile]]);
+      const result = decodeFormData(schema, formData) as { avatar: File };
+      expect(result.avatar).toBe(namedEmptyFile);
+    });
+  });
+
+  describe('nested objects', () => {
+    test('should decode nested objects and reuse containers', () => {
+      const schema = v.object({
+        user: v.object({ name: v.string(), age: v.number() }),
+      });
+      const formData = createFormData([
+        ['["user","name"]', 'Jane'],
+        ['["user","age"]', '30'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        user: { name: 'Jane', age: 30 },
+      });
+    });
+
+    test('should leave absent objects absent', () => {
+      const schema = v.object({
+        settings: v.object({ darkMode: v.boolean() }),
+      });
+      const result = decodeFormData(schema, createFormData([])) as Record<
+        string,
+        unknown
+      >;
+      expect('settings' in result).toBe(false);
+    });
+
+    test('should not crash when an object is replaced by a primitive', () => {
+      const schema = v.object({
+        nested: v.object({ flag: v.boolean() }),
+      });
+      const formData = createFormData([['["nested"]', 'hello']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        nested: 'hello',
+      });
+    });
+  });
+
+  describe('arrays', () => {
+    test('should decode indexed arrays of objects', () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string(), done: v.boolean() })),
+      });
+      const formData = createFormData([
+        ['["todos",0,"label"]', 'First'],
+        ['["todos",0,"done"]', 'on'],
+        ['["todos",1,"label"]', 'Second'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        todos: [
+          { label: 'First', done: true },
+          { label: 'Second', done: false },
+        ],
+      });
+    });
+
+    test('should decode indexed arrays of primitives', () => {
+      const schema = v.object({ scores: v.array(v.number()) });
+      const formData = createFormData([
+        ['["scores",0]', '10'],
+        ['["scores",1]', '20'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        scores: [10, 20],
+      });
+    });
+
+    test('should collect repeated keys into an array', () => {
+      const schema = v.object({ tags: v.array(v.string()) });
+      const formData = createFormData([
+        ['["tags"]', 'a'],
+        ['["tags"]', 'b'],
+        ['["tags"]', 'c'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        tags: ['a', 'b', 'c'],
+      });
+    });
+
+    test('should decode a single repeated key into an array', () => {
+      const schema = v.object({ ids: v.array(v.number()) });
+      const formData = createFormData([['["ids"]', '5']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ ids: [5] });
+    });
+
+    test('should default absent arrays to empty arrays', () => {
+      const schema = v.object({ tags: v.array(v.string()) });
+      expect(decodeFormData(schema, createFormData([]))).toStrictEqual({
+        tags: [],
+      });
+    });
+
+    test('should fill boolean defaults within array items', () => {
+      const schema = v.object({
+        items: v.array(v.object({ name: v.string(), active: v.boolean() })),
+      });
+      const formData = createFormData([
+        ['["items",0,"name"]', 'A'],
+        ['["items",0,"active"]', 'on'],
+        ['["items",1,"name"]', 'B'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        items: [
+          { name: 'A', active: true },
+          { name: 'B', active: false },
+        ],
+      });
+    });
+  });
+
+  describe('tuples', () => {
+    test('should decode tuples', () => {
+      const schema = v.object({
+        point: v.tuple([v.number(), v.number()]),
+      });
+      const formData = createFormData([
+        ['["point",0]', '1'],
+        ['["point",1]', '2'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        point: [1, 2],
+      });
+    });
+
+    test('should fill boolean holes within tuples', () => {
+      const schema = v.object({
+        entry: v.tuple([v.boolean(), v.number()]),
+      });
+      const formData = createFormData([['["entry",1]', '5']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        entry: [false, 5],
+      });
+    });
+
+    test('should not complete missing trailing tuple items', () => {
+      const schema = v.object({
+        entry: v.tuple([v.number(), v.boolean()]),
+      });
+      const formData = createFormData([['["entry",0]', '5']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        entry: [5],
+      });
+    });
+
+    test('should leave absent tuples absent', () => {
+      const schema = v.object({
+        entry: v.optional(v.tuple([v.number(), v.number()])),
+      });
+      const result = decodeFormData(schema, createFormData([])) as Record<
+        string,
+        unknown
+      >;
+      expect('entry' in result).toBe(false);
+    });
+
+    test('should support loose and strict tuples', () => {
+      const schema = v.object({
+        loose: v.looseTuple([v.number()]),
+        strict: v.strictTuple([v.boolean()]),
+      });
+      const formData = createFormData([
+        ['["loose",0]', '1'],
+        ['["strict",0]', 'on'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        loose: [1],
+        strict: [true],
+      });
+    });
+  });
+
+  describe('combinators', () => {
+    test('should descend into union options', () => {
+      const schema = v.object({
+        value: v.union([
+          v.object({ a: v.number() }),
+          v.object({ b: v.boolean() }),
+        ]),
+      });
+      const formData = createFormData([['["value","a"]', '5']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        value: { a: 5, b: false },
+      });
+    });
+
+    test('should fall back to a string when no union option matches', () => {
+      const schema = v.object({
+        value: v.union([
+          v.object({ a: v.number() }),
+          v.object({ b: v.boolean() }),
+        ]),
+      });
+      const formData = createFormData([['["value","c"]', 'raw']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        value: { c: 'raw', b: false },
+      });
+    });
+
+    test('should descend into intersect options', () => {
+      const schema = v.object({
+        value: v.intersect([
+          v.object({ a: v.number() }),
+          v.object({ b: v.boolean() }),
+        ]),
+      });
+      const formData = createFormData([
+        ['["value","a"]', '5'],
+        ['["value","b"]', 'on'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        value: { a: 5, b: true },
+      });
+    });
+
+    test('should descend into variant options', () => {
+      const schema = v.object({
+        value: v.variant('type', [
+          v.object({ type: v.literal('a'), count: v.number() }),
+          v.object({ type: v.literal('b'), flag: v.boolean() }),
+        ]),
+      });
+      const formData = createFormData([
+        ['["value","type"]', 'a'],
+        ['["value","count"]', '3'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        value: { type: 'a', count: 3, flag: false },
+      });
+    });
+
+    test('should support an intersect root schema', () => {
+      const schema = v.intersect([
+        v.object({ name: v.string() }),
+        v.object({ active: v.boolean() }),
+      ]);
+      const formData = createFormData([['["name"]', 'Jane']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        name: 'Jane',
+        active: false,
+      });
+    });
+  });
+
+  describe('wrappers', () => {
+    test('should unwrap every wrapper schema for decoding', () => {
+      const schema = v.object({
+        opt: v.optional(v.number()),
+        nul: v.nullable(v.number()),
+        nsh: v.nullish(v.number()),
+        udf: v.undefinedable(v.number()),
+        exo: v.exactOptional(v.number()),
+        nonOpt: v.nonOptional(v.optional(v.number())),
+        nonNul: v.nonNullable(v.nullable(v.number())),
+        nonNsh: v.nonNullish(v.nullish(v.number())),
+      });
+      const formData = createFormData([
+        ['["opt"]', '1'],
+        ['["nul"]', '2'],
+        ['["nsh"]', '3'],
+        ['["udf"]', '4'],
+        ['["exo"]', '5'],
+        ['["nonOpt"]', '6'],
+        ['["nonNul"]', '7'],
+        ['["nonNsh"]', '8'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        opt: 1,
+        nul: 2,
+        nsh: 3,
+        udf: 4,
+        exo: 5,
+        nonOpt: 6,
+        nonNul: 7,
+        nonNsh: 8,
+      });
+    });
+
+    test('should unwrap wrapped containers', () => {
+      const schema = v.object({
+        user: v.optional(v.object({ name: v.string() })),
+        tags: v.nullable(v.array(v.string())),
+      });
+      const formData = createFormData([
+        ['["user","name"]', 'Jane'],
+        ['["tags"]', 'a'],
+        ['["tags"]', 'b'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        user: { name: 'Jane' },
+        tags: ['a', 'b'],
+      });
+    });
+  });
+
+  describe('lazy schemas', () => {
+    test('should unwrap lazy schemas', () => {
+      const schema = v.object({
+        node: v.lazy(() => v.object({ value: v.number() })),
+      });
+      const formData = createFormData([['["node","value"]', '42']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        node: { value: 42 },
+      });
+    });
+  });
+
+  describe('pipelines', () => {
+    test('should decode values through pipe schemas', () => {
+      const schema = v.object({
+        age: v.pipe(v.number(), v.minValue(0)),
+        nested: v.pipe(
+          v.object({ active: v.boolean() }),
+          v.check(() => true)
+        ),
+        tags: v.pipe(v.array(v.string()), v.minLength(0)),
+      });
+      const formData = createFormData([
+        ['["age"]', '25'],
+        ['["nested","active"]', 'on'],
+        ['["tags"]', 'x'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        age: 25,
+        nested: { active: true },
+        tags: ['x'],
+      });
+    });
+  });
+
+  describe('booleans defaults', () => {
+    test('should default absent booleans to false', () => {
+      const schema = v.object({
+        subscribe: v.boolean(),
+        terms: v.boolean(),
+      });
+      const formData = createFormData([['["subscribe"]', 'on']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        subscribe: true,
+        terms: false,
+      });
+    });
+
+    test('should default booleans inside present nested objects', () => {
+      const schema = v.object({
+        prefs: v.object({ darkMode: v.boolean(), name: v.string() }),
+      });
+      const formData = createFormData([['["prefs","name"]', 'Jane']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        prefs: { darkMode: false, name: 'Jane' },
+      });
+    });
+  });
+
+  describe('extra and unknown fields', () => {
+    test('should build unknown nested fields as objects', () => {
+      const schema = v.object({ known: v.string() });
+      const formData = createFormData([
+        ['["known"]', 'value'],
+        ['["extra","sub"]', 'deep'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        known: 'value',
+        extra: { sub: 'deep' },
+      });
+    });
+
+    test('should decode unknown leaf values as strings', () => {
+      const schema = v.object({ known: v.string() });
+      const formData = createFormData([['["unknown"]', 'raw']]);
+      const result = decodeFormData(schema, formData) as Record<
+        string,
+        unknown
+      >;
+      expect(result).toStrictEqual({ unknown: 'raw' });
+    });
+  });
+
+  describe('prototype pollution', () => {
+    test('should ignore __proto__ keys', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['["__proto__"]', 'polluted'],
+        ['["__proto__","polluted"]', 'true'],
+      ]);
+      const result = decodeFormData(schema, formData);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(result).toStrictEqual({});
+    });
+
+    test('should ignore constructor and prototype keys', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['["constructor","x"]', 'a'],
+        ['["prototype","y"]', 'b'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({});
+    });
+
+    test('should stop at a dangerous key deeper in the path', () => {
+      const schema = v.object({
+        config: v.object({}),
+      });
+      const formData = createFormData([['["config","__proto__","x"]', 'a']]);
+      const result = decodeFormData(schema, formData) as Record<
+        string,
+        unknown
+      >;
+      expect(({} as Record<string, unknown>).x).toBeUndefined();
+      expect(result).toStrictEqual({ config: {} });
+    });
+  });
+
+  describe('invalid keys', () => {
+    test('should ignore keys that are not valid JSON', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['not json{', 'x'],
+        ['["name"]', 'Jane'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ name: 'Jane' });
+    });
+
+    test('should ignore keys that do not parse to an array', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['"name"', 'x'],
+        ['5', 'y'],
+        ['["name"]', 'Jane'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ name: 'Jane' });
+    });
+
+    test('should ignore empty array keys', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['[]', 'x'],
+        ['["name"]', 'Jane'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ name: 'Jane' });
+    });
+
+    test('should ignore keys with non-string or non-number segments', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['[true]', 'x'],
+        ['[null]', 'y'],
+        ['["name"]', 'Jane'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ name: 'Jane' });
+    });
+
+    test('should ignore keys with empty segments', () => {
+      const schema = v.object({ name: v.string() });
+      const formData = createFormData([
+        ['[""]', 'x'],
+        ['["name"]', 'Jane'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ name: 'Jane' });
+    });
+  });
+
+  describe('limits', () => {
+    test('should throw when an array index exceeds the maximum length', () => {
+      const schema = v.object({ flags: v.array(v.boolean()) });
+      const formData = createFormData([['["flags",1000000000]', 'on']]);
+      expect(() => decodeFormData(schema, formData)).toThrowError(
+        'Array exceeds the maximum length of 5000'
+      );
+    });
+  });
+
+  describe('integration', () => {
+    test('should produce values that validate against the schema', () => {
+      const schema = v.object({
+        heading: v.string(),
+        published: v.boolean(),
+        views: v.number(),
+        todos: v.array(
+          v.object({
+            label: v.string(),
+            done: v.boolean(),
+          })
+        ),
+        tags: v.array(v.string()),
+      });
+      const formData = createFormData([
+        ['["heading"]', 'My Post'],
+        ['["published"]', 'on'],
+        ['["views"]', '128'],
+        ['["todos",0,"label"]', 'Write'],
+        ['["todos",0,"done"]', 'on'],
+        ['["todos",1,"label"]', 'Review'],
+        ['["tags"]', 'tech'],
+        ['["tags"]', 'news'],
+      ]);
+      const result = v.safeParse(schema, decodeFormData(schema, formData));
+      expect(result.success).toBe(true);
+      expect(result.output).toStrictEqual({
+        heading: 'My Post',
+        published: true,
+        views: 128,
+        todos: [
+          { label: 'Write', done: true },
+          { label: 'Review', done: false },
+        ],
+        tags: ['tech', 'news'],
+      });
+    });
+  });
+});

--- a/packages/core/src/form/decodeFormData/decodeFormData.test.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.test.ts
@@ -273,6 +273,15 @@ describe('decodeFormData', () => {
         nested: 'hello',
       });
     });
+
+    test('should not crash on a scalar entry before a nested entry', () => {
+      const schema = v.object({ user: v.object({ age: v.number() }) });
+      const formData = createFormData([
+        ['["user"]', 'x'],
+        ['["user","age"]', '1'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({ user: 'x' });
+    });
   });
 
   describe('arrays', () => {
@@ -702,6 +711,14 @@ describe('decodeFormData', () => {
     test('should throw when an array index exceeds the maximum length', () => {
       const schema = v.object({ flags: v.array(v.boolean()) });
       const formData = createFormData([['["flags",1000000000]', 'on']]);
+      expect(() => decodeFormData(schema, formData)).toThrowError(
+        'Array exceeds the maximum length of 5000'
+      );
+    });
+
+    test('should throw for an oversized array index sent as a string', () => {
+      const schema = v.object({ flags: v.array(v.boolean()) });
+      const formData = createFormData([['["flags","1000000000"]', 'on']]);
       expect(() => decodeFormData(schema, formData)).toThrowError(
         'Array exceeds the maximum length of 5000'
       );

--- a/packages/core/src/form/decodeFormData/decodeFormData.test.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.test.ts
@@ -716,12 +716,17 @@ describe('decodeFormData', () => {
       );
     });
 
-    test('should throw for an oversized array index sent as a string', () => {
-      const schema = v.object({ flags: v.array(v.boolean()) });
-      const formData = createFormData([['["flags","1000000000"]', 'on']]);
-      expect(() => decodeFormData(schema, formData)).toThrowError(
-        'Array exceeds the maximum length of 5000'
-      );
+    test('should ignore string properties on arrays', () => {
+      const schema = v.object({ flags: v.array(v.string()) });
+      const formData = createFormData([
+        ['["flags","length"]', '1000000000'], // would inflate via `length`
+        ['["flags","push"]', 'x'], // would clobber the `push` method
+        ['["flags","1000000000"]', 'x'], // numeric index sent as a string
+        ['["flags"]', 'real'], // later append must still work
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        flags: ['real'],
+      });
     });
   });
 

--- a/packages/core/src/form/decodeFormData/decodeFormData.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.ts
@@ -377,12 +377,19 @@ export function decodeFormData<TSchema extends FormSchema>(
           break;
         }
 
-        // Throw on oversized array index, including indices sent as strings
-        // (see MAX_ARRAY_LENGTH)
-        if (Array.isArray(parentValue) && Number(segment) >= MAX_ARRAY_LENGTH) {
-          throw new Error(
-            `Array exceeds the maximum length of ${MAX_ARRAY_LENGTH}`
-          );
+        // Arrays are indexed by numbers; string segments would write properties
+        // like `length` or `push` that inflate or corrupt them
+        if (Array.isArray(parentValue)) {
+          if (typeof segment === 'string') {
+            break;
+          }
+
+          // Throw on oversized array index (see MAX_ARRAY_LENGTH)
+          if (segment >= MAX_ARRAY_LENGTH) {
+            throw new Error(
+              `Array exceeds the maximum length of ${MAX_ARRAY_LENGTH}`
+            );
+          }
         }
 
         // Get child schema for current segment

--- a/packages/core/src/form/decodeFormData/decodeFormData.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.ts
@@ -301,6 +301,13 @@ function fillDefaults(
     }
 
     // Otherwise, if schema has options, complete for each option
+    // Hint: Defaults from every option are applied because the matching branch
+    // of a union or variant is only known during validation, not while
+    // decoding. This is correct for intersect (all options apply) and harmless
+    // for object options (unknown keys are ignored on parse). A `strictObject`
+    // option may reject the extra keys though, so reliably decoding such a
+    // variant would require resolving its branch via the discriminator, which
+    // is not possible before validation.
   } else if (
     unwrappedSchema.type === 'union' ||
     unwrappedSchema.type === 'intersect' ||
@@ -370,8 +377,9 @@ export function decodeFormData<TSchema extends FormSchema>(
           break;
         }
 
-        // Throw on oversized array index (see MAX_ARRAY_LENGTH)
-        if (typeof segment === 'number' && segment >= MAX_ARRAY_LENGTH) {
+        // Throw on oversized array index, including indices sent as strings
+        // (see MAX_ARRAY_LENGTH)
+        if (Array.isArray(parentValue) && Number(segment) >= MAX_ARRAY_LENGTH) {
           throw new Error(
             `Array exceeds the maximum length of ${MAX_ARRAY_LENGTH}`
           );
@@ -406,6 +414,11 @@ export function decodeFormData<TSchema extends FormSchema>(
               schemaType === 'strict_tuple'
                 ? []
                 : {};
+
+            // Otherwise, stop on conflicting scalar value to avoid writing a
+            // property to a non-object, which throws in strict mode
+          } else if (typeof parentValue[segment] !== 'object') {
+            break;
           }
           parentValue = parentValue[segment];
           parentSchema = childSchema;

--- a/packages/core/src/form/decodeFormData/decodeFormData.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.ts
@@ -1,0 +1,421 @@
+import type { FormSchema } from '../../types/index.ts';
+
+// Matches decimal number with optional sign, fraction and exponent (e.g. "42",
+// "-7", "+0.5", ".5", "1.5e3"), rejecting junk like hex or "Infinity"
+// eslint-disable-next-line security/detect-unsafe-regex
+const NUMBER_REGEX = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+
+// Matches timezone-less ISO date and time with optional seconds and fractional
+// seconds (e.g. "2023-06-15T14:30" or "2023-06-15T14:30:45.123"), as emitted by
+// `<input type="datetime-local">`
+const ISO_DATE_TIME_REGEX =
+  // eslint-disable-next-line security/detect-unsafe-regex
+  /^\d{4}-(?:0[1-9]|1[0-2])-(?:[12]\d|0[1-9]|3[01])T(?:0\d|1\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?$/u;
+
+// Hint: Maximum number of items allowed per array field. A numeric path
+// segment is used as an array index, so a single crafted key like
+// `["items",1000000000]` would set the array length to one billion. Creating
+// the sparse array is cheap, but every later pass that walks it by length
+// then runs in O(length), such as `fillDefaults` and the schema validation
+// the caller runs on the result. An array of booleans even writes a value at
+// every index, so a tiny request can exhaust CPU and memory. The limit is a
+// fixed number because a legitimate sparse array (one checked checkbox at a
+// high index, the rest unchecked and absent) is indistinguishable from an
+// attack; only the index magnitude differs. Throwing rather than truncating
+// avoids silently returning wrong data.
+const MAX_ARRAY_LENGTH = 5000;
+
+/**
+ * Internal schema type with the structural properties that are read while
+ * traversing a Valibot schema.
+ */
+interface InternalSchema {
+  readonly type: string;
+  readonly wrapped?: InternalSchema;
+  readonly getter?: (input: undefined) => InternalSchema;
+  readonly entries?: Record<string, InternalSchema>;
+  readonly item?: InternalSchema;
+  readonly items?: InternalSchema[];
+  readonly options?: InternalSchema[];
+}
+
+/**
+ * Unwraps wrapper and lazy schemas until a concrete schema is reached.
+ *
+ * @param schema The schema to unwrap.
+ *
+ * @returns The unwrapped schema.
+ */
+function unwrapSchema(schema: InternalSchema): InternalSchema {
+  switch (schema.type) {
+    case 'exact_optional':
+    case 'nullable':
+    case 'nullish':
+    case 'optional':
+    case 'undefinedable':
+    case 'non_nullable':
+    case 'non_nullish':
+    case 'non_optional':
+      return unwrapSchema(schema.wrapped!);
+    case 'lazy':
+      return unwrapSchema(schema.getter!(undefined));
+    default:
+      return schema;
+  }
+}
+
+/**
+ * Returns the child schema for the given key by traversing objects, arrays,
+ * tuples and schema options. Returns `undefined` if no child schema is found.
+ *
+ * @param schema The parent schema.
+ * @param key The path key.
+ *
+ * @returns The child schema or `undefined`.
+ */
+function getChildSchema(
+  schema: InternalSchema | undefined,
+  key: string | number
+): InternalSchema | undefined {
+  if (schema) {
+    // Unwrap schema before reading its structure
+    const unwrapped = unwrapSchema(schema);
+
+    // If schema is object, return entry schema
+    if (
+      unwrapped.type === 'object' ||
+      unwrapped.type === 'loose_object' ||
+      unwrapped.type === 'strict_object'
+    ) {
+      return unwrapped.entries![key];
+    }
+
+    // If schema is array, return item schema
+    if (unwrapped.type === 'array') {
+      return unwrapped.item;
+    }
+
+    // If schema is tuple, return item schema at index
+    if (
+      unwrapped.type === 'tuple' ||
+      unwrapped.type === 'loose_tuple' ||
+      unwrapped.type === 'strict_tuple'
+    ) {
+      return unwrapped.items![key as number];
+    }
+
+    // If schema has options, return first matching child schema
+    if (
+      unwrapped.type === 'union' ||
+      unwrapped.type === 'intersect' ||
+      unwrapped.type === 'variant'
+    ) {
+      // Hint: The first matching option is used. For a union or variant where
+      // the same key has different types across options, the value is decoded
+      // based on the first option, since the matching branch is only known
+      // during validation.
+      for (const option of unwrapped.options!) {
+        const childSchema = getChildSchema(option, key);
+        if (childSchema !== undefined) {
+          return childSchema;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Decodes a stringified date based on its format. Empty strings become `null`.
+ *
+ * @param value The stringified value.
+ *
+ * @returns The decoded date.
+ */
+function decodeDate(value: string): Date | null | undefined {
+  if (!value || value === 'null') {
+    return null;
+  }
+  if (value === 'undefined') {
+    return undefined;
+  }
+  // Hint: A timezone-less date and time (from `<input type="datetime-local">`)
+  // is interpreted as local time by `new Date`, so it is forced to UTC. Dates,
+  // months and full timestamps are already parsed as UTC.
+  if (ISO_DATE_TIME_REGEX.test(value)) {
+    return new Date(`${value}Z`);
+  }
+  return new Date(value);
+}
+
+/**
+ * Decodes a stringified boolean. Empty strings become `null`.
+ *
+ * @param value The stringified value.
+ *
+ * @returns The decoded boolean.
+ */
+function decodeBoolean(value: string): boolean | null | undefined {
+  if (!value || value === 'null') {
+    return null;
+  }
+  if (value === 'undefined') {
+    return undefined;
+  }
+  return !(value === 'false' || value === 'off' || value === '0');
+}
+
+/**
+ * Decodes a stringified number. Empty strings become `null` and non-numeric
+ * values become `NaN`.
+ *
+ * @param value The stringified value.
+ *
+ * @returns The decoded number.
+ */
+function decodeNumber(value: string): number | null | undefined {
+  if (!value || value === 'null') {
+    return null;
+  }
+  if (value === 'undefined') {
+    return undefined;
+  }
+  if (NUMBER_REGEX.test(value)) {
+    return Number(value);
+  }
+  return NaN;
+}
+
+/**
+ * Decodes a stringified bigint. Empty strings become `null` and invalid values
+ * are returned unchanged.
+ *
+ * @param value The stringified value.
+ *
+ * @returns The decoded bigint.
+ */
+function decodeBigint(value: string): bigint | string | null | undefined {
+  if (!value || value === 'null') {
+    return null;
+  }
+  if (value === 'undefined') {
+    return undefined;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Decodes a single form data value based on the concrete schema type. Files
+ * and unknown types are returned unchanged.
+ *
+ * @param value The form data value.
+ * @param schema The schema of the value.
+ *
+ * @returns The decoded value.
+ */
+function decodeValue(
+  value: FormDataEntryValue,
+  schema: InternalSchema | undefined
+): unknown {
+  // Non-string values (files) and unknown schemas are returned unchanged
+  if (typeof value !== 'string' || !schema) {
+    return value;
+  }
+
+  // Decode value based on concrete schema type
+  switch (unwrapSchema(schema).type) {
+    case 'number':
+      return decodeNumber(value);
+    case 'boolean':
+      return decodeBoolean(value);
+    case 'date':
+      return decodeDate(value);
+    case 'bigint':
+      return decodeBigint(value);
+    default:
+      return value;
+  }
+}
+
+/**
+ * Fills in default values that are lost during the form data transfer. Booleans
+ * of unchecked checkboxes become `false` and absent arrays become empty. Only
+ * containers that are present in the decoded data are completed.
+ *
+ * @param schema The schema of the value.
+ * @param parent The parent object or array holding the value.
+ * @param key The key of the value within its parent.
+ */
+function fillDefaults(
+  schema: InternalSchema,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parent: any,
+  key: string | number
+): void {
+  // Unwrap schema before reading its structure
+  const unwrappedSchema = unwrapSchema(schema);
+
+  // If schema is boolean, default unchecked checkboxes to `false`
+  if (unwrappedSchema.type === 'boolean') {
+    if (parent[key] !== true) {
+      parent[key] = false;
+    }
+
+    // Otherwise, if schema is array, default absent arrays and complete items
+  } else if (unwrappedSchema.type === 'array') {
+    if (Array.isArray(parent[key])) {
+      for (let index = 0; index < parent[key].length; index++) {
+        fillDefaults(unwrappedSchema.item!, parent[key], index);
+      }
+    } else {
+      parent[key] = [];
+    }
+
+    // Otherwise, if schema is tuple, complete present items
+  } else if (
+    unwrappedSchema.type === 'tuple' ||
+    unwrappedSchema.type === 'loose_tuple' ||
+    unwrappedSchema.type === 'strict_tuple'
+  ) {
+    if (Array.isArray(parent[key])) {
+      for (let index = 0; index < unwrappedSchema.items!.length; index++) {
+        if (index < parent[key].length) {
+          fillDefaults(unwrappedSchema.items![index], parent[key], index);
+        }
+      }
+    }
+
+    // Otherwise, if schema is object, complete present entries
+  } else if (
+    unwrappedSchema.type === 'object' ||
+    unwrappedSchema.type === 'loose_object' ||
+    unwrappedSchema.type === 'strict_object'
+  ) {
+    if (parent[key] && typeof parent[key] === 'object') {
+      for (const entryKey in unwrappedSchema.entries) {
+        fillDefaults(unwrappedSchema.entries[entryKey], parent[key], entryKey);
+      }
+    }
+
+    // Otherwise, if schema has options, complete for each option
+  } else if (
+    unwrappedSchema.type === 'union' ||
+    unwrappedSchema.type === 'intersect' ||
+    unwrappedSchema.type === 'variant'
+  ) {
+    for (const option of unwrappedSchema.options!) {
+      fillDefaults(option, parent, key);
+    }
+  }
+}
+
+/**
+ * Decodes the entries of a form data object into nested form values using the
+ * Valibot schema as the source of truth. Information that is lost during the
+ * transfer via HTTP, like numbers, booleans, dates and unchecked checkboxes,
+ * is restored based on the schema.
+ *
+ * The keys of the form data are expected to be the stringified field paths that
+ * Formisch assigns to its field elements (for example `["todos",0,"label"]`).
+ *
+ * @param schema The form schema.
+ * @param formData The form data object.
+ *
+ * @returns The decoded form values.
+ */
+// @__NO_SIDE_EFFECTS__
+export function decodeFormData<TSchema extends FormSchema>(
+  schema: TSchema,
+  formData: FormData
+): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const values: any = {};
+
+  // Build nested values from form data entries
+  formData.forEach((value, key) => {
+    // Convert stringified key back to field path array, ignore invalid JSON
+    let path: unknown = null;
+    try {
+      path = JSON.parse(key);
+    } catch {
+      // Ignore invalid JSON keys
+    }
+
+    // Only process valid, non-empty field paths whose value is not empty
+    // (unselected) file input
+    if (
+      Array.isArray(path) &&
+      path.length > 0 &&
+      (typeof value === 'string' || value.size > 0 || value.name !== '')
+    ) {
+      // Create temporary references for parent value and schema
+      let parentValue = values;
+      let parentSchema: InternalSchema | undefined = schema as InternalSchema;
+
+      // Traverse path segments and build nested structure based on schema
+      for (let index = 0; index < path.length; index++) {
+        const segment = path[index];
+
+        // Skip invalid keys and keys that could pollute object prototype
+        if (
+          (typeof segment !== 'string' && typeof segment !== 'number') ||
+          segment === '' ||
+          segment === '__proto__' ||
+          segment === 'prototype' ||
+          segment === 'constructor'
+        ) {
+          break;
+        }
+
+        // Throw on oversized array index (see MAX_ARRAY_LENGTH)
+        if (typeof segment === 'number' && segment >= MAX_ARRAY_LENGTH) {
+          throw new Error(
+            `Array exceeds the maximum length of ${MAX_ARRAY_LENGTH}`
+          );
+        }
+
+        // Get child schema for current segment
+        const childSchema = getChildSchema(parentSchema, segment);
+
+        // If segment is last one, set or append decoded value
+        if (index === path.length - 1) {
+          const unwrappedSchema = childSchema && unwrapSchema(childSchema);
+
+          // If schema is dynamic array, append decoded item
+          if (unwrappedSchema && unwrappedSchema.type === 'array') {
+            parentValue[segment] ??= [];
+            parentValue[segment].push(decodeValue(value, unwrappedSchema.item));
+
+            // Otherwise, set decoded value
+          } else {
+            parentValue[segment] = decodeValue(value, childSchema);
+          }
+
+          // Otherwise, create next container and continue traversing
+        } else {
+          if (parentValue[segment] == null) {
+            // Create array for array and tuple schemas, object otherwise
+            const schemaType = childSchema && unwrapSchema(childSchema).type;
+            parentValue[segment] =
+              schemaType === 'array' ||
+              schemaType === 'tuple' ||
+              schemaType === 'loose_tuple' ||
+              schemaType === 'strict_tuple'
+                ? []
+                : {};
+          }
+          parentValue = parentValue[segment];
+          parentSchema = childSchema;
+        }
+      }
+    }
+  });
+
+  // Fill in default values that are lost during transfer
+  fillDefaults(schema as InternalSchema, { values }, 'values');
+
+  return values;
+}

--- a/packages/core/src/form/decodeFormData/index.ts
+++ b/packages/core/src/form/decodeFormData/index.ts
@@ -1,0 +1,1 @@
+export * from './decodeFormData.ts';

--- a/packages/core/src/form/index.ts
+++ b/packages/core/src/form/index.ts
@@ -1,3 +1,4 @@
 export * from './createFormStore/index.ts';
+export * from './decodeFormData/index.ts';
 export * from './validateFormInput/index.ts';
 export * from './validateIfRequired/index.ts';

--- a/website/src/components/HeadContent.tsx
+++ b/website/src/components/HeadContent.tsx
@@ -1,9 +1,6 @@
 import { component$, useComputed$ } from '@qwik.dev/core';
 import { useDocumentHead, useLocation } from '@qwik.dev/router';
-import {
-  CHAPTERS_HIDDEN_CLASS,
-  CHAPTERS_KEY,
-} from '~/routes/plugin@chapters';
+import { CHAPTERS_HIDDEN_CLASS, CHAPTERS_KEY } from '~/routes/plugin@chapters';
 import { FRAMEWORK_LIST } from '~/routes/plugin@framework';
 import { THEME_KEY } from '~/routes/plugin@theme';
 import { getAreaName, getFrameworkName } from '~/utils';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `decodeFormData(schema, formData)` to rebuild typed, nested values from `FormData` using the Valibot schema, restoring numbers, booleans, dates, arrays, and guarding against prototype pollution and array property abuse. Exported from `packages/core/src/form/decodeFormData` and re-exported via `packages/core/src/form`.

- New Features
  - Typed decoding by schema: numbers, booleans (unchecked default to false), dates (incl. `datetime-local`), and bigints; files pass through; empty unselected files are skipped.
  - Build nested objects/arrays from JSON path keys like `["todos",0,"label"]`; supports repeated-key arrays, tuples, unions/intersects/variant, wrapper and lazy schemas, and pipelines.
  - Fill defaults only within present containers: absent arrays become `[]`; booleans default to `false`.
  - Safety and limits: ignore invalid JSON keys/segments and dangerous keys (`__proto__`, `prototype`, `constructor`); ignore string properties on arrays (e.g. `"length"`, `"push"`, and numeric indices sent as strings); throw when a numeric array index would exceed 5000 items.
  - Robustness: if a parent path already holds a scalar, later nested entries for that path are ignored to avoid crashes.
  - Comprehensive tests cover decoding behavior, containers, combinators, defaults, limits, edge cases, and integration.

<sup>Written for commit 86b63c378753b0779aeba8d815bea049327f55ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/formisch/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

