### PR TITLE
Fix smaller bugs in core and methods package

### DIFF
--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` so resetting a field that was unmounted and remounted targets its live element for focus and file reset instead of a stale one
+
 ## v0.10.0 (May 24, 2026)
 
 - Change `@formisch/core` to v0.7.0

--- a/frameworks/preact/src/hooks/useField/useField.ts
+++ b/frameworks/preact/src/hooks/useField/useField.ts
@@ -56,10 +56,19 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
 
   useSignalEffect(() => {
     return () => {
-      internalFieldStore.value.elements =
-        internalFieldStore.value.elements.filter(
-          (element) => element.isConnected
-        );
+      const internalFieldStoreValue = internalFieldStore.value;
+      const elements = internalFieldStoreValue.elements.filter(
+        (element) => element.isConnected
+      );
+      // Keep `initialElements` in sync unless a reorder has moved the elements,
+      // so resetting a remounted field restores its live element, not a stale one
+      if (
+        internalFieldStoreValue.elements ===
+        internalFieldStoreValue.initialElements
+      ) {
+        internalFieldStoreValue.initialElements = elements;
+      }
+      internalFieldStoreValue.elements = elements;
     };
   });
 

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` so resetting a field that was unmounted and remounted targets its live element for focus and file reset instead of a stale one
+
 ## v0.11.0 (May 24, 2026)
 
 - Change `@formisch/core` to v0.7.0

--- a/frameworks/qwik/src/hooks/useField/useField.ts
+++ b/frameworks/qwik/src/hooks/useField/useField.ts
@@ -62,10 +62,19 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
   useTask$(({ track, cleanup }) => {
     track(internalFieldStore);
     cleanup(() => {
-      internalFieldStore.value.elements =
-        internalFieldStore.value.elements.filter(
-          (element) => element.isConnected
-        );
+      const internalFieldStoreValue = internalFieldStore.value;
+      const elements = internalFieldStoreValue.elements.filter(
+        (element) => element.isConnected
+      );
+      // Keep `initialElements` in sync unless a reorder has moved the elements,
+      // so resetting a remounted field restores its live element, not a stale one
+      if (
+        internalFieldStoreValue.elements ===
+        internalFieldStoreValue.initialElements
+      ) {
+        internalFieldStoreValue.initialElements = elements;
+      }
+      internalFieldStoreValue.elements = elements;
     });
   });
 

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` so resetting a field that was unmounted and remounted targets its live element for focus and file reset instead of a stale one
+
 ## v0.5.0 (May 24, 2026)
 
 - Change `@formisch/core` to v0.7.0

--- a/frameworks/react/src/hooks/useField/useField.test.tsx
+++ b/frameworks/react/src/hooks/useField/useField.test.tsx
@@ -1,3 +1,4 @@
+import { reset } from '@formisch/methods/react';
 import {
   act,
   fireEvent,
@@ -6,10 +7,11 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import type { ReactElement } from 'react';
+import { type ReactElement, useState } from 'react';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { Form } from '../../components/Form/index.ts';
+import type { FormStore } from '../../types/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -257,6 +259,70 @@ describe('useField', () => {
 
       await waitFor(() => {
         expect(document.activeElement).toBe(input);
+      });
+    });
+
+    test('should focus a remounted field after reset instead of a stale element', async () => {
+      const schema = v.object({
+        email: v.pipe(v.string(), v.nonEmpty('Required')),
+      });
+
+      // The field lives in its own component so unmounting it runs the
+      // adapter cleanup (which reassigns `elements`), the way a real
+      // conditionally rendered field does
+      function EmailField({
+        form,
+      }: {
+        form: FormStore<typeof schema>;
+      }): ReactElement {
+        const field = useField(form, { path: ['email'] });
+        return (
+          <input
+            data-testid="input"
+            {...field.props}
+            value={field.input ?? ''}
+          />
+        );
+      }
+
+      function Test(): ReactElement {
+        const form = useForm({ schema, initialInput: { email: '' } });
+        const [show, setShow] = useState(true);
+        return (
+          <Form of={form} onSubmit={vi.fn()} aria-label="Test">
+            {show && <EmailField form={form} />}
+            <button type="button" onClick={() => setShow((value) => !value)}>
+              toggle
+            </button>
+            <button type="button" onClick={() => reset(form)}>
+              reset
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      render(<Test />);
+
+      // Unmount then remount the field so the adapter cleanup reassigns
+      // `elements` and a stale `initialElements` would diverge
+      act(() => {
+        fireEvent.click(screen.getByText('toggle'));
+      });
+      expect(screen.queryByTestId('input')).toBeNull();
+      act(() => {
+        fireEvent.click(screen.getByText('toggle'));
+      });
+
+      // Reset the form, then submit so validation focuses the first error field
+      act(() => {
+        fireEvent.click(screen.getByText('reset'));
+      });
+      fireEvent.submit(screen.getByRole('form', { name: 'Test' }));
+
+      // Focus must land on the live remounted input, not a detached baseline
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByTestId('input'));
       });
     });
 

--- a/frameworks/react/src/hooks/useField/useField.ts
+++ b/frameworks/react/src/hooks/useField/useField.ts
@@ -54,9 +54,15 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
 
   useEffect(() => {
     return () => {
-      internalFieldStore.elements = internalFieldStore.elements.filter(
+      const elements = internalFieldStore.elements.filter(
         (element) => element.isConnected
       );
+      // Keep `initialElements` in sync unless a reorder has moved the elements,
+      // so resetting a remounted field restores its live element, not a stale one
+      if (internalFieldStore.elements === internalFieldStore.initialElements) {
+        internalFieldStore.initialElements = elements;
+      }
+      internalFieldStore.elements = elements;
     };
   }, [internalFieldStore]);
 

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` so resetting a field that was unmounted and remounted targets its live element for focus and file reset instead of a stale one
+
 ## v0.10.0 (May 24, 2026)
 
 - Change `@formisch/core` to v0.7.0

--- a/frameworks/solid/src/primitives/useField/useField.ts
+++ b/frameworks/solid/src/primitives/useField/useField.ts
@@ -104,9 +104,17 @@ export function useField(
         const internalFieldStore = getInternalFieldStore();
         internalFieldStore.elements.push(element);
         onCleanup(() => {
-          internalFieldStore.elements = internalFieldStore.elements.filter(
+          const elements = internalFieldStore.elements.filter(
             (el) => el !== element
           );
+          // Keep `initialElements` in sync unless a reorder has moved the
+          // elements, so resetting a remounted field restores its live element
+          if (
+            internalFieldStore.elements === internalFieldStore.initialElements
+          ) {
+            internalFieldStore.initialElements = elements;
+          }
+          internalFieldStore.elements = elements;
         });
       },
       onFocus() {

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` so resetting a field that was unmounted and remounted targets its live element for focus and file reset instead of a stale one
+
 ## v0.8.0 (May 24, 2026)
 
 - Change `@formisch/core` to v0.7.0

--- a/frameworks/svelte/src/runes/useField/useField.svelte.ts
+++ b/frameworks/svelte/src/runes/useField/useField.svelte.ts
@@ -90,9 +90,17 @@ export function useField(
       [createAttachmentKey()](element) {
         internalFieldStore.elements.push(element);
         return () => {
-          internalFieldStore.elements = internalFieldStore.elements.filter(
+          const elements = internalFieldStore.elements.filter(
             (el) => el !== element
           );
+          // Keep `initialElements` in sync unless a reorder has moved the
+          // elements, so resetting a remounted field restores its live element
+          if (
+            internalFieldStore.elements === internalFieldStore.initialElements
+          ) {
+            internalFieldStore.initialElements = elements;
+          }
+          internalFieldStore.elements = elements;
         };
       },
       onfocus() {

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` so resetting a field that was unmounted and remounted targets its live element for focus and file reset instead of a stale one
+
 ## v0.8.0 (May 24, 2026)
 
 - Change `@formisch/core` to v0.7.0

--- a/frameworks/vue/src/composables/useField/useField.ts
+++ b/frameworks/vue/src/composables/useField/useField.ts
@@ -57,10 +57,19 @@ export function useField(
   );
 
   onUnmounted(() => {
-    internalFieldStore.value.elements =
-      internalFieldStore.value.elements.filter(
-        (element) => element.isConnected
-      );
+    const internalFieldStoreValue = internalFieldStore.value;
+    const elements = internalFieldStoreValue.elements.filter(
+      (element) => element.isConnected
+    );
+    // Keep `initialElements` in sync unless a reorder has moved the elements,
+    // so resetting a remounted field restores its live element, not a stale one
+    if (
+      internalFieldStoreValue.elements ===
+      internalFieldStoreValue.initialElements
+    ) {
+      internalFieldStoreValue.initialElements = elements;
+    }
+    internalFieldStoreValue.elements = elements;
   });
 
   const input = computed(() => getFieldInput(internalFieldStore.value));

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the library will be documented in this file.
 - Fix `setFieldBool` to set the boolean property on object field stores themselves, not only on their children
 - Fix `setInitialFieldInput` to update the initial input instead of the current input of array and object field stores, so resetting nullish arrays and objects to a new initial input works
 - Fix `resetItemState` to initialize missing array children, so resetting an item whose nested array grew beyond its existing field stores no longer leaves items without a child store
-- Fix `setFieldInput` to reset reused child stores when an array grows after shrinking, so stale state from removed items no longer resurfaces
+- Fix `setFieldInput` to clear stale state from reused child stores when an array grows after shrinking, without losing their dirty baseline so a changed value is still detected as dirty
 - Fix `decodeFormData` to complete missing trailing tuple items, so unchecked checkboxes and absent arrays at the end of tuples are restored
 - Fix `decodeFormData` to preserve a decoded `null` for nullable booleans instead of coercing it to `false`
 - Fix `validateFormInput` to focus the first erroring field whose element can actually receive focus, so the focus is no longer consumed by a field without a focusable element (e.g. unmounted, disabled or hidden)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the library will be documented in this file.
 - Fix `setFieldBool` to set the boolean property on object field stores themselves, not only on their children
 - Fix `setInitialFieldInput` to update the initial input instead of the current input of array and object field stores, so resetting nullish arrays and objects to a new initial input works
 - Fix `resetItemState` to initialize missing array children, so resetting an item whose nested array grew beyond its existing field stores no longer leaves items without a child store
-- Fix `resetItemState` to keep tuple field stores at their fixed length instead of growing them for a longer input, which previously threw
+- Fix `resetItemState`, `setFieldInput` and `setInitialFieldInput` to keep tuple field stores at their fixed length instead of growing them for a longer input, which previously threw
 - Fix `setFieldInput` to clear stale state from reused child stores when an array grows after shrinking, without losing their dirty baseline so a changed value is still detected as dirty
 - Fix `decodeFormData` to complete missing trailing tuple items, so unchecked checkboxes and absent arrays at the end of tuples are restored
 - Fix `decodeFormData` to preserve a decoded `null` for nullable booleans instead of coercing it to `false`

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the library will be documented in this file.
 - Fix `setFieldBool` to set the boolean property on object field stores themselves, not only on their children
 - Fix `setInitialFieldInput` to update the initial input instead of the current input of array and object field stores, so resetting nullish arrays and objects to a new initial input works
 - Fix `resetItemState` to initialize missing array children, so resetting an item whose nested array grew beyond its existing field stores no longer leaves items without a child store
+- Fix `resetItemState` to keep tuple field stores at their fixed length instead of growing them for a longer input, which previously threw
 - Fix `setFieldInput` to clear stale state from reused child stores when an array grows after shrinking, without losing their dirty baseline so a changed value is still detected as dirty
 - Fix `decodeFormData` to complete missing trailing tuple items, so unchecked checkboxes and absent arrays at the end of tuples are restored
 - Fix `decodeFormData` to preserve a decoded `null` for nullable booleans instead of coercing it to `false`

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the library will be documented in this file.
 - Fix `setInitialFieldInput` to update the initial input instead of the current input of array and object field stores, so resetting nullish arrays and objects to a new initial input works
 - Fix `resetItemState` to initialize missing array children, so resetting an item whose nested array grew beyond its existing field stores no longer leaves items without a child store
 - Fix `resetItemState`, `setFieldInput` and `setInitialFieldInput` to keep tuple field stores at their fixed length instead of growing them for a longer input, which previously threw
+- Fix `resetItemState` to keep `initialElements` in sync with `elements` while a field owns its element array, so a later reset restores the field's live element after a replaced or remounted field re-registers
 - Change `ValidArrayPath` to reject fixed-length tuples, so field array methods only accept dynamic array paths
 - Fix `setFieldInput` to clear stale state from reused child stores when an array grows after shrinking, without losing their dirty baseline so a changed value is still detected as dirty
 - Fix `decodeFormData` to complete missing trailing tuple items, so unchecked checkboxes and absent arrays at the end of tuples are restored

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the library will be documented in this file.
 - Fix `setInitialFieldInput` to update the initial input instead of the current input of array and object field stores, so resetting nullish arrays and objects to a new initial input works
 - Fix `resetItemState` to initialize missing array children, so resetting an item whose nested array grew beyond its existing field stores no longer leaves items without a child store
 - Fix `resetItemState`, `setFieldInput` and `setInitialFieldInput` to keep tuple field stores at their fixed length instead of growing them for a longer input, which previously threw
+- Change `ValidArrayPath` to reject fixed-length tuples, so field array methods only accept dynamic array paths
 - Fix `setFieldInput` to clear stale state from reused child stores when an array grows after shrinking, without losing their dirty baseline so a changed value is still detected as dirty
 - Fix `decodeFormData` to complete missing trailing tuple items, so unchecked checkboxes and absent arrays at the end of tuples are restored
 - Fix `decodeFormData` to preserve a decoded `null` for nullable booleans instead of coercing it to `false`

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `focusFieldElement` utility that focuses the first focusable element of a field store
+- Fix `setFieldBool` to set the boolean property on object field stores themselves, not only on their children
+- Fix `setInitialFieldInput` to update the initial input instead of the current input of array and object field stores, so resetting nullish arrays and objects to a new initial input works
+- Fix `resetItemState` to initialize missing array children, so resetting an item whose nested array grew beyond its existing field stores no longer leaves items without a child store
+- Fix `setFieldInput` to reset reused child stores when an array grows after shrinking, so stale state from removed items no longer resurfaces
+- Fix `decodeFormData` to complete missing trailing tuple items, so unchecked checkboxes and absent arrays at the end of tuples are restored
+- Fix `decodeFormData` to preserve a decoded `null` for nullable booleans instead of coercing it to `false`
+- Fix `validateFormInput` to focus the first erroring field whose element can actually receive focus, so the focus is no longer consumed by a field without a focusable element (e.g. unmounted, disabled or hidden)
+- Fix `validateFormInput` to always reset the validating state, even if schema parsing throws
+
 ## v0.7.0 (May 24, 2026)
 
 - Add `FormSchema` type that constrains a form's root schema to object schemas (sync or async) and combinators (`intersect`, `union`, `variant`)

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -152,7 +152,7 @@ describe('resetItemState', () => {
   });
 
   describe('edge cases', () => {
-    test('should skip missing array children gracefully', () => {
+    test('should initialize missing array children', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {
         initialInput: { items: ['a'] },
       });
@@ -164,9 +164,13 @@ describe('resetItemState', () => {
         // Reset with more items than children exist
         resetItemState(itemsStore, ['x', 'y', 'z']);
 
-        // Should handle gracefully - only reset existing children
+        // Should initialize missing children so every item has a field store
         expect(itemsStore.items.value.length).toBe(3);
+        expect(itemsStore.children).toHaveLength(3);
         expect(itemsStore.children[0].input.value).toBe('x');
+        expect(itemsStore.children[1].input.value).toBe('y');
+        expect(itemsStore.children[2].input.value).toBe('z');
+        expect(itemsStore.children[2].name).toBe('["items",2]');
       }
     });
   });

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -151,6 +151,46 @@ describe('resetItemState', () => {
     });
   });
 
+  describe('keepStart', () => {
+    test('should keep start input as the dirty baseline for value fields', () => {
+      const store = createTestStore(v.object({ name: v.string() }), {
+        initialInput: { name: 'John' },
+      });
+
+      const nameStore = store.children.name;
+      nameStore.errors.value = ['Error'];
+
+      resetItemState(nameStore, 'Jane', true);
+
+      // Current input is updated and errors are cleared, but the start input is
+      // preserved so the field is still detected as dirty
+      expect(nameStore.input.value).toBe('Jane');
+      expect(nameStore.startInput.value).toBe('John');
+      expect(nameStore.errors.value).toBe(null);
+    });
+
+    test('should keep start items as the dirty baseline for array fields', () => {
+      const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+        initialInput: { items: ['a', 'b'] },
+      });
+
+      const itemsStore = store.children.items;
+      expect(itemsStore.kind).toBe('array');
+
+      if (itemsStore.kind === 'array') {
+        const startItems = itemsStore.startItems.value;
+
+        resetItemState(itemsStore, ['x', 'y', 'z'], true);
+
+        // Current items grow to the new length while the start items are kept
+        expect(itemsStore.items.value.length).toBe(3);
+        expect(itemsStore.startItems.value).toBe(startItems);
+        expect(itemsStore.children[0].input.value).toBe('x');
+        expect(itemsStore.children[0].startInput.value).toBe('a');
+      }
+    });
+  });
+
   describe('edge cases', () => {
     test('should initialize missing array children', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -173,5 +173,27 @@ describe('resetItemState', () => {
         expect(itemsStore.children[2].name).toBe('["items",2]');
       }
     });
+
+    test('should not grow a tuple beyond its fixed children', () => {
+      const store = createTestStore(
+        v.object({ pair: v.tuple([v.string(), v.number()]) }),
+        { initialInput: { pair: ['a', 1] } }
+      );
+
+      const pairStore = store.children.pair;
+      expect(pairStore.kind).toBe('array');
+
+      if (pairStore.kind === 'array') {
+        // Reset with more items than the tuple defines (tuples have no
+        // `schema.item`, so the extra entry must not be initialized)
+        expect(() => resetItemState(pairStore, ['x', 2, 3])).not.toThrow();
+
+        // The tuple keeps its fixed length, ignoring the extra entry
+        expect(pairStore.items.value).toHaveLength(2);
+        expect(pairStore.children).toHaveLength(2);
+        expect(pairStore.children[0].input.value).toBe('x');
+        expect(pairStore.children[1].input.value).toBe(2);
+      }
+    });
   });
 });

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -191,6 +191,44 @@ describe('resetItemState', () => {
     });
   });
 
+  describe('elements', () => {
+    test('should keep initialElements in sync when the store owns its array', () => {
+      const store = createTestStore(v.object({ name: v.string() }), {
+        initialInput: { name: 'a' },
+      });
+      const field = store.children.name;
+      field.elements.push(document.createElement('input'));
+      // Precondition: the store owns its array (elements === initialElements)
+      expect(field.elements).toBe(field.initialElements);
+
+      resetItemState(field, 'b');
+
+      // Both stay the same (empty) array, so an element registered on remount
+      // is reflected in initialElements for a later reset
+      expect(field.elements).toBe(field.initialElements);
+      expect(field.elements).toHaveLength(0);
+      const element = document.createElement('input');
+      field.elements.push(element);
+      expect(field.initialElements).toContain(element);
+    });
+
+    test('should not touch initialElements when a reorder moved the elements', () => {
+      const store = createTestStore(v.object({ name: v.string() }), {
+        initialInput: { name: 'a' },
+      });
+      const field = store.children.name;
+      const home = field.initialElements;
+      // Simulate a reorder having moved elements (diverged from initialElements)
+      field.elements = [document.createElement('input')];
+      expect(field.elements).not.toBe(field.initialElements);
+
+      resetItemState(field, 'b');
+
+      // The reorder home baseline is preserved
+      expect(field.initialElements).toBe(home);
+    });
+  });
+
   describe('edge cases', () => {
     test('should initialize missing array children', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -1,6 +1,10 @@
 import { initializeFieldStore } from '../../field/initializeFieldStore/index.ts';
 import { batch, createId } from '../../framework/index.ts';
-import type { InternalFieldStore, PathKey } from '../../types/index.ts';
+import type {
+  FieldElement,
+  InternalFieldStore,
+  PathKey,
+} from '../../types/index.ts';
 
 /**
  * Resets the state of a field store (signal values) deeply nested. Sets
@@ -22,8 +26,14 @@ export function resetItemState(
 ): void {
   // Batch all state updates for optimal reactivity performance
   batch(() => {
-    // Clear elements array
-    internalFieldStore.elements = [];
+    // Clear elements array, keeping `initialElements` in sync while the store
+    // still owns it (not moved by a reorder) so a later `reset` restores the
+    // live element once the field remounts
+    const elements: FieldElement[] = [];
+    if (internalFieldStore.elements === internalFieldStore.initialElements) {
+      internalFieldStore.initialElements = elements;
+    }
+    internalFieldStore.elements = elements;
 
     // Clear errors
     internalFieldStore.errors.value = null;

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -11,10 +11,14 @@ import type { InternalFieldStore, PathKey } from '../../types/index.ts';
  *
  * @param internalFieldStore The field store to reset.
  * @param input The new input value (can be any type including array or object).
+ * @param keepStart Whether to keep `startInput` and `startItems` as the dirty
+ * baseline instead of resetting them to the new input. Used when a field store
+ * is reused for an in-place edit so its dirty state is detected correctly.
  */
 export function resetItemState(
   internalFieldStore: InternalFieldStore,
-  input: unknown
+  input: unknown,
+  keepStart = false
 ): void {
   // Batch all state updates for optimal reactivity performance
   batch(() => {
@@ -38,8 +42,10 @@ export function resetItemState(
       // For arrays and objects, input is null/undefined or true (not actual value)
       const objectInput = input == null ? input : true;
 
-      // Set start input
-      internalFieldStore.startInput.value = objectInput;
+      // Set start input unless it is kept as the dirty baseline
+      if (!keepStart) {
+        internalFieldStore.startInput.value = objectInput;
+      }
 
       // Set current input
       internalFieldStore.input.value = objectInput;
@@ -59,8 +65,10 @@ export function resetItemState(
           // Create new items array with unique IDs for each item
           const newItems = Array.from({ length }, createId);
 
-          // Set start items
-          internalFieldStore.startItems.value = newItems;
+          // Set start items unless they are kept as the dirty baseline
+          if (!keepStart) {
+            internalFieldStore.startItems.value = newItems;
+          }
 
           // Set current items
           internalFieldStore.items.value = newItems;
@@ -76,7 +84,8 @@ export function resetItemState(
               resetItemState(
                 internalFieldStore.children[index],
                 // @ts-expect-error
-                input[index]
+                input[index],
+                keepStart
               );
 
               // Otherwise, initialize a new child with the corresponding input
@@ -108,8 +117,10 @@ export function resetItemState(
 
           // Otherwise, clear items arrays
         } else {
-          // Set start items to empty array
-          internalFieldStore.startItems.value = [];
+          // Set start items to empty array unless kept as the dirty baseline
+          if (!keepStart) {
+            internalFieldStore.startItems.value = [];
+          }
 
           // Set current items to empty array
           internalFieldStore.items.value = [];
@@ -123,15 +134,18 @@ export function resetItemState(
           resetItemState(
             internalFieldStore.children[key],
             // @ts-expect-error
-            input?.[key]
+            input?.[key],
+            keepStart
           );
         }
       }
 
       // Otherwise, if field store is value, handle primitive type reset
     } else {
-      // Set start input
-      internalFieldStore.startInput.value = input;
+      // Set start input unless it is kept as the dirty baseline
+      if (!keepStart) {
+        internalFieldStore.startInput.value = input;
+      }
 
       // Set current input
       internalFieldStore.input.value = input;

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -10,11 +10,11 @@ import type { InternalFieldStore, PathKey } from '../../types/index.ts';
  * form reset functionality.
  *
  * @param internalFieldStore The field store to reset.
- * @param initialInput The new input value (can be any type including array or object).
+ * @param input The new input value (can be any type including array or object).
  */
 export function resetItemState(
   internalFieldStore: InternalFieldStore,
-  initialInput: unknown
+  input: unknown
 ): void {
   // Batch all state updates for optimal reactivity performance
   batch(() => {
@@ -36,7 +36,7 @@ export function resetItemState(
       internalFieldStore.kind === 'object'
     ) {
       // For arrays and objects, input is null/undefined or true (not actual value)
-      const objectInput = initialInput == null ? initialInput : true;
+      const objectInput = input == null ? input : true;
 
       // Set start input
       internalFieldStore.startInput.value = objectInput;
@@ -46,11 +46,11 @@ export function resetItemState(
 
       // If field store is array, handle array-specific reset
       if (internalFieldStore.kind === 'array') {
-        // If initial input is provided, create items with IDs
-        if (initialInput) {
+        // If input is provided, create items with IDs
+        if (input) {
           // Create new items array with unique IDs for each item
           // @ts-expect-error
-          const newItems = initialInput.map(createId);
+          const newItems = input.map(createId);
 
           // Set start items
           internalFieldStore.startItems.value = newItems;
@@ -65,7 +65,7 @@ export function resetItemState(
           for (
             let index = 0;
             // @ts-expect-error
-            index < initialInput.length;
+            index < input.length;
             index++
           ) {
             // If child exists at this index, reset its state
@@ -74,7 +74,7 @@ export function resetItemState(
               resetItemState(
                 internalFieldStore.children[index],
                 // @ts-expect-error
-                initialInput[index]
+                input[index]
               );
 
               // Otherwise, initialize a new child with the corresponding input
@@ -95,7 +95,7 @@ export function resetItemState(
                 // @ts-expect-error
                 internalFieldStore.schema.item,
                 // @ts-expect-error
-                initialInput[index],
+                input[index],
                 path
               );
 
@@ -121,7 +121,7 @@ export function resetItemState(
           resetItemState(
             internalFieldStore.children[key],
             // @ts-expect-error
-            initialInput?.[key]
+            input?.[key]
           );
         }
       }
@@ -129,10 +129,10 @@ export function resetItemState(
       // Otherwise, if field store is value, handle primitive type reset
     } else {
       // Set start input
-      internalFieldStore.startInput.value = initialInput;
+      internalFieldStore.startInput.value = input;
 
       // Set current input
-      internalFieldStore.input.value = initialInput;
+      internalFieldStore.input.value = input;
     }
   });
 }

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -48,9 +48,16 @@ export function resetItemState(
       if (internalFieldStore.kind === 'array') {
         // If input is provided, create items with IDs
         if (input) {
+          // Dynamic arrays grow to the input length, while tuples keep their
+          // fixed number of children (their schema has no `item` to initialize
+          // additional ones)
+          const length =
+            internalFieldStore.schema.type === 'array'
+              ? (input as unknown[]).length
+              : internalFieldStore.children.length;
+
           // Create new items array with unique IDs for each item
-          // @ts-expect-error
-          const newItems = input.map(createId);
+          const newItems = Array.from({ length }, createId);
 
           // Set start items
           internalFieldStore.startItems.value = newItems;
@@ -62,12 +69,7 @@ export function resetItemState(
           let path: PathKey[] | undefined;
 
           // Reset state for each array item
-          for (
-            let index = 0;
-            // @ts-expect-error
-            index < input.length;
-            index++
-          ) {
+          for (let index = 0; index < length; index++) {
             // If child exists at this index, reset its state
             if (internalFieldStore.children[index]) {
               // Recursively reset child with corresponding input

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -1,5 +1,6 @@
+import { initializeFieldStore } from '../../field/initializeFieldStore/index.ts';
 import { batch, createId } from '../../framework/index.ts';
-import type { InternalFieldStore } from '../../types/index.ts';
+import type { InternalFieldStore, PathKey } from '../../types/index.ts';
 
 /**
  * Resets the state of a field store (signal values) deeply nested. Sets
@@ -57,6 +58,9 @@ export function resetItemState(
           // Set current items
           internalFieldStore.items.value = newItems;
 
+          // Parse path lazily, only when a missing child must be initialized
+          let path: PathKey[] | undefined;
+
           // Reset state for each array item
           for (
             let index = 0;
@@ -72,6 +76,31 @@ export function resetItemState(
                 // @ts-expect-error
                 initialInput[index]
               );
+
+              // Otherwise, initialize a new child with the corresponding input
+            } else {
+              // Parse path only when needed
+              path ??= JSON.parse(internalFieldStore.name) as PathKey[];
+
+              // Create empty child object
+              // @ts-expect-error
+              internalFieldStore.children[index] = {};
+
+              // Add current index to path
+              path.push(index);
+
+              // Initialize field store for new child
+              initializeFieldStore(
+                internalFieldStore.children[index],
+                // @ts-expect-error
+                internalFieldStore.schema.item,
+                // @ts-expect-error
+                initialInput[index],
+                path
+              );
+
+              // Remove index from path for next iteration
+              path.pop();
             }
           }
 

--- a/packages/core/src/field/focusFieldElement/focusFieldElement.test.ts
+++ b/packages/core/src/field/focusFieldElement/focusFieldElement.test.ts
@@ -70,4 +70,19 @@ describe('focusFieldElement', () => {
     expect(focusFieldElement(store.children.name)).toBe(true);
     expect(document.activeElement).toBe(focusable);
   });
+
+  test('should focus an element inside a shadow root and return true', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const input = document.createElement('input');
+    shadow.appendChild(input);
+    store.children.name.elements = [input];
+
+    // `document.activeElement` retargets to the host, so the focus must be
+    // read back from the element's own shadow root instead
+    expect(focusFieldElement(store.children.name)).toBe(true);
+    expect(shadow.activeElement).toBe(input);
+  });
 });

--- a/packages/core/src/field/focusFieldElement/focusFieldElement.test.ts
+++ b/packages/core/src/field/focusFieldElement/focusFieldElement.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import * as v from 'valibot';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { createTestStore } from '../../vitest/index.ts';
+import { focusFieldElement } from './focusFieldElement.ts';
+
+describe('focusFieldElement', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('should return false and focus nothing for a field without elements', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    store.children.name.elements = [];
+
+    expect(focusFieldElement(store.children.name)).toBe(false);
+  });
+
+  test('should focus a connected element and return true', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    store.children.name.elements = [input];
+
+    expect(focusFieldElement(store.children.name)).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+
+  test('should skip a detached element and return false', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const input = document.createElement('input');
+    store.children.name.elements = [input];
+
+    expect(focusFieldElement(store.children.name)).toBe(false);
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  test('should skip a disabled element and return false', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const input = document.createElement('input');
+    input.disabled = true;
+    document.body.appendChild(input);
+    store.children.name.elements = [input];
+
+    expect(focusFieldElement(store.children.name)).toBe(false);
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  test('should focus the first focusable element when several exist', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const first = document.createElement('input');
+    const second = document.createElement('input');
+    document.body.appendChild(first);
+    document.body.appendChild(second);
+    store.children.name.elements = [first, second];
+
+    expect(focusFieldElement(store.children.name)).toBe(true);
+    expect(document.activeElement).toBe(first);
+  });
+
+  test('should fall through to the next element when the first is not focusable', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const disabled = document.createElement('input');
+    disabled.disabled = true;
+    const focusable = document.createElement('input');
+    document.body.appendChild(disabled);
+    document.body.appendChild(focusable);
+    store.children.name.elements = [disabled, focusable];
+
+    expect(focusFieldElement(store.children.name)).toBe(true);
+    expect(document.activeElement).toBe(focusable);
+  });
+});

--- a/packages/core/src/field/focusFieldElement/focusFieldElement.ts
+++ b/packages/core/src/field/focusFieldElement/focusFieldElement.ts
@@ -4,7 +4,8 @@ import type { InternalFieldStore } from '../../types/index.ts';
  * Focuses the first focusable element of a field store. The elements are tried
  * in order and the first one that actually receives focus wins, so detached,
  * disabled or hidden elements are skipped. The browser decides focusability,
- * which is read back via `document.activeElement`.
+ * which is read back via the element's root `activeElement` so elements in a
+ * shadow root or another document are handled correctly.
  *
  * Hint: A `display: none` or `hidden` element is correctly skipped in real
  * browsers, but jsdom has no layout and focuses it anyway, so that case cannot
@@ -21,7 +22,11 @@ export function focusFieldElement(
   // focus, so the focus is not consumed by an element that cannot be focused
   for (const element of internalFieldStore.elements) {
     element.focus();
-    if (document.activeElement === element) {
+    // Read focus back from the element's own root (shadow root or document)
+    // so elements in a shadow DOM or another document are handled correctly
+    if (
+      (element.getRootNode() as Document | ShadowRoot).activeElement === element
+    ) {
       return true;
     }
   }

--- a/packages/core/src/field/focusFieldElement/focusFieldElement.ts
+++ b/packages/core/src/field/focusFieldElement/focusFieldElement.ts
@@ -1,0 +1,31 @@
+import type { InternalFieldStore } from '../../types/index.ts';
+
+/**
+ * Focuses the first focusable element of a field store. The elements are tried
+ * in order and the first one that actually receives focus wins, so detached,
+ * disabled or hidden elements are skipped. The browser decides focusability,
+ * which is read back via `document.activeElement`.
+ *
+ * Hint: A `display: none` or `hidden` element is correctly skipped in real
+ * browsers, but jsdom has no layout and focuses it anyway, so that case cannot
+ * be covered by unit tests.
+ *
+ * @param internalFieldStore The field store to focus.
+ *
+ * @returns Whether an element was focused.
+ */
+export function focusFieldElement(
+  internalFieldStore: InternalFieldStore
+): boolean {
+  // Try to focus each element and stop at the first that actually receives
+  // focus, so the focus is not consumed by an element that cannot be focused
+  for (const element of internalFieldStore.elements) {
+    element.focus();
+    if (document.activeElement === element) {
+      return true;
+    }
+  }
+
+  // Otherwise, no element could be focused
+  return false;
+}

--- a/packages/core/src/field/focusFieldElement/index.ts
+++ b/packages/core/src/field/focusFieldElement/index.ts
@@ -1,0 +1,1 @@
+export * from './focusFieldElement.ts';

--- a/packages/core/src/field/index.ts
+++ b/packages/core/src/field/index.ts
@@ -1,3 +1,4 @@
+export * from './focusFieldElement/index.ts';
 export * from './getDirtyFieldInput/index.ts';
 export * from './getElementInput/index.ts';
 export * from './getFieldBool/index.ts';

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -129,7 +129,10 @@ export function initializeFieldStore(
     internalFieldStore.schema = schema;
     internalFieldStore.name = JSON.stringify(path);
 
-    // Initialize elements array
+    // Initialize elements array. `initialElements` and `elements` start as the
+    // same array so that `reset` can restore elements that array methods move
+    // between field stores (see `initialElements` in the `InternalBaseStore`
+    // interface).
     const initialElements: FieldElement[] = [];
     internalFieldStore.initialElements = initialElements;
     internalFieldStore.elements = initialElements;

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -129,10 +129,10 @@ export function initializeFieldStore(
     internalFieldStore.schema = schema;
     internalFieldStore.name = JSON.stringify(path);
 
-    // Initialize elements array. `initialElements` and `elements` start as the
-    // same array so that `reset` can restore elements that array methods move
-    // between field stores (see `initialElements` in the `InternalBaseStore`
-    // interface).
+    // Initialize elements array
+    // Hint: `initialElements` and `elements` start as the same array so that
+    // `reset` can restore elements that array methods move between field stores
+    // (see `initialElements` in the `InternalBaseStore` interface).
     const initialElements: FieldElement[] = [];
     internalFieldStore.initialElements = initialElements;
     internalFieldStore.elements = initialElements;

--- a/packages/core/src/field/setFieldBool/setFieldBool.test.ts
+++ b/packages/core/src/field/setFieldBool/setFieldBool.test.ts
@@ -39,13 +39,12 @@ describe('setFieldBool', () => {
       }
     });
 
-    test('should not set property on object itself', () => {
+    test('should set property on object itself', () => {
       const store = createTestStore(
         v.object({ user: v.object({ name: v.string() }) })
       );
       setFieldBool(store.children.user, 'isTouched', true);
-      // Object fields don't have their own isTouched set directly
-      expect(store.children.user.isTouched.value).toBe(false);
+      expect(store.children.user.isTouched.value).toBe(true);
     });
   });
 

--- a/packages/core/src/field/setFieldBool/setFieldBool.ts
+++ b/packages/core/src/field/setFieldBool/setFieldBool.ts
@@ -16,11 +16,11 @@ export function setFieldBool(
 ): void {
   // Batch all state updates for optimal reactivity performance
   batch(() => {
-    // If field store is array, set property on self and children
-    if (internalFieldStore.kind === 'array') {
-      // Set property on current field
-      internalFieldStore[type].value = bool;
+    // Set property on current field
+    internalFieldStore[type].value = bool;
 
+    // If field store is array, set property on children
+    if (internalFieldStore.kind === 'array') {
       // Set property on each array item
       for (
         let index = 0;
@@ -32,16 +32,12 @@ export function setFieldBool(
       }
 
       // Otherwise, if field store is object, set property on children
-    } else if (internalFieldStore.kind == 'object') {
+    } else if (internalFieldStore.kind === 'object') {
       // Set property on each object property
       for (const key in internalFieldStore.children) {
         // Recursively set property on child
         setFieldBool(internalFieldStore.children[key], type, bool);
       }
-
-      // Otherwise, set property on value field
-    } else {
-      internalFieldStore[type].value = bool;
     }
   });
 }

--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -141,6 +141,31 @@ describe('setFieldInput', () => {
     });
   });
 
+  describe('reusing child stores when growing', () => {
+    test('should reset stale child state when array grows after shrinking', () => {
+      const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+        initialInput: { items: ['a', 'b', 'c'] },
+      });
+      const itemsStore = store.children.items;
+      expect(itemsStore.kind).toBe('array');
+      if (itemsStore.kind === 'array') {
+        // Give the third item some state, then shrink the array so its child
+        // store becomes a stale, invisible leftover
+        itemsStore.children[2].errors.value = ['Stale error'];
+        itemsStore.children[2].isDirty.value = true;
+        setFieldInput(store, ['items'], ['a']);
+
+        // Grow back so the stale child store is reused for a new item
+        setFieldInput(store, ['items'], ['a', 'x', 'y']);
+
+        // The reused child must carry the new value with clean state
+        expect(itemsStore.children[2].input.value).toBe('y');
+        expect(itemsStore.children[2].errors.value).toBeNull();
+        expect(itemsStore.children[2].isDirty.value).toBe(false);
+      }
+    });
+  });
+
   describe('dirty state for objects', () => {
     test('should mark object as dirty when input becomes null', () => {
       const store = createTestStore(

--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -109,6 +109,22 @@ describe('setFieldInput', () => {
       setFieldInput(store, ['items'], null);
       expect(store.children.items.input.value).toBeNull();
     });
+
+    test('should keep a tuple at its fixed length when given a longer input', () => {
+      const store = createTestStore(
+        v.object({ pair: v.tuple([v.string(), v.number()]) }),
+        { initialInput: { pair: ['a', 1] } }
+      );
+      const pairStore = store.children.pair;
+      expect(pairStore.kind).toBe('array');
+      if (pairStore.kind === 'array') {
+        // Tuples have no `item` schema, so the extra entry must be ignored
+        expect(() => setFieldInput(store, ['pair'], ['x', 2, 3])).not.toThrow();
+        expect(pairStore.items.value).toHaveLength(2);
+        expect(getFieldInput(pairStore.children[0])).toBe('x');
+        expect(getFieldInput(pairStore.children[1])).toBe(2);
+      }
+    });
   });
 
   describe('dirty state for arrays', () => {

--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -142,27 +142,47 @@ describe('setFieldInput', () => {
   });
 
   describe('reusing child stores when growing', () => {
-    test('should reset stale child state when array grows after shrinking', () => {
+    test('should clear stale errors but keep the dirty baseline when reused', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {
         initialInput: { items: ['a', 'b', 'c'] },
       });
       const itemsStore = store.children.items;
       expect(itemsStore.kind).toBe('array');
       if (itemsStore.kind === 'array') {
-        // Give the third item some state, then shrink the array so its child
+        // Give the third item a stale error, then shrink the array so its child
         // store becomes a stale, invisible leftover
         itemsStore.children[2].errors.value = ['Stale error'];
-        itemsStore.children[2].isDirty.value = true;
         setFieldInput(store, ['items'], ['a']);
 
-        // Grow back so the stale child store is reused for a new item
+        // Grow back so the stale child store is reused for a changed value
         setFieldInput(store, ['items'], ['a', 'x', 'y']);
 
-        // The reused child must carry the new value with clean state
+        // The reused child carries the new value with cleared errors, but stays
+        // dirty because its value ('y') differs from its initial input ('c')
         expect(itemsStore.children[2].input.value).toBe('y');
         expect(itemsStore.children[2].errors.value).toBeNull();
-        expect(itemsStore.children[2].isDirty.value).toBe(false);
+        expect(itemsStore.children[2].isDirty.value).toBe(true);
       }
+    });
+
+    test('should report dirty after shrinking then growing with changed values', () => {
+      const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+        initialInput: { items: ['a', 'b', 'c'] },
+      });
+      setFieldInput(store, ['items'], ['a']); // shrink
+      setFieldInput(store, ['items'], ['a', 'x', 'y']); // grow with changed values
+      // Same final input as a direct edit, so the array must be dirty
+      expect(getFieldBool(store.children.items, 'isDirty')).toBe(true);
+    });
+
+    test('should report clean after shrinking then growing back to initial', () => {
+      const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+        initialInput: { items: ['a', 'b', 'c'] },
+      });
+      setFieldInput(store, ['items'], ['a']); // shrink
+      setFieldInput(store, ['items'], ['a', 'b', 'c']); // grow back to initial
+      // Content matches the initial input again, so the array must be clean
+      expect(getFieldBool(store.children.items, 'isDirty')).toBe(false);
     });
   });
 

--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -125,6 +125,27 @@ describe('setFieldInput', () => {
         expect(getFieldInput(pairStore.children[1])).toBe(2);
       }
     });
+
+    test('should not grow a tuple beyond its children when items were cleared', () => {
+      const store = createTestStore(
+        v.object({ pair: v.tuple([v.string(), v.number()]) }),
+        { initialInput: { pair: ['a', 1] } }
+      );
+      const pairStore = store.children.pair;
+      expect(pairStore.kind).toBe('array');
+      if (pairStore.kind === 'array') {
+        // Simulate a previously cleared tuple (e.g. reset to `null`), then set
+        // a longer-than-fixed input
+        pairStore.items.value = [];
+        setFieldInput(store, ['pair'], ['x', 2, 3]);
+
+        // Items stay capped to the fixed child count, so reads do not throw
+        expect(pairStore.items.value).toHaveLength(2);
+        expect(() => getFieldInput(pairStore)).not.toThrow();
+        expect(getFieldInput(pairStore.children[0])).toBe('x');
+        expect(getFieldInput(pairStore.children[1])).toBe(2);
+      }
+    });
   });
 
   describe('dirty state for arrays', () => {

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -54,14 +54,18 @@ function setNestedInput(
         index < arrayInput.length;
         index++
       ) {
-        // If a stale child store from a previously longer array is reused,
-        // reset its state so it does not keep stale errors, touched, dirty
-        // or nested values
+        // Reset the reused stale child but keep its start input as baseline
+        // Hint: A child store from a previously longer array still holds stale
+        // errors and nested values that must be cleared, but its `startInput`
+        // and `startItems` are the dirty baseline. Passing `keepStart`
+        // preserves them so editing a regrown index is detected as dirty, just
+        // like a direct edit on a never-shrunk array would be.
         if (internalFieldStore.children[index]) {
           resetItemState(
             internalFieldStore.children[index],
             // @ts-expect-error
-            arrayInput[index]
+            arrayInput[index],
+            true
           );
 
           // Otherwise, create and initialize a brand-new child

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -28,32 +28,25 @@ function setNestedInput(
     const arrayInput = input ?? [];
     const items = internalFieldStore.items.value;
 
+    // Tuples have a fixed number of children, so ignore any extra input items
+    // instead of growing them (they have no `item` schema to initialize
+    // additional children, unlike dynamic arrays)
+    const length =
+      internalFieldStore.schema.type === 'array'
+        ? (arrayInput as unknown[]).length
+        : internalFieldStore.children.length;
+
     // If new array is shorter, truncate items
-    if (
-      // @ts-expect-error
-      arrayInput.length < items.length
-    ) {
-      internalFieldStore.items.value = items.slice(
-        0,
-        // @ts-expect-error
-        arrayInput.length
-      );
+    if (length < items.length) {
+      internalFieldStore.items.value = items.slice(0, length);
 
       // Otherwise, if new array is longer, extend items
-    } else if (
-      // @ts-expect-error
-      arrayInput.length > items.length
-    ) {
+    } else if (length > items.length) {
       // Parse path for child initialization
       const path = JSON.parse(internalFieldStore.name) as PathKey[];
 
       // Initialize or reset each newly visible child
-      for (
-        let index = items.length;
-        // @ts-expect-error
-        index < arrayInput.length;
-        index++
-      ) {
+      for (let index = items.length; index < length; index++) {
         // Reset the reused stale child but keep its start input as baseline
         // Hint: A child store from a previously longer array still holds stale
         // errors and nested values that must be cleared, but its `startInput`
@@ -101,12 +94,7 @@ function setNestedInput(
     }
 
     // Set input for each array item
-    for (
-      let index = 0;
-      // @ts-expect-error
-      index < arrayInput.length;
-      index++
-    ) {
+    for (let index = 0; index < length; index++) {
       // Recursively set nested input
       setNestedInput(
         internalFieldStore.children[index],

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -1,3 +1,4 @@
+import { resetItemState } from '../../array/resetItemState/index.ts';
 import { batch, createId, untrack } from '../../framework/index.ts';
 import type {
   InternalFieldStore,
@@ -43,20 +44,28 @@ function setNestedInput(
       // @ts-expect-error
       arrayInput.length > items.length
     ) {
-      // If new items exceed children capacity, initialize new children
-      // @ts-expect-error
-      if (arrayInput.length > internalFieldStore.children.length) {
-        // TODO: Check if we can merge this for loop with the one below
-        // Parse path for child initialization
-        const path = JSON.parse(internalFieldStore.name) as PathKey[];
+      // Parse path for child initialization
+      const path = JSON.parse(internalFieldStore.name) as PathKey[];
 
-        // Initialize missing children
-        for (
-          let index = internalFieldStore.children.length;
-          // @ts-expect-error
-          index < arrayInput.length;
-          index++
-        ) {
+      // Initialize or reset each newly visible child
+      for (
+        let index = items.length;
+        // @ts-expect-error
+        index < arrayInput.length;
+        index++
+      ) {
+        // If a stale child store from a previously longer array is reused,
+        // reset its state so it does not keep stale errors, touched, dirty
+        // or nested values
+        if (internalFieldStore.children[index]) {
+          resetItemState(
+            internalFieldStore.children[index],
+            // @ts-expect-error
+            arrayInput[index]
+          );
+
+          // Otherwise, create and initialize a brand-new child
+        } else {
           // Create empty child object
           // @ts-expect-error
           internalFieldStore.children[index] = {};

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -85,11 +85,11 @@ function setNestedInput(
         }
       }
 
-      // Extend items array with new items
+      // Extend items array with new items, capped to the clamped length so a
+      // tuple never grows beyond its fixed number of children
       internalFieldStore.items.value = [
         ...items,
-        // @ts-expect-error
-        ...arrayInput.slice(items.length).map(createId),
+        ...Array.from({ length: length - items.length }, createId),
       ];
     }
 

--- a/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.test.ts
+++ b/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.test.ts
@@ -88,5 +88,23 @@ describe('setInitialFieldInput', () => {
         expect(itemsStore.children[1].initialInput.value).toBe('y');
       }
     });
+
+    test('should keep a tuple at its fixed length when given a longer input', () => {
+      const store = createTestStore(
+        v.object({ pair: v.tuple([v.string(), v.number()]) }),
+        { initialInput: { pair: ['a', 1] } }
+      );
+      const pairStore = store.children.pair;
+      expect(pairStore.kind).toBe('array');
+      if (pairStore.kind === 'array') {
+        // Tuples have no `item` schema, so the extra entry must be ignored
+        expect(() =>
+          setInitialFieldInput(pairStore, ['x', 2, 3])
+        ).not.toThrow();
+        expect(pairStore.initialItems.value).toHaveLength(2);
+        expect(pairStore.children[0].initialInput.value).toBe('x');
+        expect(pairStore.children[1].initialInput.value).toBe(2);
+      }
+    });
   });
 });

--- a/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.test.ts
+++ b/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.test.ts
@@ -21,17 +21,20 @@ describe('setInitialFieldInput', () => {
       const userStore = store.children.user;
       expect(userStore.kind).toBe('object');
       if (userStore.kind === 'object') {
+        expect(userStore.initialInput.value).toBe(true);
         expect(userStore.children.name.initialInput.value).toBe('John');
       }
     });
 
-    test('should set null input for nullish object', () => {
+    test('should set null initial input for nullish object', () => {
       const store = createTestStore(
         v.object({ user: v.nullish(v.object({ name: v.string() })) }),
         { initialInput: { user: { name: 'John' } } }
       );
       setInitialFieldInput(store.children.user, null);
-      expect(store.children.user.input.value).toBeNull();
+      expect(store.children.user.initialInput.value).toBeNull();
+      // Current input is not affected by setting the initial input
+      expect(store.children.user.input.value).toBe(true);
     });
   });
 
@@ -44,6 +47,7 @@ describe('setInitialFieldInput', () => {
       const itemsStore = store.children.items;
       expect(itemsStore.kind).toBe('array');
       if (itemsStore.kind === 'array') {
+        expect(itemsStore.initialInput.value).toBe(true);
         expect(itemsStore.initialItems.value).toHaveLength(2);
       }
     });
@@ -61,13 +65,15 @@ describe('setInitialFieldInput', () => {
       }
     });
 
-    test('should set null input for nullish array', () => {
+    test('should set null initial input for nullish array', () => {
       const store = createTestStore(
         v.object({ items: v.nullish(v.array(v.string())) }),
         { initialInput: { items: ['a'] } }
       );
       setInitialFieldInput(store.children.items, null);
-      expect(store.children.items.input.value).toBeNull();
+      expect(store.children.items.initialInput.value).toBeNull();
+      // Current input is not affected by setting the initial input
+      expect(store.children.items.input.value).toBe(true);
     });
 
     test('should set initial input on existing children', () => {

--- a/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.ts
+++ b/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.ts
@@ -18,8 +18,8 @@ export function setInitialFieldInput(
   batch(() => {
     // If field store is array, handle array initial input
     if (internalFieldStore.kind === 'array') {
-      // Set array input
-      internalFieldStore.input.value =
+      // Set initial array input
+      internalFieldStore.initialInput.value =
         initialInput == null ? initialInput : true;
 
       // Normalize input to empty array if nullish
@@ -79,8 +79,8 @@ export function setInitialFieldInput(
 
       // Otherwise, if field store is object, handle object initial input
     } else if (internalFieldStore.kind === 'object') {
-      // Set object input
-      internalFieldStore.input.value =
+      // Set initial object input
+      internalFieldStore.initialInput.value =
         initialInput == null ? initialInput : true;
 
       // Set initial input for each object property

--- a/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.ts
+++ b/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.ts
@@ -25,19 +25,23 @@ export function setInitialFieldInput(
       // Normalize input to empty array if nullish
       const initialArrayInput = initialInput ?? [];
 
+      // Tuples have a fixed number of children, so ignore any extra input items
+      // instead of growing them (they have no `item` schema to initialize
+      // additional children, unlike dynamic arrays)
+      const length =
+        internalFieldStore.schema.type === 'array'
+          ? (initialArrayInput as unknown[]).length
+          : internalFieldStore.children.length;
+
       // If initial input exceeds children capacity, initialize new children
-      if (
-        // @ts-expect-error
-        initialArrayInput.length > internalFieldStore.children.length
-      ) {
+      if (length > internalFieldStore.children.length) {
         // Parse path for child initialization
         const path = JSON.parse(internalFieldStore.name) as PathKey[];
 
         // Initialize missing children
         for (
           let index = internalFieldStore.children.length;
-          // @ts-expect-error
-          index < initialArrayInput.length;
+          index < length;
           index++
         ) {
           // Create empty child object
@@ -63,9 +67,7 @@ export function setInitialFieldInput(
       }
 
       // Set initial items with unique IDs
-      internalFieldStore.initialItems.value =
-        // @ts-expect-error
-        initialArrayInput.map(createId);
+      internalFieldStore.initialItems.value = Array.from({ length }, createId);
 
       // Set initial input for each array item
       for (let index = 0; index < internalFieldStore.children.length; index++) {

--- a/packages/core/src/form/decodeFormData/decodeFormData.test.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.test.ts
@@ -100,17 +100,32 @@ describe('decodeFormData', () => {
       });
     });
 
-    test('should resolve "null" and "undefined" booleans to false', () => {
-      // Boolean fields always resolve to true or false (checkbox semantics), so
-      // nullish branches of boolean decoding are overridden by default filling
+    test('should default absent and "undefined" booleans to false', () => {
+      // Unchecked checkboxes are absent from the form data, and the "undefined"
+      // string decodes to `undefined`; both are filled to `false`
       const schema = v.object({ a: v.boolean(), b: v.boolean() });
-      const formData = createFormData([
-        ['["a"]', 'null'],
-        ['["b"]', 'undefined'],
-      ]);
+      const formData = createFormData([['["b"]', 'undefined']]);
       expect(decodeFormData(schema, formData)).toStrictEqual({
         a: false,
         b: false,
+      });
+    });
+
+    test('should preserve decoded null for nullable booleans', () => {
+      // A nullable boolean keeps its decoded `null` (from an empty string or
+      // the "null" string) instead of being coerced to `false` by default
+      // filling
+      const schema = v.object({
+        a: v.nullable(v.boolean()),
+        b: v.nullable(v.boolean()),
+      });
+      const formData = createFormData([
+        ['["a"]', ''],
+        ['["b"]', 'null'],
+      ]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        a: null,
+        b: null,
       });
     });
 
@@ -380,13 +395,23 @@ describe('decodeFormData', () => {
       });
     });
 
-    test('should not complete missing trailing tuple items', () => {
+    test('should complete missing trailing tuple items', () => {
       const schema = v.object({
         entry: v.tuple([v.number(), v.boolean()]),
       });
       const formData = createFormData([['["entry",0]', '5']]);
       expect(decodeFormData(schema, formData)).toStrictEqual({
-        entry: [5],
+        entry: [5, false],
+      });
+    });
+
+    test('should complete absent array at end of tuple', () => {
+      const schema = v.object({
+        entry: v.tuple([v.number(), v.array(v.string())]),
+      });
+      const formData = createFormData([['["entry",0]', '5']]);
+      expect(decodeFormData(schema, formData)).toStrictEqual({
+        entry: [5, []],
       });
     });
 

--- a/packages/core/src/form/decodeFormData/decodeFormData.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.ts
@@ -258,9 +258,11 @@ function fillDefaults(
   // Unwrap schema before reading its structure
   const unwrappedSchema = unwrapSchema(schema);
 
-  // If schema is boolean, default unchecked checkboxes to `false`
+  // If schema is boolean, default absent (unchecked checkbox) values to
+  // `false`. Only `undefined` is treated as absent so that a decoded `null`
+  // (e.g. from a nullable boolean) is preserved instead of coerced to `false`.
   if (unwrappedSchema.type === 'boolean') {
-    if (parent[key] !== true) {
+    if (parent[key] === undefined) {
       parent[key] = false;
     }
 
@@ -274,7 +276,7 @@ function fillDefaults(
       parent[key] = [];
     }
 
-    // Otherwise, if schema is tuple, complete present items
+    // Otherwise, if schema is tuple, complete items of present tuples
   } else if (
     unwrappedSchema.type === 'tuple' ||
     unwrappedSchema.type === 'loose_tuple' ||
@@ -282,9 +284,7 @@ function fillDefaults(
   ) {
     if (Array.isArray(parent[key])) {
       for (let index = 0; index < unwrappedSchema.items!.length; index++) {
-        if (index < parent[key].length) {
-          fillDefaults(unwrappedSchema.items![index], parent[key], index);
-        }
+        fillDefaults(unwrappedSchema.items![index], parent[key], index);
       }
     }
 

--- a/packages/core/src/form/decodeFormData/decodeFormData.ts
+++ b/packages/core/src/form/decodeFormData/decodeFormData.ts
@@ -258,9 +258,9 @@ function fillDefaults(
   // Unwrap schema before reading its structure
   const unwrappedSchema = unwrapSchema(schema);
 
-  // If schema is boolean, default absent (unchecked checkbox) values to
-  // `false`. Only `undefined` is treated as absent so that a decoded `null`
-  // (e.g. from a nullable boolean) is preserved instead of coerced to `false`.
+  // If schema is boolean, default absent (unchecked checkbox) values to `false`
+  // Hint: Only `undefined` is treated as absent so that a decoded `null` (e.g.
+  // from a nullable boolean) is preserved instead of being coerced to `false`.
   if (unwrappedSchema.type === 'boolean') {
     if (parent[key] === undefined) {
       parent[key] = false;

--- a/packages/core/src/form/validateFormInput/validateFormInput.test.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.test.ts
@@ -300,6 +300,27 @@ describe('validateFormInput', () => {
       expect(mockFocus).not.toHaveBeenCalled();
     });
 
+    test('should focus next error field when the first has no element', async () => {
+      const schema = v.object({ name: v.string(), email: v.string() });
+      const store = createTestStore(schema, {
+        initialInput: { name: '', email: '' },
+        issues: [
+          validationIssue('Name is required', [objectPath('name')]),
+          validationIssue('Email is required', [objectPath('email')]),
+        ],
+      });
+
+      // The first erroring field (name) has no registered element, so focus
+      // must fall through to the second erroring field (email)
+      const emailInput = document.createElement('input');
+      const mockFocus = vi.spyOn(emailInput, 'focus');
+      store.children.email.elements = [emailInput];
+
+      await validateFormInput(store, { shouldFocus: true });
+
+      expect(mockFocus).toHaveBeenCalledOnce();
+    });
+
     test('should only focus first field with error', async () => {
       const schema = v.object({ name: v.string(), email: v.string() });
       const store = createTestStore(schema, {
@@ -356,6 +377,18 @@ describe('validateFormInput', () => {
       expect(store.validators).toBe(0);
       await validateFormInput(store);
       expect(store.validators).toBe(0);
+    });
+
+    test('should reset validation state when parse rejects', async () => {
+      const schema = v.object({ name: v.string() });
+      const parse = vi.fn().mockRejectedValue(new Error('Parse failed'));
+      const store = createFormStore({ schema }, parse);
+
+      await expect(validateFormInput(store)).rejects.toThrow('Parse failed');
+
+      // The validators counter and isValidating must not leak on error
+      expect(store.validators).toBe(0);
+      expect(store.isValidating.value).toBe(false);
     });
 
     test('should handle concurrent validations', async () => {

--- a/packages/core/src/form/validateFormInput/validateFormInput.test.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import * as v from 'valibot';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   arrayPath,
   createTestStore,
@@ -249,6 +249,10 @@ describe('validateFormInput', () => {
   });
 
   describe('focus behavior', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
     test('should focus first error field when shouldFocus is true', async () => {
       const schema = v.object({ name: v.string(), email: v.string() });
       const store = createTestStore(schema, {
@@ -260,12 +264,12 @@ describe('validateFormInput', () => {
       });
 
       const inputElement = document.createElement('input');
-      const mockFocus = vi.spyOn(inputElement, 'focus');
+      document.body.appendChild(inputElement);
       store.children.name.elements = [inputElement];
 
       await validateFormInput(store, { shouldFocus: true });
 
-      expect(mockFocus).toHaveBeenCalledOnce();
+      expect(document.activeElement).toBe(inputElement);
     });
 
     test('should not focus when shouldFocus is false', async () => {
@@ -276,6 +280,7 @@ describe('validateFormInput', () => {
       });
 
       const inputElement = document.createElement('input');
+      document.body.appendChild(inputElement);
       const mockFocus = vi.spyOn(inputElement, 'focus');
       store.children.name.elements = [inputElement];
 
@@ -292,6 +297,7 @@ describe('validateFormInput', () => {
       });
 
       const inputElement = document.createElement('input');
+      document.body.appendChild(inputElement);
       const mockFocus = vi.spyOn(inputElement, 'focus');
       store.children.name.elements = [inputElement];
 
@@ -313,12 +319,37 @@ describe('validateFormInput', () => {
       // The first erroring field (name) has no registered element, so focus
       // must fall through to the second erroring field (email)
       const emailInput = document.createElement('input');
-      const mockFocus = vi.spyOn(emailInput, 'focus');
+      document.body.appendChild(emailInput);
       store.children.email.elements = [emailInput];
 
       await validateFormInput(store, { shouldFocus: true });
 
-      expect(mockFocus).toHaveBeenCalledOnce();
+      expect(document.activeElement).toBe(emailInput);
+    });
+
+    test('should skip an erroring field whose element cannot be focused', async () => {
+      const schema = v.object({ name: v.string(), email: v.string() });
+      const store = createTestStore(schema, {
+        initialInput: { name: '', email: '' },
+        issues: [
+          validationIssue('Name is required', [objectPath('name')]),
+          validationIssue('Email is required', [objectPath('email')]),
+        ],
+      });
+
+      // The first erroring field has a disabled (unfocusable) element, so the
+      // focus must fall through to the second erroring field
+      const nameInput = document.createElement('input');
+      nameInput.disabled = true;
+      const emailInput = document.createElement('input');
+      document.body.appendChild(nameInput);
+      document.body.appendChild(emailInput);
+      store.children.name.elements = [nameInput];
+      store.children.email.elements = [emailInput];
+
+      await validateFormInput(store, { shouldFocus: true });
+
+      expect(document.activeElement).toBe(emailInput);
     });
 
     test('should only focus first field with error', async () => {
@@ -333,6 +364,8 @@ describe('validateFormInput', () => {
 
       const nameInput = document.createElement('input');
       const emailInput = document.createElement('input');
+      document.body.appendChild(nameInput);
+      document.body.appendChild(emailInput);
       const mockFocusName = vi.spyOn(nameInput, 'focus');
       const mockFocusEmail = vi.spyOn(emailInput, 'focus');
       store.children.name.elements = [nameInput];
@@ -342,6 +375,7 @@ describe('validateFormInput', () => {
 
       expect(mockFocusName).toHaveBeenCalledOnce();
       expect(mockFocusEmail).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(nameInput);
     });
   });
 

--- a/packages/core/src/form/validateFormInput/validateFormInput.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.ts
@@ -27,99 +27,105 @@ export async function validateFormInput(
   internalFormStore: InternalFormStore,
   config?: ValidateFormInputConfig
 ): Promise<v.SafeParseResult<Schema>> {
-  // Update validation state
-  internalFormStore.validators++;
-  internalFormStore.isValidating.value = true;
+  try {
+    // Update validation state
+    internalFormStore.validators++;
+    internalFormStore.isValidating.value = true;
 
-  // Parse form input with Valibot schema
-  const result = await internalFormStore.parse(
-    untrack(() => getFieldInput(internalFormStore))
-  );
+    // Parse form input with Valibot schema
+    const result = await internalFormStore.parse(
+      untrack(() => getFieldInput(internalFormStore))
+    );
 
-  // Create variables for root and nested errors
-  let rootErrors: [string, ...string[]] | undefined;
-  let nestedErrors:
-    | Record<string, [string, ...string[]] | undefined>
-    | undefined;
+    // Create variables for root and nested errors
+    let rootErrors: [string, ...string[]] | undefined;
+    let nestedErrors:
+      | Record<string, [string, ...string[]] | undefined>
+      | undefined;
 
-  // Process validation issues into error variables
-  if (result.issues) {
-    // Initialize nested errors object
-    nestedErrors = {};
+    // Process validation issues into error variables
+    if (result.issues) {
+      // Initialize nested errors object
+      nestedErrors = {};
 
-    // Process each validation issue
-    for (const issue of result.issues) {
-      // If issue has path, assign to nested errors
-      if (issue.path) {
-        // Initialize path array
-        const path = [];
+      // Process each validation issue
+      for (const issue of result.issues) {
+        // If issue has path, assign to nested errors
+        if (issue.path) {
+          // Initialize path array
+          const path = [];
 
-        // Build path from issue path items
-        for (const pathItem of issue.path) {
-          const key = pathItem.key;
-          const keyType = typeof key;
-          const itemType = pathItem.type;
-          // Skip unsupported path types
-          if (
-            (keyType !== 'string' && keyType !== 'number') ||
-            itemType === 'map' ||
-            itemType === 'set'
-          ) {
-            break;
+          // Build path from issue path items
+          for (const pathItem of issue.path) {
+            const key = pathItem.key;
+            const keyType = typeof key;
+            const itemType = pathItem.type;
+            // Skip unsupported path types
+            if (
+              (keyType !== 'string' && keyType !== 'number') ||
+              itemType === 'map' ||
+              itemType === 'set'
+            ) {
+              break;
+            }
+
+            // Add key to path
+            path.push(key);
           }
 
-          // Add key to path
-          path.push(key);
-        }
+          // Convert path to name of field
+          const name = JSON.stringify(path);
 
-        // Convert path to name of field
-        const name = JSON.stringify(path);
+          // Append or initialize nested errors
+          const fieldErrors = nestedErrors[name];
+          if (fieldErrors) {
+            fieldErrors.push(issue.message);
+          } else {
+            nestedErrors[name] = [issue.message];
+          }
 
-        // Append or initialize nested errors
-        const fieldErrors = nestedErrors[name];
-        if (fieldErrors) {
-          fieldErrors.push(issue.message);
+          // Otherwise, assign to root errors
         } else {
-          nestedErrors[name] = [issue.message];
-        }
-
-        // Otherwise, assign to root errors
-      } else {
-        if (rootErrors) {
-          rootErrors.push(issue.message);
-        } else {
-          rootErrors = [issue.message];
+          if (rootErrors) {
+            rootErrors.push(issue.message);
+          } else {
+            rootErrors = [issue.message];
+          }
         }
       }
     }
-  }
 
-  // Create variable to decide if first error field should be focused
-  let shouldFocus = config?.shouldFocus ?? false;
+    // Create variable to decide if first error field should be focused
+    let shouldFocus = config?.shouldFocus ?? false;
 
-  // Batch all state updates for optimal reactivity performance
-  batch(() => {
-    // Set or reset errors on each field store
-    walkFieldStore(internalFormStore, (internalFieldStore) => {
-      if (internalFieldStore.name === '[]') {
-        internalFieldStore.errors.value = rootErrors ?? null;
-      } else {
-        const fieldErrors = nestedErrors?.[internalFieldStore.name] ?? null;
-        internalFieldStore.errors.value = fieldErrors;
+    // Batch all state updates for optimal reactivity performance
+    batch(() => {
+      // Set or reset errors on each field store
+      walkFieldStore(internalFormStore, (internalFieldStore) => {
+        if (internalFieldStore.name === '[]') {
+          internalFieldStore.errors.value = rootErrors ?? null;
+        } else {
+          const fieldErrors = nestedErrors?.[internalFieldStore.name] ?? null;
+          internalFieldStore.errors.value = fieldErrors;
 
-        // Focus first field with error if configured
-        if (shouldFocus && fieldErrors) {
-          internalFieldStore.elements[0]?.focus();
-          shouldFocus = false;
+          // Focus first field that has an error and a rendered element, so the
+          // focus is not consumed by an erroring field without an element
+          if (shouldFocus && fieldErrors && internalFieldStore.elements[0]) {
+            internalFieldStore.elements[0].focus();
+            shouldFocus = false;
+          }
         }
-      }
+      });
     });
 
-    // Update validation state of form
-    internalFormStore.validators--;
-    internalFormStore.isValidating.value = internalFormStore.validators > 0;
-  });
+    // Return validation result
+    return result;
 
-  // Return validation result
-  return result;
+    // Always reset validation state, even if parsing throws
+  } finally {
+    batch(() => {
+      internalFormStore.validators--;
+      internalFormStore.isValidating.value = internalFormStore.validators > 0;
+    });
+  }
 }

--- a/packages/core/src/form/validateFormInput/validateFormInput.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.ts
@@ -31,11 +31,11 @@ export async function validateFormInput(
   internalFormStore: InternalFormStore,
   config?: ValidateFormInputConfig
 ): Promise<v.SafeParseResult<Schema>> {
-  try {
-    // Update validation state
-    internalFormStore.validators++;
-    internalFormStore.isValidating.value = true;
+  // Update validation state
+  internalFormStore.validators++;
+  internalFormStore.isValidating.value = true;
 
+  try {
     // Parse form input with Valibot schema
     const result = await internalFormStore.parse(
       untrack(() => getFieldInput(internalFormStore))
@@ -102,7 +102,8 @@ export async function validateFormInput(
     // Create variable to decide if first error field should be focused
     let shouldFocus = config?.shouldFocus ?? false;
 
-    // Batch all state updates for optimal reactivity performance
+    // Batch error, focus and validation state updates together so reactive
+    // subscribers observe a single consistent update
     batch(() => {
       // Set or reset errors on each field store
       walkFieldStore(internalFormStore, (internalFieldStore) => {
@@ -124,16 +125,22 @@ export async function validateFormInput(
           }
         }
       });
+
+      // Reset validation state of form
+      internalFormStore.validators--;
+      internalFormStore.isValidating.value = internalFormStore.validators > 0;
     });
 
     // Return validation result
     return result;
 
-    // Always reset validation state, even if parsing throws
-  } finally {
+    // If parsing throws, still reset validation state so form does not stay
+    // stuck in a validating state
+  } catch (error) {
     batch(() => {
       internalFormStore.validators--;
       internalFormStore.isValidating.value = internalFormStore.validators > 0;
     });
+    throw error;
   }
 }

--- a/packages/core/src/form/validateFormInput/validateFormInput.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.ts
@@ -1,5 +1,9 @@
 import type * as v from 'valibot';
-import { getFieldInput, walkFieldStore } from '../../field/index.ts';
+import {
+  focusFieldElement,
+  getFieldInput,
+  walkFieldStore,
+} from '../../field/index.ts';
 import { batch, untrack } from '../../framework/index.ts';
 import type { InternalFormStore, Schema } from '../../types/index.ts';
 
@@ -108,10 +112,14 @@ export async function validateFormInput(
           const fieldErrors = nestedErrors?.[internalFieldStore.name] ?? null;
           internalFieldStore.errors.value = fieldErrors;
 
-          // Focus first field that has an error and a rendered element, so the
-          // focus is not consumed by an erroring field without an element
-          if (shouldFocus && fieldErrors && internalFieldStore.elements[0]) {
-            internalFieldStore.elements[0].focus();
+          // Focus the first erroring field whose element can actually receive
+          // focus, so the focus is not consumed by a field without a focusable
+          // element (e.g. unmounted or hidden)
+          if (
+            shouldFocus &&
+            fieldErrors &&
+            focusFieldElement(internalFieldStore)
+          ) {
             shouldFocus = false;
           }
         }

--- a/packages/core/src/types/field/field.qwik.ts
+++ b/packages/core/src/types/field/field.qwik.ts
@@ -20,6 +20,17 @@ export interface InternalBaseStore {
    */
   schema: NoSerialize<Schema>;
   /**
+   * The initial elements of the field.
+   *
+   * Hint: This may look unused, but do not remove it. `copyItemState` and
+   * `swapItemState` move the `elements` reference between field stores when
+   * array items are inserted, moved, removed or swapped, and `reset` restores
+   * each field's original element via `elements = initialElements`. Without it,
+   * focus and file reset target the wrong element after a reorder followed by a
+   * reset.
+   */
+  initialElements: FieldElement[];
+  /**
    * The elements of the field.
    */
   elements: FieldElement[];
@@ -155,15 +166,6 @@ export interface InternalValueStore extends InternalBaseStore {
    * The input of the value field.
    */
   input: Signal<unknown>;
-
-  /**
-   * The touched state of the field.
-   */
-  isTouched: Signal<boolean>;
-  /**
-   * The dirty state of the field.
-   */
-  isDirty: Signal<boolean>;
 }
 
 /**

--- a/packages/core/src/types/field/field.ts
+++ b/packages/core/src/types/field/field.ts
@@ -27,6 +27,13 @@ export interface InternalBaseStore {
   schema: Schema;
   /**
    * The initial elements of the field.
+   *
+   * Hint: This may look unused, but do not remove it. `copyItemState` and
+   * `swapItemState` move the `elements` reference between field stores when
+   * array items are inserted, moved, removed or swapped, and `reset` restores
+   * each field's original element via `elements = initialElements`. Without it,
+   * focus and file reset target the wrong element after a reorder followed by a
+   * reset.
    */
   initialElements: FieldElement[];
   /**

--- a/packages/core/src/types/path/path.test-d.ts
+++ b/packages/core/src/types/path/path.test-d.ts
@@ -609,6 +609,24 @@ describe('ValidArrayPath', () => {
       >
     >().toEqualTypeOf<['rows', number, 'tags']>();
   });
+
+  test('should reject a fixed tuple as a field array target', () => {
+    expectTypeOf<
+      ValidArrayPath<{ pair: [string, number] }, ['pair']>
+    >().toEqualTypeOf<never>();
+  });
+
+  test('should accept a dynamic array nested inside a tuple', () => {
+    expectTypeOf<
+      ValidArrayPath<{ pair: [string, string[]] }, ['pair', 1]>
+    >().toEqualTypeOf<['pair', 1]>();
+  });
+
+  test('should accept an array reached by indexing into a tuple of objects', () => {
+    expectTypeOf<
+      ValidArrayPath<{ t: [{ tags: string[] }, number] }, ['t', 0, 'tags']>
+    >().toEqualTypeOf<['t', 0, 'tags']>();
+  });
 });
 
 describe('DirtyPath', () => {

--- a/packages/core/src/types/path/path.test-d.ts
+++ b/packages/core/src/types/path/path.test-d.ts
@@ -627,6 +627,18 @@ describe('ValidArrayPath', () => {
       ValidArrayPath<{ t: [{ tags: string[] }, number] }, ['t', 0, 'tags']>
     >().toEqualTypeOf<['t', 0, 'tags']>();
   });
+
+  test('should not suggest a fixed tuple key for an invalid array path', () => {
+    expectTypeOf<
+      ValidArrayPath<{ pair: [string, number] }, ['missing']>
+    >().toEqualTypeOf<never>();
+  });
+
+  test('should suggest only dynamic-array keys for an invalid array path', () => {
+    expectTypeOf<
+      ValidArrayPath<{ pair: [string, number]; tags: string[] }, ['missing']>
+    >().toEqualTypeOf<readonly ['tags']>();
+  });
 });
 
 describe('DirtyPath', () => {

--- a/packages/core/src/types/path/path.ts
+++ b/packages/core/src/types/path/path.ts
@@ -139,7 +139,10 @@ export type PathValue<TValue, TPath extends Path> = TPath extends readonly [
   : TValue;
 
 /**
- * Checks whether a value is an array or contains one anywhere in its shape.
+ * Checks whether a value is a dynamic array or contains one anywhere in its
+ * shape. A fixed-length tuple is not itself a dynamic array, but it counts when
+ * it contains one, so paths can still navigate through tuples to reach nested
+ * arrays.
  *
  * Hint: The inner conditionals (`TValue extends readonly unknown[]` and
  * `TValue extends Record<PropertyKey, unknown>`) distribute over union members,
@@ -154,7 +157,11 @@ type IsOrHasArray<TValue> = true extends (
   IsAny<TValue> extends true
     ? false
     : TValue extends readonly unknown[]
-      ? true
+      ? // A dynamic array counts directly; a tuple only if an element is or
+        // contains a dynamic array
+        number extends TValue['length']
+        ? true
+        : IsOrHasArray<TValue[number]>
       : TValue extends Record<PropertyKey, unknown>
         ? {
             [TKey in keyof TValue]: IsOrHasArray<TValue[TKey]>;

--- a/packages/core/src/types/path/path.ts
+++ b/packages/core/src/types/path/path.ts
@@ -219,7 +219,13 @@ type LazyArrayPath<
   // If path to check is empty, return possible array paths
   TPathToCheck extends readonly []
     ? TValue extends readonly unknown[]
-      ? TValidPath
+      ? // Only accept dynamic arrays; tuples have a fixed arity, so navigate
+        // into their indices instead of accepting the tuple as a field array
+        number extends TValue['length']
+        ? TValidPath
+        : IsNever<ExactKeysOfArrayPath<TValue>> extends false
+          ? readonly [...TValidPath, ExactKeysOfArrayPath<TValue>]
+          : never
       : readonly [...TValidPath, ExactKeysOfArrayPath<TValue>]
     : // If first key of path to check is valid, continue with next key
       TPathToCheck extends readonly [

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the library will be documented in this file.
 
 - Fix `reset` method to apply a new `initialInput` to nullish array and object fields
 - Fix `insert` and `replace` methods to no longer crash when an item's initial input contains a nested array with more items than the existing field stores
-- Fix `setInput` method so growing an array after it was shrunk no longer resurfaces stale state from removed items
+- Fix `setInput` method so growing an array after it was shrunk no longer resurfaces stale state from removed items and still detects changed values as dirty
 - Fix `focus` method to focus the first element that can actually receive focus, skipping detached, disabled or hidden elements
 - Fix `validate` and `handleSubmit` methods to focus the first field with an error and a focusable element, and to reset the validating state if validation throws
 

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `reset` method to apply a new `initialInput` to nullish array and object fields
+- Fix `insert` and `replace` methods to no longer crash when an item's initial input contains a nested array with more items than the existing field stores
+- Fix `setInput` method so growing an array after it was shrunk no longer resurfaces stale state from removed items
+- Fix `focus` method to focus the first element that can actually receive focus, skipping detached, disabled or hidden elements
+- Fix `validate` and `handleSubmit` methods to focus the first field with an error and a focusable element, and to reset the validating state if validation throws
+
 ## v0.8.0 (May 24, 2026)
 
 - Add `pickDirty` method to filter an externally-supplied value down to its dirty parts using the form's dirty mask (issue #21, pull request #98)

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the library will be documented in this file.
 - Fix `reset` method to apply a new `initialInput` to nullish array and object fields
 - Fix `insert` and `replace` methods to no longer crash when an item's initial input contains a nested array with more items than the existing field stores
 - Fix `setInput` method so growing an array after it was shrunk no longer resurfaces stale state from removed items and still detects changed values as dirty
+- Change field array methods to reject fixed-length tuple paths at the type level, since a tuple's fixed arity makes operations like `insert` and `remove` invalid
 - Fix `focus` method to focus the first element that can actually receive focus, skipping detached, disabled or hidden elements
 - Fix `validate` and `handleSubmit` methods to focus the first field with an error and a focusable element, and to reset the validating state if validation throws
 

--- a/packages/methods/src/focus/focus.test.ts
+++ b/packages/methods/src/focus/focus.test.ts
@@ -1,19 +1,23 @@
 // @vitest-environment jsdom
 import * as v from 'valibot';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createTestStore } from '../vitest/index.ts';
 import { focus } from './focus.ts';
 
 describe('focus', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
   test('should focus first element of field', () => {
     const store = createTestStore(v.object({ name: v.string() }));
     const input = document.createElement('input');
-    const focusSpy = vi.spyOn(input, 'focus');
+    document.body.appendChild(input);
     store.children.name.elements = [input];
 
     focus(store, { path: ['name'] });
 
-    expect(focusSpy).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(input);
   });
 
   test('should not throw if field has no elements', () => {
@@ -27,6 +31,8 @@ describe('focus', () => {
     const store = createTestStore(v.object({ name: v.string() }));
     const input1 = document.createElement('input');
     const input2 = document.createElement('input');
+    document.body.appendChild(input1);
+    document.body.appendChild(input2);
     const focusSpy1 = vi.spyOn(input1, 'focus');
     const focusSpy2 = vi.spyOn(input2, 'focus');
     store.children.name.elements = [input1, input2];
@@ -35,6 +41,33 @@ describe('focus', () => {
 
     expect(focusSpy1).toHaveBeenCalledOnce();
     expect(focusSpy2).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(input1);
+  });
+
+  test('should skip a detached element and focus the next one', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const detached = document.createElement('input');
+    const connected = document.createElement('input');
+    document.body.appendChild(connected);
+    store.children.name.elements = [detached, connected];
+
+    focus(store, { path: ['name'] });
+
+    expect(document.activeElement).toBe(connected);
+  });
+
+  test('should skip a disabled element and focus the next one', () => {
+    const store = createTestStore(v.object({ name: v.string() }));
+    const disabled = document.createElement('input');
+    disabled.disabled = true;
+    const focusable = document.createElement('input');
+    document.body.appendChild(disabled);
+    document.body.appendChild(focusable);
+    store.children.name.elements = [disabled, focusable];
+
+    focus(store, { path: ['name'] });
+
+    expect(document.activeElement).toBe(focusable);
   });
 
   test('should focus nested field', () => {
@@ -43,7 +76,7 @@ describe('focus', () => {
       { initialInput: { user: { email: '' } } }
     );
     const input = document.createElement('input');
-    const focusSpy = vi.spyOn(input, 'focus');
+    document.body.appendChild(input);
 
     const userStore = store.children.user;
     expect(userStore.kind).toBe('object');
@@ -53,6 +86,6 @@ describe('focus', () => {
 
     focus(store, { path: ['user', 'email'] });
 
-    expect(focusSpy).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(input);
   });
 });

--- a/packages/methods/src/focus/focus.ts
+++ b/packages/methods/src/focus/focus.ts
@@ -1,5 +1,6 @@
 import {
   type BaseFormStore,
+  focusFieldElement,
   type FormSchema,
   getFieldStore,
   INTERNAL,
@@ -22,7 +23,7 @@ export interface FocusFieldConfig<
 }
 
 /**
- * Focuses the first input element of a field. This is useful for
+ * Focuses the first focusable input element of a field. This is useful for
  * programmatically setting focus to a specific field, such as after
  * validation errors or user interactions.
  *
@@ -36,5 +37,5 @@ export function focus<
   form: BaseFormStore<TSchema>,
   config: FocusFieldConfig<TSchema, TFieldPath>
 ): void {
-  getFieldStore(form[INTERNAL], config.path).elements[0]?.focus();
+  focusFieldElement(getFieldStore(form[INTERNAL], config.path));
 }

--- a/packages/methods/src/insert/insert.test.ts
+++ b/packages/methods/src/insert/insert.test.ts
@@ -79,6 +79,45 @@ describe('insert', () => {
     }
   });
 
+  test('should initialize missing children when inserting item with longer nested array', () => {
+    const store = createTestStore(
+      v.object({ list: v.array(v.object({ tags: v.array(v.string()) })) }),
+      { initialInput: { list: [{ tags: ['a'] }] } }
+    );
+
+    // Insert at occupied index 0 - the reused child's nested tags array grows
+    insert(store, { path: ['list'], at: 0, initialInput: { tags: ['x', 'y'] } });
+
+    const listStore = store.children.list;
+    expect(listStore.kind).toBe('array');
+    if (listStore.kind === 'array') {
+      expect(listStore.items.value).toHaveLength(2);
+
+      const newItemStore = listStore.children[0];
+      expect(newItemStore.kind).toBe('object');
+      if (newItemStore.kind === 'object') {
+        const tagsStore = newItemStore.children.tags;
+        expect(tagsStore.kind).toBe('array');
+        if (tagsStore.kind === 'array') {
+          expect(tagsStore.items.value).toHaveLength(2);
+          expect(tagsStore.children).toHaveLength(2);
+          expect(tagsStore.children[0].input.value).toBe('x');
+          expect(tagsStore.children[1].input.value).toBe('y');
+        }
+      }
+
+      const shiftedItemStore = listStore.children[1];
+      expect(shiftedItemStore.kind).toBe('object');
+      if (shiftedItemStore.kind === 'object') {
+        const tagsStore = shiftedItemStore.children.tags;
+        expect(tagsStore.kind).toBe('array');
+        if (tagsStore.kind === 'array') {
+          expect(tagsStore.children[0].input.value).toBe('a');
+        }
+      }
+    }
+  });
+
   test('should mark array as dirty after insert', () => {
     const store = createTestStore(v.object({ items: v.array(v.string()) }), {
       initialInput: { items: ['a'] },

--- a/packages/methods/src/insert/insert.test.ts
+++ b/packages/methods/src/insert/insert.test.ts
@@ -86,7 +86,11 @@ describe('insert', () => {
     );
 
     // Insert at occupied index 0 - the reused child's nested tags array grows
-    insert(store, { path: ['list'], at: 0, initialInput: { tags: ['x', 'y'] } });
+    insert(store, {
+      path: ['list'],
+      at: 0,
+      initialInput: { tags: ['x', 'y'] },
+    });
 
     const listStore = store.children.list;
     expect(listStore.kind).toBe('array');

--- a/packages/methods/src/replace/replace.test.ts
+++ b/packages/methods/src/replace/replace.test.ts
@@ -59,6 +59,37 @@ describe('replace', () => {
     expect(store.children.items.isDirty.value).toBe(true);
   });
 
+  test('should initialize missing children of nested array item', () => {
+    const store = createTestStore(
+      v.object({ list: v.array(v.object({ tags: v.array(v.string()) })) }),
+      { initialInput: { list: [{ tags: ['a'] }] } }
+    );
+
+    replace(store, {
+      path: ['list'],
+      at: 0,
+      initialInput: { tags: ['x', 'y', 'z'] },
+    });
+
+    const listStore = store.children.list;
+    expect(listStore.kind).toBe('array');
+    if (listStore.kind === 'array') {
+      const itemStore = listStore.children[0];
+      expect(itemStore.kind).toBe('object');
+      if (itemStore.kind === 'object') {
+        const tagsStore = itemStore.children.tags;
+        expect(tagsStore.kind).toBe('array');
+        if (tagsStore.kind === 'array') {
+          expect(tagsStore.items.value).toHaveLength(3);
+          expect(tagsStore.children).toHaveLength(3);
+          expect(tagsStore.children[0].input.value).toBe('x');
+          expect(tagsStore.children[1].input.value).toBe('y');
+          expect(tagsStore.children[2].input.value).toBe('z');
+        }
+      }
+    }
+  });
+
   test('should replace with object item', () => {
     const store = createTestStore(
       v.object({ users: v.array(v.object({ name: v.string() })) }),

--- a/packages/methods/src/reset/reset.test.ts
+++ b/packages/methods/src/reset/reset.test.ts
@@ -298,6 +298,53 @@ describe('reset', () => {
       expect(store.children.name.input.value).toBe('John');
       expect(store.children.name.initialInput.value).toBe('John');
     });
+
+    test('should reset nullish object field to new initial input', () => {
+      const store = createTestStore(
+        v.object({ user: v.nullish(v.object({ name: v.string() })) })
+      );
+
+      reset(store, { path: ['user'], initialInput: { name: 'John' } });
+
+      expect(store.children.user.initialInput.value).toBe(true);
+      expect(store.children.user.input.value).toBe(true);
+      const userStore = store.children.user;
+      expect(userStore.kind).toBe('object');
+      if (userStore.kind === 'object') {
+        expect(userStore.children.name.initialInput.value).toBe('John');
+        expect(userStore.children.name.input.value).toBe('John');
+      }
+    });
+
+    test('should reset nullish object field to undefined initial input', () => {
+      const store = createTestStore(
+        v.object({ user: v.nullish(v.object({ name: v.string() })) }),
+        { initialInput: { user: { name: 'John' } } }
+      );
+
+      reset(store, { path: ['user'], initialInput: undefined });
+
+      expect(store.children.user.initialInput.value).toBeUndefined();
+      expect(store.children.user.input.value).toBeUndefined();
+    });
+
+    test('should reset nullish array field to new initial input', () => {
+      const store = createTestStore(
+        v.object({ items: v.nullish(v.array(v.string())) })
+      );
+
+      reset(store, { path: ['items'], initialInput: ['x', 'y'] });
+
+      expect(store.children.items.initialInput.value).toBe(true);
+      expect(store.children.items.input.value).toBe(true);
+      const itemsStore = store.children.items;
+      expect(itemsStore.kind).toBe('array');
+      if (itemsStore.kind === 'array') {
+        expect(itemsStore.items.value).toHaveLength(2);
+        expect(itemsStore.children[0].input.value).toBe('x');
+        expect(itemsStore.children[1].input.value).toBe('y');
+      }
+    });
   });
 
   describe('file input reset', () => {

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -121,7 +121,10 @@ export function reset(
 
       // Reset state of fields by walking field store
       walkFieldStore(internalFieldStore, (internalFieldStore) => {
-        // Reset elements to initial elements
+        // Restore elements that array methods move between field stores (see
+        // `copyItemState`/`swapItemState`) to their initial position. Do not
+        // remove: without it, focus and file reset target the wrong element
+        // after a reorder followed by a reset.
         internalFieldStore.elements = internalFieldStore.initialElements;
 
         // Reset errors if it is not to be kept

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -121,9 +121,10 @@ export function reset(
 
       // Reset state of fields by walking field store
       walkFieldStore(internalFieldStore, (internalFieldStore) => {
-        // Restore elements that array methods move between field stores (see
-        // `copyItemState`/`swapItemState`) to their initial position. Do not
-        // remove: without it, focus and file reset target the wrong element
+        // Reset elements to initial elements
+        // Hint: `copyItemState` and `swapItemState` move elements between field
+        // stores during array methods, so this restores each field's original
+        // element. Without it, focus and file reset target the wrong element
         // after a reorder followed by a reset.
         internalFieldStore.elements = internalFieldStore.initialElements;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   semver@7: 7.5.2
   serialize-javascript@6: 7.0.5
   seroval@1: 1.4.1
+  shell-quote@1: 1.8.4
   svgo@3: 3.3.3
   tar@4: 7.5.11
   tar@6: 7.5.11
@@ -8620,8 +8621,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@1.29.2:
@@ -17559,7 +17560,7 @@ snapshots:
       picomatch: 4.0.4
       pidtree: 0.6.0
       read-package-json-fast: 4.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       which: 5.0.0
 
   npm-run-path@4.0.1:
@@ -18714,7 +18715,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@1.29.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ overrides:
   'semver@7': '7.5.2'
   'serialize-javascript@6': '7.0.5'
   'seroval@1': '1.4.1'
+  'shell-quote@1': '1.8.4'
   'svgo@3': '3.3.3'
   'tar@4': '7.5.11'
   'tar@6': '7.5.11'


### PR DESCRIPTION
- **Fix setFieldBool function to set property on object itself**
- **Fix setInitialFieldInput to correctly set initial input for arrays and objects**
- **Fix resetItemState to initialize missing array children**
- **Fix booleans in decodeFormData and improve tuple completion**
- **Fix setFieldInput when array grows after shrinking**
- **Fix parameter name in resetItemState function for clarity**
- **Fix focusing error fields and resetting state in validateFormInput**
- **Add focusFieldElement function and related tests for improved focus handling**
- **Add tests to initialize missing children in nested arrays**
- **Documentation initial elements handling in code**
- **Update changelogs to document recent fixes in methods and core functionalities**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes state, decoding, and focus/validation edge cases across `core`, `methods`, and framework `useField` adapters. Adds a focus helper with shadow DOM support and keeps element refs in sync so reset/focus/file inputs target live elements after remounts, reorders, or resets.

- New Features
  - Add `focusFieldElement` and use it in `@formisch/methods` (`focus`, `validate`, `handleSubmit`) to focus the first focusable element (works in shadow roots/portals).

- Bug Fixes
  - Framework `useField`: keep `initialElements` in sync on unmount/remount so `reset`/focus/file reset target the live element, not a stale one.
  - Arrays/objects/tuples: initialize missing children on `reset`/`insert`/`replace`; keep tuples fixed-length (also in `setFieldInput`/`setInitialFieldInput`); when arrays grow after shrinking, reuse children, clear stale state, and keep the dirty baseline; during `reset`, keep `initialElements` in sync with `elements` so a later reset restores a remounted/replaced element; `setInitialFieldInput` updates initial input for arrays/objects and `reset` applies new `initialInput` to nullish fields.
  - Decoding: default booleans only when absent (`undefined`); nullable booleans keep `null`; complete missing trailing tuple items and absent arrays at the end of tuples.
  - Validation/focus: focus the first erroring field that can actually receive focus (skip detached/disabled/hidden); always reset validating state even if parsing throws.
  - Other: `setFieldBool` sets flags on object field stores; `ValidArrayPath` rejects fixed-length tuple paths; internal types track `initialElements`.

<sup>Written for commit cd2f417cee9499f596b975276a6eebf02f7cc778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/formisch/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

