### PR TITLE
Fix resetItemState and initializeFieldStore to maintain non-nullish values

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add `isEdited` field state that is set when a field's value changes, is not set on focus, and stays set after reverting to the initial value
-- Fix `resetItemState` to keep a non-nullish array or object as an empty value instead of `undefined` when its input is omitted (issue #139)
+- Fix `resetItemState` to keep a non-nullish array, object or tuple consistent with its initial state instead of `undefined` when its input is omitted (issue #139)
 
 ## v0.8.0 (June 15, 2026)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add `isEdited` field state that is set when a field's value changes, is not set on focus, and stays set after reverting to the initial value
+- Fix `resetItemState` to keep a non-nullish array or object as an empty value instead of `undefined` when its input is omitted (issue #139)
 
 ## v0.8.0 (June 15, 2026)
 

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -316,6 +316,12 @@ describe('resetItemState', () => {
         expect(pairStore.children).toHaveLength(2);
         expect(pairStore.children[0].input.value).toBeUndefined();
         expect(pairStore.children[1].input.value).toBeUndefined();
+
+        // An explicit null input normalizes to undefined children too, so it
+        // stays consistent with the initial state
+        resetItemState(pairStore, null);
+        expect(pairStore.children[0].input.value).toBeUndefined();
+        expect(pairStore.children[1].input.value).toBeUndefined();
       }
     });
   });

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -118,7 +118,7 @@ describe('resetItemState', () => {
       }
     });
 
-    test('should reset array to empty when input is null', () => {
+    test('should reset non-nullish array to present empty when input is nullish', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {
         initialInput: { items: ['a', 'b'] },
       });
@@ -131,6 +131,26 @@ describe('resetItemState', () => {
 
         expect(itemsStore.items.value).toEqual([]);
         expect(itemsStore.startItems.value).toEqual([]);
+        // A non-nullish array stays a present empty array (`true`) instead of
+        // becoming `null`, matching how `initializeFieldStore` represents it
+        expect(itemsStore.input.value).toBe(true);
+      }
+    });
+
+    test('should reset nullish array to null when input is null', () => {
+      const store = createTestStore(
+        v.object({ items: v.nullish(v.array(v.string())) }),
+        { initialInput: { items: ['a', 'b'] } }
+      );
+
+      const itemsStore = store.children.items;
+      expect(itemsStore.kind).toBe('array');
+
+      if (itemsStore.kind === 'array') {
+        resetItemState(itemsStore, null);
+
+        expect(itemsStore.items.value).toEqual([]);
+        // A nullish array preserves the explicit nullish value
         expect(itemsStore.input.value).toBe(null);
       }
     });

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -295,5 +295,28 @@ describe('resetItemState', () => {
         expect(pairStore.children[1].input.value).toBe(2);
       }
     });
+
+    test('should keep a non-nullish tuple at its fixed length when input is nullish', () => {
+      const store = createTestStore(
+        v.object({ pair: v.tuple([v.string(), v.number()]) }),
+        { initialInput: { pair: ['a', 1] } }
+      );
+
+      const pairStore = store.children.pair;
+      expect(pairStore.kind).toBe('array');
+
+      if (pairStore.kind === 'array') {
+        // Reset without input, e.g. replacing an item that omits the tuple key
+        resetItemState(pairStore, undefined);
+
+        // The tuple stays present with its fixed children reset to undefined,
+        // instead of collapsing to an empty array
+        expect(pairStore.input.value).toBe(true);
+        expect(pairStore.items.value).toHaveLength(2);
+        expect(pairStore.children).toHaveLength(2);
+        expect(pairStore.children[0].input.value).toBeUndefined();
+        expect(pairStore.children[1].input.value).toBeUndefined();
+      }
+    });
   });
 });

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -98,8 +98,9 @@ export function resetItemState(
 
           // Reset state for each array item
           for (let index = 0; index < length; index++) {
-            // A tuple reset without input resets its children to undefined
-            const itemInput = input && (input as unknown[])[index];
+            // A tuple reset without input (or with nullish input) resets each
+            // child to undefined, mirroring `initializeFieldStore`
+            const itemInput = (input as unknown[] | null | undefined)?.[index];
 
             // If child exists at this index, reset its state
             if (internalFieldStore.children[index]) {

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -69,15 +69,18 @@ export function resetItemState(
 
       // If field store is array, handle array-specific reset
       if (internalFieldStore.kind === 'array') {
-        // If input is provided, create items with IDs
-        if (input) {
+        // Tuples have a fixed number of children that the schema cannot
+        // recreate (no `item`), so they keep them even when the input is
+        // nullish, just like `initializeFieldStore`
+        const isTuple = internalFieldStore.schema.type !== 'array';
+
+        // If input is provided or store is a tuple, (re)create items with IDs
+        if (input || isTuple) {
           // Dynamic arrays grow to the input length, while tuples keep their
-          // fixed number of children (their schema has no `item` to initialize
-          // additional ones)
-          const length =
-            internalFieldStore.schema.type === 'array'
-              ? (input as unknown[]).length
-              : internalFieldStore.children.length;
+          // fixed number of children
+          const length = isTuple
+            ? internalFieldStore.children.length
+            : (input as unknown[]).length;
 
           // Create new items array with unique IDs for each item
           const newItems = Array.from({ length }, createId);
@@ -95,13 +98,15 @@ export function resetItemState(
 
           // Reset state for each array item
           for (let index = 0; index < length; index++) {
+            // A tuple reset without input resets its children to undefined
+            const itemInput = input && (input as unknown[])[index];
+
             // If child exists at this index, reset its state
             if (internalFieldStore.children[index]) {
               // Recursively reset child with corresponding input
               resetItemState(
                 internalFieldStore.children[index],
-                // @ts-expect-error
-                input[index],
+                itemInput,
                 keepStart
               );
 
@@ -122,8 +127,7 @@ export function resetItemState(
                 internalFieldStore.children[index],
                 // @ts-expect-error
                 internalFieldStore.schema.item,
-                // @ts-expect-error
-                input[index],
+                itemInput,
                 path
               );
 

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -52,8 +52,12 @@ export function resetItemState(
       internalFieldStore.kind === 'array' ||
       internalFieldStore.kind === 'object'
     ) {
-      // For arrays and objects, input is null/undefined or true (not actual value)
-      const objectInput = input == null ? input : true;
+      // For arrays and objects, input is null/undefined or true (not actual
+      // value). Mirror `initializeFieldStore` so a missing input on a
+      // non-nullish array or object becomes a present empty container (`true`)
+      // instead of `undefined`, keeping reset consistent with the initial state.
+      const objectInput =
+        internalFieldStore.isNullish && input == null ? input : true;
 
       // Set start input unless it is kept as the dirty baseline
       if (!keepStart) {

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -113,6 +113,10 @@ export function initializeFieldStore(
     schema.type === 'variant'
   ) {
     // Initialize field store for each schema option
+    // Hint: Options share a single field store per key, so per-branch metadata
+    // (`schema`, `kind`, `isNullish`) is approximated last-write-wins. A key
+    // that differs across branches (e.g. nullish in one, required in another)
+    // is therefore not fully represented. See #95 for the long-term fix.
     for (const schemaOption of schema.options) {
       initializeFieldStore(
         internalFieldStore,

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -222,6 +222,9 @@ export function initializeFieldStore(
           }
         }
 
+        // Store whether array is nullish so resetting can stay consistent
+        internalFieldStore.isNullish = nullish;
+
         // Set array input (nullish or true)
         const arrayInput =
           nullish && initialInput == null ? initialInput : true;
@@ -278,6 +281,9 @@ export function initializeFieldStore(
           // Remove key from path for next iteration
           path.pop();
         }
+
+        // Store whether object is nullish so resetting can stay consistent
+        internalFieldStore.isNullish = nullish;
 
         // Set object input (nullish or true)
         const objectInput =

--- a/packages/core/src/types/field/field.qwik.ts
+++ b/packages/core/src/types/field/field.qwik.ts
@@ -66,6 +66,14 @@ export interface InternalArrayStore extends InternalBaseStore {
    */
   kind: 'array';
   /**
+   * Whether the array schema is wrapped in a nullish schema.
+   *
+   * Hint: This indicates whether a missing input should be represented as the
+   * nullish value (`null`/`undefined`) or as a present but empty array
+   * (`true`). It keeps resetting consistent with the initial state.
+   */
+  isNullish: boolean;
+  /**
    * The children of the array field.
    */
   children: InternalFieldStore[];
@@ -120,6 +128,14 @@ export interface InternalObjectStore extends InternalBaseStore {
    * The kind of field store.
    */
   kind: 'object';
+  /**
+   * Whether the object schema is wrapped in a nullish schema.
+   *
+   * Hint: This indicates whether a missing input should be represented as the
+   * nullish value (`null`/`undefined`) or as a present but empty object
+   * (`true`). It keeps resetting consistent with the initial state.
+   */
+  isNullish: boolean;
   /**
    * The children of the object field.
    */

--- a/packages/core/src/types/field/field.ts
+++ b/packages/core/src/types/field/field.ts
@@ -72,6 +72,14 @@ export interface InternalArrayStore extends InternalBaseStore {
    */
   kind: 'array';
   /**
+   * Whether the array schema is wrapped in a nullish schema.
+   *
+   * Hint: This indicates whether a missing input should be represented as the
+   * nullish value (`null`/`undefined`) or as a present but empty array
+   * (`true`). It keeps resetting consistent with the initial state.
+   */
+  isNullish: boolean;
+  /**
    * The children of the array field.
    */
   children: InternalFieldStore[];
@@ -126,6 +134,14 @@ export interface InternalObjectStore extends InternalBaseStore {
    * The kind of field store.
    */
   kind: 'object';
+  /**
+   * Whether the object schema is wrapped in a nullish schema.
+   *
+   * Hint: This indicates whether a missing input should be represented as the
+   * nullish value (`null`/`undefined`) or as a present but empty object
+   * (`true`). It keeps resetting consistent with the initial state.
+   */
+  isNullish: boolean;
   /**
    * The children of the object field.
    */

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to the library will be documented in this file.
 
 ## vX.X.X (Month DD, YYYY)
 
+- Change `@formisch/core` to vX.X.X
 - Add `keepEdited` config option to the `reset` method to keep the edited state of fields
 - Change `insert`, `move`, `remove`, `replace` and `swap` methods to set the edited state of the field array
+- Fix `replace` and `insert` to keep a non-nullish array, object or tuple consistent with the initial form state instead of `undefined` when its key is omitted (issue #139)
 
 ## v0.9.0 (June 15, 2026)
 

--- a/packages/methods/src/replace/replace.test.ts
+++ b/packages/methods/src/replace/replace.test.ts
@@ -180,4 +180,21 @@ describe('replace', () => {
       a: [{ type: 'array', string: undefined, array: [] }],
     });
   });
+
+  test('should keep a nested tuple at its fixed length when its key is omitted', () => {
+    const store = createTestStore(
+      v.object({
+        a: v.array(v.object({ pair: v.tuple([v.string(), v.number()]) })),
+      }),
+      { initialInput: { a: [{ pair: ['x', 1] }] } }
+    );
+
+    replace(store, { path: ['a'], at: 0, initialInput: {} });
+
+    // An omitted non-nullish tuple keeps its fixed positions (reset to
+    // `undefined`) instead of collapsing to an empty array
+    expect(getFieldInput(store)).toStrictEqual({
+      a: [{ pair: [undefined, undefined] }],
+    });
+  });
 });

--- a/packages/methods/src/replace/replace.test.ts
+++ b/packages/methods/src/replace/replace.test.ts
@@ -1,3 +1,4 @@
+import { getFieldInput } from '@formisch/core';
 import * as v from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { createTestStore } from '../vitest/index.ts';
@@ -131,5 +132,52 @@ describe('replace', () => {
     if (itemsStore.kind === 'array') {
       expect(itemsStore.children).toHaveLength(3);
     }
+  });
+
+  test('should keep nested array present and empty when its key is omitted', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ nested: v.array(v.string()) })) }),
+      { initialInput: { items: [{ nested: ['a'] }] } }
+    );
+
+    replace(store, { path: ['items'], at: 0, initialInput: {} });
+
+    // The omitted nested array must stay a present empty array, consistent with
+    // how a fresh form initialized without the key behaves (not `undefined`)
+    expect(getFieldInput(store)).toStrictEqual({ items: [{ nested: [] }] });
+  });
+
+  test('should fully switch variant items including nested arrays (#139)', () => {
+    const store = createTestStore(
+      v.object({
+        a: v.array(
+          v.variant('type', [
+            v.object({ type: v.literal('string'), string: v.string() }),
+            v.object({ type: v.literal('array'), array: v.array(v.string()) }),
+          ])
+        ),
+      }),
+      { initialInput: { a: [{ type: 'string', string: 'foo' }] } }
+    );
+
+    // Switch to the "array" variant with a full value
+    replace(store, {
+      path: ['a'],
+      at: 0,
+      initialInput: { type: 'array', array: ['foo', 'bar'] },
+    });
+    expect(getFieldInput(store)).toStrictEqual({
+      a: [{ type: 'array', string: undefined, array: ['foo', 'bar'] }],
+    });
+
+    // Switch to the "array" variant but omit the array key -> stays `[]`
+    replace(store, {
+      path: ['a'],
+      at: 0,
+      initialInput: { type: 'array' },
+    });
+    expect(getFieldInput(store)).toStrictEqual({
+      a: [{ type: 'array', string: undefined, array: [] }],
+    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes how arrays, objects, and tuples are reset and initialized in `@formisch/core` so non-nullish schemas keep a present empty container when a key is omitted or input is nullish, matching the initial state. Resolves nested, tuple, and variant edge cases and aligns resets with initialization (issue #139).

- **Bug Fixes**
  - Mirror initialization across `initializeFieldStore` and `resetItemState`: record `isNullish` on array/object stores; for non-nullish arrays/objects set input to `true` when omitted or nullish; keep tuples present at fixed length with children set to `undefined`; preserve `null`/`undefined` for nullish schemas.
  - In `@formisch/methods`, ensure `replace` (and `insert`) keep empty containers for non-nullish arrays/objects/tuples when keys are omitted; add tests for nested arrays, variant switches, and tuples.

<sup>Written for commit b5af23a39701e039f9f99d738207e9df468ebfe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/formisch/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

