### PR TITLE
Add isEdited state to field and form stores

### DIFF
--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` property to the field, field array and form stores
+
 ## v0.11.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/frameworks/preact/src/hooks/useField/useField.test.tsx
+++ b/frameworks/preact/src/hooks/useField/useField.test.tsx
@@ -27,6 +27,7 @@ describe('useField', () => {
       expect(field.errors.value).toBe(null);
       expect(field.isTouched.value).toBe(false);
       expect(field.isDirty.value).toBe(false);
+      expect(field.isEdited.value).toBe(false);
       expect(field.isValid.value).toBe(true);
       expect(field.props.name).toBe('["name"]');
       expect(field.props.autofocus).toBe(false);
@@ -248,6 +249,112 @@ describe('useField', () => {
 
       await waitFor(() => {
         expect(valid).toHaveTextContent('false');
+      });
+    });
+  });
+
+  describe('edited state', () => {
+    test('should not set isEdited on focus but should set isTouched', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({ schema: v.object({ name: v.string() }) });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input.value ?? ''}
+            />
+            <span data-testid="touched">{String(field.isTouched.value)}</span>
+            <span data-testid="edited">{String(field.isEdited.value)}</span>
+          </div>
+        );
+      }
+
+      render(<Test />);
+
+      const touched = screen.getByTestId('touched');
+      const edited = screen.getByTestId('edited');
+      expect(touched).toHaveTextContent('false');
+      expect(edited).toHaveTextContent('false');
+
+      fireEvent.focus(screen.getByTestId('input'));
+
+      await waitFor(() => {
+        expect(touched).toHaveTextContent('true');
+        expect(edited).toHaveTextContent('false');
+      });
+    });
+
+    test('should set isEdited on input', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({ schema: v.object({ name: v.string() }) });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input.value ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited.value)}</span>
+          </div>
+        );
+      }
+
+      render(<Test />);
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      expect(edited).toHaveTextContent('false');
+
+      fireEvent.input(input, { target: { value: 'changed' } });
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+      });
+    });
+
+    test('should keep isEdited after reverting the value to its initial value', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: 'initial' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input.value ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited.value)}</span>
+            <span data-testid="dirty">{String(field.isDirty.value)}</span>
+          </div>
+        );
+      }
+
+      render(<Test />);
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      const dirty = screen.getByTestId('dirty');
+      expect(edited).toHaveTextContent('false');
+      expect(dirty).toHaveTextContent('false');
+
+      fireEvent.input(input, { target: { value: 'changed' } });
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+        expect(dirty).toHaveTextContent('true');
+      });
+
+      fireEvent.input(input, { target: { value: 'initial' } });
+
+      await waitFor(() => {
+        expect(dirty).toHaveTextContent('false');
+        expect(edited).toHaveTextContent('true');
       });
     });
   });

--- a/frameworks/preact/src/hooks/useField/useField.ts
+++ b/frameworks/preact/src/hooks/useField/useField.ts
@@ -80,6 +80,9 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
       isTouched: computed(() =>
         getFieldBool(internalFieldStore.value, 'isTouched')
       ),
+      isEdited: computed(() =>
+        getFieldBool(internalFieldStore.value, 'isEdited')
+      ),
       isDirty: computed(() =>
         getFieldBool(internalFieldStore.value, 'isDirty')
       ),

--- a/frameworks/preact/src/hooks/useFieldArray/useFieldArray.ts
+++ b/frameworks/preact/src/hooks/useFieldArray/useFieldArray.ts
@@ -60,6 +60,9 @@ export function useFieldArray(
       isTouched: computed(() =>
         getFieldBool(internalFieldStore.value, 'isTouched')
       ),
+      isEdited: computed(() =>
+        getFieldBool(internalFieldStore.value, 'isEdited')
+      ),
       isDirty: computed(() =>
         getFieldBool(internalFieldStore.value, 'isDirty')
       ),

--- a/frameworks/preact/src/hooks/useForm/useForm.ts
+++ b/frameworks/preact/src/hooks/useForm/useForm.ts
@@ -35,6 +35,7 @@ export function useForm(config: FormConfig): FormStore {
       isSubmitted: internalFormStore.isSubmitted,
       isValidating: internalFormStore.isValidating,
       isTouched: computed(() => getFieldBool(internalFormStore, 'isTouched')),
+      isEdited: computed(() => getFieldBool(internalFormStore, 'isEdited')),
       isDirty: computed(() => getFieldBool(internalFormStore, 'isDirty')),
       isValid: computed(() => !getFieldBool(internalFormStore, 'errors')),
       errors: internalFormStore.errors,

--- a/frameworks/preact/src/types/field.ts
+++ b/frameworks/preact/src/types/field.ts
@@ -75,6 +75,10 @@ export interface FieldStore<
    */
   readonly isTouched: ReadonlySignal<boolean>;
   /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: ReadonlySignal<boolean>;
+  /**
    * Whether the field input differs from its initial value.
    */
   readonly isDirty: ReadonlySignal<boolean>;
@@ -119,6 +123,10 @@ export interface FieldArrayStore<
    * Whether the field array has been touched.
    */
   readonly isTouched: ReadonlySignal<boolean>;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: ReadonlySignal<boolean>;
   /**
    * Whether the field array input differs from its initial value.
    */

--- a/frameworks/preact/src/types/form.ts
+++ b/frameworks/preact/src/types/form.ts
@@ -23,6 +23,10 @@ export interface FormStore<TSchema extends FormSchema = FormSchema>
    */
   readonly isTouched: ReadonlySignal<boolean>;
   /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: ReadonlySignal<boolean>;
+  /**
    * Whether any field in the form differs from its initial value.
    */
   readonly isDirty: ReadonlySignal<boolean>;

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` property to the field, field array and form stores
+
 ## v0.12.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/frameworks/qwik/src/hooks/useField/useField.ts
+++ b/frameworks/qwik/src/hooks/useField/useField.ts
@@ -85,6 +85,9 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
     isTouched: createComputed$(() =>
       getFieldBool(internalFieldStore.value, 'isTouched')
     ),
+    isEdited: createComputed$(() =>
+      getFieldBool(internalFieldStore.value, 'isEdited')
+    ),
     isDirty: createComputed$(() =>
       getFieldBool(internalFieldStore.value, 'isDirty')
     ),

--- a/frameworks/qwik/src/hooks/useFieldArray/useFieldArray.ts
+++ b/frameworks/qwik/src/hooks/useFieldArray/useFieldArray.ts
@@ -59,6 +59,9 @@ export function useFieldArray(
     isTouched: createComputed$(() =>
       getFieldBool(internalFieldStore.value, 'isTouched')
     ),
+    isEdited: createComputed$(() =>
+      getFieldBool(internalFieldStore.value, 'isEdited')
+    ),
     isDirty: createComputed$(() =>
       getFieldBool(internalFieldStore.value, 'isDirty')
     ),

--- a/frameworks/qwik/src/hooks/useForm$/useForm$.ts
+++ b/frameworks/qwik/src/hooks/useForm$/useForm$.ts
@@ -53,6 +53,9 @@ export function useFormQrl(configQrl: QRL<() => FormConfig>): FormStore {
       isTouched: createComputed$(() =>
         getFieldBool(internalFormStore, 'isTouched')
       ),
+      isEdited: createComputed$(() =>
+        getFieldBool(internalFormStore, 'isEdited')
+      ),
       isDirty: createComputed$(() =>
         getFieldBool(internalFormStore, 'isDirty')
       ),

--- a/frameworks/qwik/src/types/field.ts
+++ b/frameworks/qwik/src/types/field.ts
@@ -70,6 +70,10 @@ export interface FieldStore<
    */
   readonly isTouched: ReadonlySignal<boolean>;
   /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: ReadonlySignal<boolean>;
+  /**
    * Whether the field input differs from its initial value.
    */
   readonly isDirty: ReadonlySignal<boolean>;
@@ -114,6 +118,10 @@ export interface FieldArrayStore<
    * Whether the field array has been touched.
    */
   readonly isTouched: ReadonlySignal<boolean>;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: ReadonlySignal<boolean>;
   /**
    * Whether the field array input differs from its initial value.
    */

--- a/frameworks/qwik/src/types/form.ts
+++ b/frameworks/qwik/src/types/form.ts
@@ -23,6 +23,10 @@ export interface FormStore<TSchema extends FormSchema = FormSchema>
    */
   readonly isTouched: ReadonlySignal<boolean>;
   /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: ReadonlySignal<boolean>;
+  /**
    * Whether any field in the form differs from its initial value.
    */
   readonly isDirty: ReadonlySignal<boolean>;

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` property to the field, field array and form stores
+
 ## v0.6.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/frameworks/react/src/hooks/useField/useField.test.tsx
+++ b/frameworks/react/src/hooks/useField/useField.test.tsx
@@ -28,6 +28,7 @@ describe('useField', () => {
       expect(field.input).toBe(undefined);
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
+      expect(field.isEdited).toBe(false);
       expect(field.isDirty).toBe(false);
       expect(field.isValid).toBe(true);
       expect(field.props.name).toBe('["name"]');
@@ -104,6 +105,111 @@ describe('useField', () => {
         expect(result.current.errors).toEqual(['Invalid email']);
         expect(result.current.isValid).toBe(false);
       });
+    });
+  });
+
+  describe('edited state', () => {
+    test('should not set isEdited on focus but should set isTouched', async () => {
+      function Test(): ReactElement {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: '' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input data-testid="input" {...field.props} />
+            <span data-testid="touched">{String(field.isTouched)}</span>
+            <span data-testid="edited">{String(field.isEdited)}</span>
+          </div>
+        );
+      }
+
+      render(<Test />);
+
+      const touched = screen.getByTestId('touched');
+      const edited = screen.getByTestId('edited');
+
+      fireEvent.focus(screen.getByTestId('input'));
+
+      // Focusing marks the field as touched, but not as edited
+      await waitFor(() => {
+        expect(touched).toHaveTextContent('true');
+      });
+      expect(edited).toHaveTextContent('false');
+    });
+
+    test('should set isEdited on input', async () => {
+      function Test(): ReactElement {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: '' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited)}</span>
+          </div>
+        );
+      }
+
+      render(<Test />);
+
+      const edited = screen.getByTestId('edited');
+      expect(edited).toHaveTextContent('false');
+
+      fireEvent.change(screen.getByTestId('input'), {
+        target: { value: 'changed' },
+      });
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+      });
+    });
+
+    test('should keep isEdited after reverting the value to its initial value', async () => {
+      function Test(): ReactElement {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: 'initial' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited)}</span>
+            <span data-testid="dirty">{String(field.isDirty)}</span>
+          </div>
+        );
+      }
+
+      render(<Test />);
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      const dirty = screen.getByTestId('dirty');
+
+      fireEvent.change(input, { target: { value: 'changed' } });
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+        expect(dirty).toHaveTextContent('true');
+      });
+
+      // Reverting to the initial value clears isDirty but keeps isEdited
+      fireEvent.change(input, { target: { value: 'initial' } });
+      await waitFor(() => {
+        expect(dirty).toHaveTextContent('false');
+      });
+      expect(edited).toHaveTextContent('true');
     });
   });
 

--- a/frameworks/react/src/hooks/useField/useField.ts
+++ b/frameworks/react/src/hooks/useField/useField.ts
@@ -78,6 +78,9 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
       get isTouched() {
         return getFieldBool(internalFieldStore, 'isTouched');
       },
+      get isEdited() {
+        return getFieldBool(internalFieldStore, 'isEdited');
+      },
       get isDirty() {
         return getFieldBool(internalFieldStore, 'isDirty');
       },

--- a/frameworks/react/src/hooks/useFieldArray/useFieldArray.ts
+++ b/frameworks/react/src/hooks/useFieldArray/useFieldArray.ts
@@ -66,6 +66,9 @@ export function useFieldArray(
       get isTouched() {
         return getFieldBool(internalFieldStore, 'isTouched');
       },
+      get isEdited() {
+        return getFieldBool(internalFieldStore, 'isEdited');
+      },
       get isDirty() {
         return getFieldBool(internalFieldStore, 'isDirty');
       },

--- a/frameworks/react/src/hooks/useForm/useForm.ts
+++ b/frameworks/react/src/hooks/useForm/useForm.ts
@@ -58,6 +58,9 @@ export function useForm(config: FormConfig): FormStore {
       get isTouched() {
         return getFieldBool(internalFormStore, 'isTouched');
       },
+      get isEdited() {
+        return getFieldBool(internalFormStore, 'isEdited');
+      },
       get isDirty() {
         return getFieldBool(internalFormStore, 'isDirty');
       },

--- a/frameworks/react/src/types/field.ts
+++ b/frameworks/react/src/types/field.ts
@@ -64,6 +64,10 @@ export interface FieldStore<
    */
   readonly isTouched: boolean;
   /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether the field input differs from its initial value.
    */
   readonly isDirty: boolean;
@@ -106,6 +110,10 @@ export interface FieldArrayStore<
    * Whether the field array has been touched.
    */
   readonly isTouched: boolean;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: boolean;
   /**
    * Whether the field array input differs from its initial value.
    */

--- a/frameworks/react/src/types/form.ts
+++ b/frameworks/react/src/types/form.ts
@@ -22,6 +22,10 @@ export interface FormStore<TSchema extends FormSchema = FormSchema>
    */
   readonly isTouched: boolean;
   /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether any field in the form differs from its initial value.
    */
   readonly isDirty: boolean;

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` property to the field, field array and form stores
+
 ## v0.11.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/frameworks/solid/src/primitives/createForm/createForm.ts
+++ b/frameworks/solid/src/primitives/createForm/createForm.ts
@@ -31,6 +31,9 @@ export function createForm(config: FormConfig): FormStore {
   const getIsTouched = createMemo(() =>
     getFieldBool(internalFormStore, 'isTouched')
   );
+  const getIsEdited = createMemo(() =>
+    getFieldBool(internalFormStore, 'isEdited')
+  );
   const getIsDirty = createMemo(() =>
     getFieldBool(internalFormStore, 'isDirty')
   );
@@ -51,6 +54,9 @@ export function createForm(config: FormConfig): FormStore {
     },
     get isTouched() {
       return getIsTouched();
+    },
+    get isEdited() {
+      return getIsEdited();
     },
     get isDirty() {
       return getIsDirty();

--- a/frameworks/solid/src/primitives/useField/useField.test.tsx
+++ b/frameworks/solid/src/primitives/useField/useField.test.tsx
@@ -25,6 +25,7 @@ describe('useField', () => {
       expect(field.input).toBe(undefined);
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
+      expect(field.isEdited).toBe(false);
       expect(field.isDirty).toBe(false);
       expect(field.isValid).toBe(true);
       expect(field.props.name).toBe('["name"]');
@@ -99,6 +100,111 @@ describe('useField', () => {
         expect(result.errors).toEqual(['Invalid email']);
         expect(result.isValid).toBe(false);
       });
+    });
+  });
+
+  describe('edited state', () => {
+    test('should not set isEdited on focus but should set isTouched', async () => {
+      function Test(): JSX.Element {
+        const form = createForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: '' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input data-testid="input" {...field.props} />
+            <span data-testid="touched">{String(field.isTouched)}</span>
+            <span data-testid="edited">{String(field.isEdited)}</span>
+          </div>
+        );
+      }
+
+      render(() => <Test />);
+
+      const touched = screen.getByTestId('touched');
+      const edited = screen.getByTestId('edited');
+
+      fireEvent.focus(screen.getByTestId('input'));
+
+      // Focusing marks the field as touched, but not as edited
+      await waitFor(() => {
+        expect(touched).toHaveTextContent('true');
+      });
+      expect(edited).toHaveTextContent('false');
+    });
+
+    test('should set isEdited on input', async () => {
+      function Test(): JSX.Element {
+        const form = createForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: '' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited)}</span>
+          </div>
+        );
+      }
+
+      render(() => <Test />);
+
+      const edited = screen.getByTestId('edited');
+      expect(edited).toHaveTextContent('false');
+
+      fireEvent.input(screen.getByTestId('input'), {
+        target: { value: 'changed' },
+      });
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+      });
+    });
+
+    test('should keep isEdited after reverting the value to its initial value', async () => {
+      function Test(): JSX.Element {
+        const form = createForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: 'initial' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited)}</span>
+            <span data-testid="dirty">{String(field.isDirty)}</span>
+          </div>
+        );
+      }
+
+      render(() => <Test />);
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      const dirty = screen.getByTestId('dirty');
+
+      fireEvent.input(input, { target: { value: 'changed' } });
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+        expect(dirty).toHaveTextContent('true');
+      });
+
+      // Reverting to the initial value clears isDirty but keeps isEdited
+      fireEvent.input(input, { target: { value: 'initial' } });
+      await waitFor(() => {
+        expect(dirty).toHaveTextContent('false');
+      });
+      expect(edited).toHaveTextContent('true');
     });
   });
 

--- a/frameworks/solid/src/primitives/useField/useField.ts
+++ b/frameworks/solid/src/primitives/useField/useField.ts
@@ -60,6 +60,9 @@ export function useField(
   const getIsTouched = createMemo(() =>
     getFieldBool(getInternalFieldStore(), 'isTouched')
   );
+  const getIsEdited = createMemo(() =>
+    getFieldBool(getInternalFieldStore(), 'isEdited')
+  );
   const getIsDirty = createMemo(() =>
     getFieldBool(getInternalFieldStore(), 'isDirty')
   );
@@ -79,6 +82,9 @@ export function useField(
     },
     get isTouched() {
       return getIsTouched();
+    },
+    get isEdited() {
+      return getIsEdited();
     },
     get isDirty() {
       return getIsDirty();

--- a/frameworks/solid/src/primitives/useFieldArray/useFieldArray.ts
+++ b/frameworks/solid/src/primitives/useFieldArray/useFieldArray.ts
@@ -62,6 +62,9 @@ export function useFieldArray(
   const getIsTouched = createMemo(() =>
     getFieldBool(getInternalFieldStore(), 'isTouched')
   );
+  const getIsEdited = createMemo(() =>
+    getFieldBool(getInternalFieldStore(), 'isEdited')
+  );
   const getIsDirty = createMemo(() =>
     getFieldBool(getInternalFieldStore(), 'isDirty')
   );
@@ -81,6 +84,9 @@ export function useFieldArray(
     },
     get isTouched() {
       return getIsTouched();
+    },
+    get isEdited() {
+      return getIsEdited();
     },
     get isDirty() {
       return getIsDirty();

--- a/frameworks/solid/src/types/field.ts
+++ b/frameworks/solid/src/types/field.ts
@@ -68,6 +68,10 @@ export interface FieldStore<
    */
   readonly isTouched: boolean;
   /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether the field input differs from its initial value.
    */
   readonly isDirty: boolean;
@@ -110,6 +114,10 @@ export interface FieldArrayStore<
    * Whether the field array has been touched.
    */
   readonly isTouched: boolean;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: boolean;
   /**
    * Whether the field array input differs from its initial value.
    */

--- a/frameworks/solid/src/types/form.ts
+++ b/frameworks/solid/src/types/form.ts
@@ -22,6 +22,10 @@ export interface FormStore<TSchema extends FormSchema = FormSchema>
    */
   readonly isTouched: boolean;
   /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether any field in the form differs from its initial value.
    */
   readonly isDirty: boolean;

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` property to the field, field array and form stores
+
 ## v0.9.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/frameworks/svelte/src/runes/createForm/createForm.svelte.ts
+++ b/frameworks/svelte/src/runes/createForm/createForm.svelte.ts
@@ -35,6 +35,7 @@ export function createForm(config: FormConfig): FormStore {
   });
 
   const isTouched = $derived(getFieldBool(internalFormStore, 'isTouched'));
+  const isEdited = $derived(getFieldBool(internalFormStore, 'isEdited'));
   const isDirty = $derived(getFieldBool(internalFormStore, 'isDirty'));
   const isValid = $derived(!getFieldBool(internalFormStore, 'errors'));
 
@@ -51,6 +52,9 @@ export function createForm(config: FormConfig): FormStore {
     },
     get isTouched() {
       return isTouched;
+    },
+    get isEdited() {
+      return isEdited;
     },
     get isDirty() {
       return isDirty;

--- a/frameworks/svelte/src/runes/useField/useField.svelte.ts
+++ b/frameworks/svelte/src/runes/useField/useField.svelte.ts
@@ -56,6 +56,7 @@ export function useField(
 
   const input = $derived(getFieldInput(internalFieldStore));
   const isTouched = $derived(getFieldBool(internalFieldStore, 'isTouched'));
+  const isEdited = $derived(getFieldBool(internalFieldStore, 'isEdited'));
   const isDirty = $derived(getFieldBool(internalFieldStore, 'isDirty'));
   const isValid = $derived(!getFieldBool(internalFieldStore, 'errors'));
 
@@ -71,6 +72,9 @@ export function useField(
     },
     get isTouched() {
       return isTouched;
+    },
+    get isEdited() {
+      return isEdited;
     },
     get isDirty() {
       return isDirty;

--- a/frameworks/svelte/src/runes/useField/useField.test.ts
+++ b/frameworks/svelte/src/runes/useField/useField.test.ts
@@ -21,6 +21,7 @@ describe('useField', () => {
       expect(field.input).toBe(undefined);
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
+      expect(field.isEdited).toBe(false);
       expect(field.isDirty).toBe(false);
       expect(field.isValid).toBe(true);
       expect(field.props.name).toBe('["name"]');
@@ -190,6 +191,87 @@ describe('useField', () => {
 
       await waitFor(() => {
         expect(valid).toHaveTextContent('false');
+      });
+    });
+  });
+
+  describe('edited state', () => {
+    test('focus does not set isEdited but sets isTouched', async () => {
+      render(FieldHost, {
+        props: {
+          config: {
+            schema: v.object({ name: v.string() }),
+            initialInput: { name: 'initial' },
+          },
+          path: ['name'],
+        },
+      });
+
+      const touched = screen.getByTestId('touched');
+      const edited = screen.getByTestId('edited');
+      expect(touched).toHaveTextContent('false');
+      expect(edited).toHaveTextContent('false');
+
+      await fireEvent.focus(screen.getByTestId('input'));
+
+      await waitFor(() => {
+        expect(touched).toHaveTextContent('true');
+        expect(edited).toHaveTextContent('false');
+      });
+    });
+
+    test('input sets isEdited', async () => {
+      render(FieldHost, {
+        props: {
+          config: {
+            schema: v.object({ name: v.string() }),
+            initialInput: { name: 'initial' },
+          },
+          path: ['name'],
+        },
+      });
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      expect(edited).toHaveTextContent('false');
+
+      await fireEvent.input(input, { target: { value: 'changed' } });
+      flushSync();
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+      });
+    });
+
+    test('reverting to initial keeps isEdited', async () => {
+      render(FieldHost, {
+        props: {
+          config: {
+            schema: v.object({ name: v.string() }),
+            initialInput: { name: 'initial' },
+          },
+          path: ['name'],
+        },
+      });
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      const dirty = screen.getByTestId('dirty');
+
+      await fireEvent.input(input, { target: { value: 'changed' } });
+      flushSync();
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+        expect(dirty).toHaveTextContent('true');
+      });
+
+      await fireEvent.input(input, { target: { value: 'initial' } });
+      flushSync();
+
+      await waitFor(() => {
+        expect(dirty).toHaveTextContent('false');
+        expect(edited).toHaveTextContent('true');
       });
     });
   });

--- a/frameworks/svelte/src/runes/useFieldArray/useFieldArray.svelte.ts
+++ b/frameworks/svelte/src/runes/useFieldArray/useFieldArray.svelte.ts
@@ -56,6 +56,7 @@ export function useFieldArray(
   );
 
   const isTouched = $derived(getFieldBool(internalFieldStore, 'isTouched'));
+  const isEdited = $derived(getFieldBool(internalFieldStore, 'isEdited'));
   const isDirty = $derived(getFieldBool(internalFieldStore, 'isDirty'));
   const isValid = $derived(!getFieldBool(internalFieldStore, 'errors'));
 
@@ -71,6 +72,9 @@ export function useFieldArray(
     },
     get isTouched() {
       return isTouched;
+    },
+    get isEdited() {
+      return isEdited;
     },
     get isDirty() {
       return isDirty;

--- a/frameworks/svelte/src/types/field.ts
+++ b/frameworks/svelte/src/types/field.ts
@@ -68,6 +68,10 @@ export interface FieldStore<
    */
   readonly isTouched: boolean;
   /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether the field input differs from its initial value.
    */
   readonly isDirty: boolean;
@@ -110,6 +114,10 @@ export interface FieldArrayStore<
    * Whether the field array has been touched.
    */
   readonly isTouched: boolean;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: boolean;
   /**
    * Whether the field array input differs from its initial value.
    */

--- a/frameworks/svelte/src/types/form.ts
+++ b/frameworks/svelte/src/types/form.ts
@@ -22,6 +22,10 @@ export interface FormStore<TSchema extends FormSchema = FormSchema>
    */
   readonly isTouched: boolean;
   /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether any field in the form differs from its initial value.
    */
   readonly isDirty: boolean;

--- a/frameworks/svelte/src/vitest/FieldHost.svelte
+++ b/frameworks/svelte/src/vitest/FieldHost.svelte
@@ -40,6 +40,7 @@
 <Form of={form} {onsubmit} aria-label="Test">
   <input data-testid="input" {...field.props} value={field.input ?? ''} />
   <span data-testid="touched">{String(field.isTouched)}</span>
+  <span data-testid="edited">{String(field.isEdited)}</span>
   <span data-testid="dirty">{String(field.isDirty)}</span>
   <span data-testid="valid">{String(field.isValid)}</span>
   {#if field.errors}

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` property to the field, field array and form stores
+
 ## v0.9.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/frameworks/vue/src/composables/useField/useField.test.ts
+++ b/frameworks/vue/src/composables/useField/useField.test.ts
@@ -20,6 +20,7 @@ describe('useField', () => {
       expect(field.input).toBe(undefined);
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
+      expect(field.isEdited).toBe(false);
       expect(field.isDirty).toBe(false);
       expect(field.isValid).toBe(true);
       expect(field.props.name).toBe('["name"]');
@@ -201,6 +202,122 @@ describe('useField', () => {
 
       await vi.waitFor(() => {
         expect(valid.text()).toBe('false');
+      });
+    });
+  });
+
+  describe('edited state', () => {
+    test('should not set isEdited on focus but should set isTouched', async () => {
+      const Test = defineComponent({
+        setup() {
+          const form = useForm({
+            schema: v.object({ name: v.string() }),
+            initialInput: { name: 'initial' },
+          });
+          const field = useField(form, { path: ['name'] });
+          return () =>
+            h('div', [
+              h('input', {
+                'data-testid': 'input',
+                ...field.props,
+                value: field.input ?? '',
+              }),
+              h('span', { 'data-testid': 'touched' }, String(field.isTouched)),
+              h('span', { 'data-testid': 'edited' }, String(field.isEdited)),
+            ]);
+        },
+      });
+
+      const wrapper = mount(Test);
+      const touched = wrapper.get('[data-testid="touched"]');
+      const edited = wrapper.get('[data-testid="edited"]');
+      expect(touched.text()).toBe('false');
+      expect(edited.text()).toBe('false');
+
+      await wrapper.get('[data-testid="input"]').trigger('focus');
+
+      await vi.waitFor(() => {
+        expect(touched.text()).toBe('true');
+        expect(edited.text()).toBe('false');
+      });
+    });
+
+    test('should set isEdited on input', async () => {
+      const Test = defineComponent({
+        setup() {
+          const form = useForm({
+            schema: v.object({ name: v.string() }),
+            initialInput: { name: 'initial' },
+          });
+          const field = useField(form, { path: ['name'] });
+          return () =>
+            h('div', [
+              h('input', {
+                'data-testid': 'input',
+                ...field.props,
+                value: field.input ?? '',
+                onInput: (e: Event) => {
+                  field.input = (e.target as HTMLInputElement).value;
+                },
+              }),
+              h('span', { 'data-testid': 'edited' }, String(field.isEdited)),
+            ]);
+        },
+      });
+
+      const wrapper = mount(Test);
+      const input = wrapper.get<HTMLInputElement>('[data-testid="input"]');
+      const edited = wrapper.get('[data-testid="edited"]');
+      expect(edited.text()).toBe('false');
+
+      await input.setValue('changed');
+
+      await vi.waitFor(() => {
+        expect(edited.text()).toBe('true');
+      });
+    });
+
+    test('should keep isEdited after reverting the value to its initial value', async () => {
+      const Test = defineComponent({
+        setup() {
+          const form = useForm({
+            schema: v.object({ name: v.string() }),
+            initialInput: { name: 'initial' },
+          });
+          const field = useField(form, { path: ['name'] });
+          return () =>
+            h('div', [
+              h('input', {
+                'data-testid': 'input',
+                ...field.props,
+                value: field.input ?? '',
+                onInput: (e: Event) => {
+                  field.input = (e.target as HTMLInputElement).value;
+                },
+              }),
+              h('span', { 'data-testid': 'edited' }, String(field.isEdited)),
+              h('span', { 'data-testid': 'dirty' }, String(field.isDirty)),
+            ]);
+        },
+      });
+
+      const wrapper = mount(Test);
+      const input = wrapper.get<HTMLInputElement>('[data-testid="input"]');
+      const edited = wrapper.get('[data-testid="edited"]');
+      const dirty = wrapper.get('[data-testid="dirty"]');
+
+      await input.setValue('changed');
+
+      await vi.waitFor(() => {
+        expect(edited.text()).toBe('true');
+        expect(dirty.text()).toBe('true');
+      });
+
+      await input.setValue('initial');
+
+      await vi.waitFor(() => {
+        expect(dirty.text()).toBe('false');
+        expect(edited.text()).toBe('true');
       });
     });
   });

--- a/frameworks/vue/src/composables/useField/useField.ts
+++ b/frameworks/vue/src/composables/useField/useField.ts
@@ -76,6 +76,9 @@ export function useField(
   const isTouched = computed(() =>
     getFieldBool(internalFieldStore.value, 'isTouched')
   );
+  const isEdited = computed(() =>
+    getFieldBool(internalFieldStore.value, 'isEdited')
+  );
   const isDirty = computed(() =>
     getFieldBool(internalFieldStore.value, 'isDirty')
   );
@@ -103,6 +106,9 @@ export function useField(
     },
     get isTouched() {
       return isTouched.value;
+    },
+    get isEdited() {
+      return isEdited.value;
     },
     get isDirty() {
       return isDirty.value;

--- a/frameworks/vue/src/composables/useFieldArray/useFieldArray.ts
+++ b/frameworks/vue/src/composables/useFieldArray/useFieldArray.ts
@@ -58,6 +58,9 @@ export function useFieldArray(
   const isTouched = computed(() =>
     getFieldBool(internalFieldStore.value, 'isTouched')
   );
+  const isEdited = computed(() =>
+    getFieldBool(internalFieldStore.value, 'isEdited')
+  );
   const isDirty = computed(() =>
     getFieldBool(internalFieldStore.value, 'isDirty')
   );
@@ -77,6 +80,9 @@ export function useFieldArray(
     },
     get isTouched() {
       return isTouched.value;
+    },
+    get isEdited() {
+      return isEdited.value;
     },
     get isDirty() {
       return isDirty.value;

--- a/frameworks/vue/src/composables/useForm/useForm.ts
+++ b/frameworks/vue/src/composables/useForm/useForm.ts
@@ -37,6 +37,7 @@ export function useForm(config: FormConfig): FormStore {
   const isTouched = computed(() =>
     getFieldBool(internalFormStore, 'isTouched')
   );
+  const isEdited = computed(() => getFieldBool(internalFormStore, 'isEdited'));
   const isDirty = computed(() => getFieldBool(internalFormStore, 'isDirty'));
   const isValid = computed(() => !getFieldBool(internalFormStore, 'errors'));
 
@@ -53,6 +54,9 @@ export function useForm(config: FormConfig): FormStore {
     },
     get isTouched() {
       return isTouched.value;
+    },
+    get isEdited() {
+      return isEdited.value;
     },
     get isDirty() {
       return isDirty.value;

--- a/frameworks/vue/src/types/field.ts
+++ b/frameworks/vue/src/types/field.ts
@@ -67,6 +67,10 @@ export interface FieldStore<
    */
   readonly isTouched: boolean;
   /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether the field input differs from its initial value.
    */
   readonly isDirty: boolean;
@@ -103,6 +107,10 @@ export interface FieldArrayStore<
    * Whether the field array has been touched.
    */
   readonly isTouched: boolean;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: boolean;
   /**
    * Whether the field array input differs from its initial value.
    */

--- a/frameworks/vue/src/types/form.ts
+++ b/frameworks/vue/src/types/form.ts
@@ -22,6 +22,10 @@ export interface FormStore<TSchema extends FormSchema = FormSchema>
    */
   readonly isTouched: boolean;
   /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
    * Whether any field in the form differs from its initial value.
    */
   readonly isDirty: boolean;

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `isEdited` field state that is set when a field's value changes, is not set on focus, and stays set after reverting to the initial value
+
 ## v0.8.0 (June 15, 2026)
 
 - Add `focusFieldElement` utility that focuses the first focusable element of a field store

--- a/packages/core/src/array/copyItemState/copyItemState.test.ts
+++ b/packages/core/src/array/copyItemState/copyItemState.test.ts
@@ -18,6 +18,7 @@ describe('copyItemState', () => {
       // Modify source state
       sourceStore.input.value = 'modified';
       sourceStore.isTouched.value = true;
+      sourceStore.isEdited.value = true;
       sourceStore.isDirty.value = true;
       sourceStore.errors.value = ['Error'];
 
@@ -26,6 +27,7 @@ describe('copyItemState', () => {
       expect(targetStore.input.value).toBe('modified');
       expect(targetStore.startInput.value).toBe('hello');
       expect(targetStore.isTouched.value).toBe(true);
+      expect(targetStore.isEdited.value).toBe(true);
       expect(targetStore.isDirty.value).toBe(true);
       expect(targetStore.errors.value).toEqual(['Error']);
     });

--- a/packages/core/src/array/copyItemState/copyItemState.ts
+++ b/packages/core/src/array/copyItemState/copyItemState.ts
@@ -5,8 +5,9 @@ import type { InternalFieldStore, PathKey } from '../../types/index.ts';
 /**
  * Copies the deeply nested state (signal values) from one field store to
  * another. This includes the `elements`, `errors`, `startInput`, `input`,
- * `isTouched`, `isDirty`, and for arrays `startItems` and `items` properties.
- * Recursively walks through the field stores and copies all signal values.
+ * `isTouched`, `isEdited`, `isDirty`, and for arrays `startItems` and `items`
+ * properties. Recursively walks through the field stores and copies all signal
+ * values.
  *
  * @param fromInternalFieldStore The source field store to copy from.
  * @param toInternalFieldStore The destination field store to copy to.
@@ -35,6 +36,10 @@ export function copyItemState(
       // Copy touched state
       toInternalFieldStore.isTouched.value =
         fromInternalFieldStore.isTouched.value;
+
+      // Copy edited state
+      toInternalFieldStore.isEdited.value =
+        fromInternalFieldStore.isEdited.value;
 
       // Copy dirty state
       toInternalFieldStore.isDirty.value = fromInternalFieldStore.isDirty.value;

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -16,6 +16,7 @@ describe('resetItemState', () => {
       // Modify state
       nameStore.input.value = 'modified';
       nameStore.isTouched.value = true;
+      nameStore.isEdited.value = true;
       nameStore.isDirty.value = true;
       nameStore.errors.value = ['Error'];
       nameStore.elements = [document.createElement('input')];
@@ -25,6 +26,7 @@ describe('resetItemState', () => {
       expect(nameStore.input.value).toBe('reset-value');
       expect(nameStore.startInput.value).toBe('reset-value');
       expect(nameStore.isTouched.value).toBe(false);
+      expect(nameStore.isEdited.value).toBe(false);
       expect(nameStore.isDirty.value).toBe(false);
       expect(nameStore.errors.value).toBe(null);
       expect(nameStore.elements).toEqual([]);

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -8,10 +8,10 @@ import type {
 
 /**
  * Resets the state of a field store (signal values) deeply nested. Sets
- * `elements` to empty array, `errors` to `null`, `isTouched` and `isDirty` to
- * `false`, and `startInput`, `input`, `startItems`, and `items` to the new
- * input value. Keeps the `initialInput` and `initialItems` state unchanged for
- * form reset functionality.
+ * `elements` to empty array, `errors` to `null`, `isTouched`, `isEdited` and
+ * `isDirty` to `false`, and `startInput`, `input`, `startItems`, and `items` to
+ * the new input value. Keeps the `initialInput` and `initialItems` state
+ * unchanged for form reset functionality.
  *
  * @param internalFieldStore The field store to reset.
  * @param input The new input value (can be any type including array or object).
@@ -40,6 +40,9 @@ export function resetItemState(
 
     // Reset touched to false
     internalFieldStore.isTouched.value = false;
+
+    // Reset edited to false
+    internalFieldStore.isEdited.value = false;
 
     // Reset dirty to false
     internalFieldStore.isDirty.value = false;

--- a/packages/core/src/array/swapItemState/swapItemState.test.ts
+++ b/packages/core/src/array/swapItemState/swapItemState.test.ts
@@ -17,6 +17,7 @@ describe('swapItemState', () => {
       firstStore.isTouched.value = true;
       firstStore.errors.value = ['First error'];
       secondStore.isDirty.value = true;
+      secondStore.isEdited.value = true;
 
       swapItemState(firstStore, secondStore);
 
@@ -24,6 +25,8 @@ describe('swapItemState', () => {
       expect(secondStore.input.value).toBe('hello');
       expect(firstStore.isTouched.value).toBe(false);
       expect(secondStore.isTouched.value).toBe(true);
+      expect(firstStore.isEdited.value).toBe(true);
+      expect(secondStore.isEdited.value).toBe(false);
       expect(firstStore.isDirty.value).toBe(true);
       expect(secondStore.isDirty.value).toBe(false);
       expect(firstStore.errors.value).toBe(null);

--- a/packages/core/src/array/swapItemState/swapItemState.ts
+++ b/packages/core/src/array/swapItemState/swapItemState.ts
@@ -5,8 +5,8 @@ import type { InternalFieldStore, PathKey } from '../../types/index.ts';
 /**
  * Swaps the deeply nested state (signal values) between two field stores. This
  * includes the `elements`, `errors`, `startInput`, `input`, `isTouched`,
- * `isDirty`, and for arrays `startItems` and `items` properties. Recursively
- * walks through the field stores and swaps all signal values.
+ * `isEdited`, `isDirty`, and for arrays `startItems` and `items` properties.
+ * Recursively walks through the field stores and swaps all signal values.
  *
  * @param firstInternalFieldStore The first field store to swap.
  * @param secondInternalFieldStore The second field store to swap.
@@ -47,6 +47,12 @@ export function swapItemState(
       firstInternalFieldStore.isTouched.value =
         secondInternalFieldStore.isTouched.value;
       secondInternalFieldStore.isTouched.value = tempIsTouched;
+
+      // Swap edited state
+      const tempIsEdited = firstInternalFieldStore.isEdited.value;
+      firstInternalFieldStore.isEdited.value =
+        secondInternalFieldStore.isEdited.value;
+      secondInternalFieldStore.isEdited.value = tempIsEdited;
 
       // Swap dirty state
       const tempIsDirty = firstInternalFieldStore.isDirty.value;

--- a/packages/core/src/field/getFieldBool/getFieldBool.test.ts
+++ b/packages/core/src/field/getFieldBool/getFieldBool.test.ts
@@ -29,6 +29,13 @@ describe('getFieldBool', () => {
       store.children.name.isDirty.value = true;
       expect(getFieldBool(store.children.name, 'isDirty')).toBe(true);
     });
+
+    test('should check isEdited property', () => {
+      const store = createTestStore(v.object({ name: v.string() }));
+      expect(getFieldBool(store.children.name, 'isEdited')).toBe(false);
+      store.children.name.isEdited.value = true;
+      expect(getFieldBool(store.children.name, 'isEdited')).toBe(true);
+    });
   });
 
   describe('object fields', () => {

--- a/packages/core/src/field/getFieldBool/getFieldBool.ts
+++ b/packages/core/src/field/getFieldBool/getFieldBool.ts
@@ -12,7 +12,7 @@ import type { InternalFieldStore } from '../../types/index.ts';
 // @__NO_SIDE_EFFECTS__
 export function getFieldBool(
   internalFieldStore: InternalFieldStore,
-  type: 'errors' | 'isTouched' | 'isDirty'
+  type: 'errors' | 'isTouched' | 'isEdited' | 'isDirty'
 ): boolean {
   // If current field has property set to true, return true
   if (internalFieldStore[type].value) {

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.test.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.test.ts
@@ -16,6 +16,7 @@ describe('initializeFieldStore', () => {
       expect(field.startInput.value).toBe('John');
       expect(field.errors.value).toBeNull();
       expect(field.isTouched.value).toBe(false);
+      expect(field.isEdited.value).toBe(false);
       expect(field.isDirty.value).toBe(false);
     });
 

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -140,6 +140,7 @@ export function initializeFieldStore(
     // Initialize common signals
     internalFieldStore.errors = createSignal(null);
     internalFieldStore.isTouched = createSignal(false);
+    internalFieldStore.isEdited = createSignal(false);
     internalFieldStore.isDirty = createSignal(false);
 
     // If schema is array or tuple, initialize as array field

--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -19,6 +19,24 @@ describe('setFieldInput', () => {
       expect(store.children.name.isTouched.value).toBe(true);
     });
 
+    test('should mark field as edited', () => {
+      const store = createTestStore(v.object({ name: v.string() }));
+      setFieldInput(store, ['name'], 'John');
+      expect(store.children.name.isEdited.value).toBe(true);
+    });
+
+    test('should keep field edited after reverting to initial value', () => {
+      const store = createTestStore(v.object({ name: v.string() }), {
+        initialInput: { name: 'John' },
+      });
+      setFieldInput(store, ['name'], 'Jane');
+      setFieldInput(store, ['name'], 'John');
+      // Unlike `isDirty`, `isEdited` stays `true` even after the value is
+      // changed back to its initial value
+      expect(store.children.name.isDirty.value).toBe(false);
+      expect(store.children.name.isEdited.value).toBe(true);
+    });
+
     test('should mark field as dirty when value changes', () => {
       const store = createTestStore(v.object({ name: v.string() }), {
         initialInput: { name: 'John' },

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -19,8 +19,9 @@ function setNestedInput(
   internalFieldStore: InternalFieldStore,
   input: unknown
 ): void {
-  // Mark field as touched
+  // Mark field as touched and edited
   internalFieldStore.isTouched.value = true;
+  internalFieldStore.isEdited.value = true;
 
   // If field store is array, handle array input
   if (internalFieldStore.kind === 'array') {

--- a/packages/core/src/types/field/field.qwik.ts
+++ b/packages/core/src/types/field/field.qwik.ts
@@ -43,6 +43,15 @@ export interface InternalBaseStore {
    */
   isTouched: Signal<boolean>;
   /**
+   * The edited state of the field.
+   *
+   * Hint: Unlike `isTouched`, which is also set when a field is focused, this
+   * is only set when the field's value is changed. Unlike `isDirty`, it stays
+   * `true` even if the value is changed back to its initial value. It is only
+   * reset when the field is reset.
+   */
+  isEdited: Signal<boolean>;
+  /**
    * The dirty state of the field.
    */
   isDirty: Signal<boolean>;

--- a/packages/core/src/types/field/field.ts
+++ b/packages/core/src/types/field/field.ts
@@ -49,6 +49,15 @@ export interface InternalBaseStore {
    */
   isTouched: Signal<boolean>;
   /**
+   * The edited state of the field.
+   *
+   * Hint: Unlike `isTouched`, which is also set when a field is focused, this
+   * is only set when the field's value is changed. Unlike `isDirty`, it stays
+   * `true` even if the value is changed back to its initial value. It is only
+   * reset when the field is reset.
+   */
+  isEdited: Signal<boolean>;
+  /**
    * The dirty state of the field.
    */
   isDirty: Signal<boolean>;

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `keepEdited` config option to the `reset` method to keep the edited state of fields
+- Change `insert`, `move`, `remove`, `replace` and `swap` methods to set the edited state of the field array
+
 ## v0.9.0 (June 15, 2026)
 
 - Change `@formisch/core` to v0.8.0

--- a/packages/methods/src/insert/insert.test.ts
+++ b/packages/methods/src/insert/insert.test.ts
@@ -132,6 +132,16 @@ describe('insert', () => {
     expect(store.children.items.isDirty.value).toBe(true);
   });
 
+  test('should mark array as edited after insert', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: ['a'] },
+    });
+
+    insert(store, { path: ['items'], initialInput: 'b' });
+
+    expect(store.children.items.isEdited.value).toBe(true);
+  });
+
   test('should insert object item', () => {
     const store = createTestStore(
       v.object({ users: v.array(v.object({ name: v.string() })) }),

--- a/packages/methods/src/insert/insert.ts
+++ b/packages/methods/src/insert/insert.ts
@@ -131,8 +131,9 @@ export function insert<
       // Mark array input as present in children
       internalArrayStore.input.value = true;
 
-      // Mark field array as touched and dirty
+      // Mark field array as touched, edited and dirty
       internalArrayStore.isTouched.value = true;
+      internalArrayStore.isEdited.value = true;
       internalArrayStore.isDirty.value = true;
 
       // Validate if required

--- a/packages/methods/src/move/move.test.ts
+++ b/packages/methods/src/move/move.test.ts
@@ -62,6 +62,16 @@ describe('move', () => {
     expect(store.children.items.isTouched.value).toBe(true);
   });
 
+  test('should mark array as edited after move', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: ['a', 'b'] },
+    });
+
+    move(store, { path: ['items'], from: 0, to: 1 });
+
+    expect(store.children.items.isEdited.value).toBe(true);
+  });
+
   test('should mark array as dirty after move', () => {
     const store = createTestStore(v.object({ items: v.array(v.string()) }), {
       initialInput: { items: ['a', 'b'] },

--- a/packages/methods/src/move/move.ts
+++ b/packages/methods/src/move/move.ts
@@ -114,8 +114,9 @@ export function move<
         internalArrayStore.children[config.to]
       );
 
-      // Mark field array as touched and update dirty state
+      // Mark field array as touched and edited and update dirty state
       internalArrayStore.isTouched.value = true;
+      internalArrayStore.isEdited.value = true;
       internalArrayStore.isDirty.value =
         internalArrayStore.startItems.value.join() !== newItems.join();
 

--- a/packages/methods/src/remove/remove.test.ts
+++ b/packages/methods/src/remove/remove.test.ts
@@ -64,6 +64,16 @@ describe('remove', () => {
     expect(store.children.items.isDirty.value).toBe(true);
   });
 
+  test('should mark array as edited after removal', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: ['a', 'b', 'c'] },
+    });
+
+    remove(store, { path: ['items'], at: 1 });
+
+    expect(store.children.items.isEdited.value).toBe(true);
+  });
+
   test('should remove item from nested array', () => {
     const store = createTestStore(
       v.object({ outer: v.object({ items: v.array(v.string()) }) }),

--- a/packages/methods/src/remove/remove.ts
+++ b/packages/methods/src/remove/remove.ts
@@ -70,8 +70,9 @@ export function remove<
         );
       }
 
-      // Mark field array as touched and update dirty state
+      // Mark field array as touched and edited and update dirty state
       internalArrayStore.isTouched.value = true;
+      internalArrayStore.isEdited.value = true;
       internalArrayStore.isDirty.value =
         internalArrayStore.startItems.value.join() !== newItems.join();
 

--- a/packages/methods/src/replace/replace.test.ts
+++ b/packages/methods/src/replace/replace.test.ts
@@ -59,6 +59,16 @@ describe('replace', () => {
     expect(store.children.items.isDirty.value).toBe(true);
   });
 
+  test('should mark array as edited after replace', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: ['a', 'b'] },
+    });
+
+    replace(store, { path: ['items'], at: 0, initialInput: 'x' });
+
+    expect(store.children.items.isEdited.value).toBe(true);
+  });
+
   test('should initialize missing children of nested array item', () => {
     const store = createTestStore(
       v.object({ list: v.array(v.object({ tags: v.array(v.string()) })) }),

--- a/packages/methods/src/replace/replace.ts
+++ b/packages/methods/src/replace/replace.ts
@@ -78,8 +78,9 @@ export function replace<
         config.initialInput
       );
 
-      // Mark field array as touched and dirty
+      // Mark field array as touched, edited and dirty
       internalArrayStore.isTouched.value = true;
+      internalArrayStore.isEdited.value = true;
       internalArrayStore.isDirty.value = true;
 
       // Validate if required

--- a/packages/methods/src/reset/reset.test.ts
+++ b/packages/methods/src/reset/reset.test.ts
@@ -26,6 +26,15 @@ describe('reset', () => {
       expect(store.children.name.isTouched.value).toBe(false);
     });
 
+    test('should reset field edited state', () => {
+      const store = createTestStore(v.object({ name: v.string() }));
+      store.children.name.isEdited.value = true;
+
+      reset(store);
+
+      expect(store.children.name.isEdited.value).toBe(false);
+    });
+
     test('should reset field errors', () => {
       const store = createTestStore(v.object({ name: v.string() }));
       store.children.name.errors.value = ['Error'];
@@ -150,6 +159,17 @@ describe('reset', () => {
       reset(store, { keepTouched: true });
 
       expect(store.children.name.isTouched.value).toBe(true);
+    });
+  });
+
+  describe('form reset with keepEdited', () => {
+    test('should keep edited state', () => {
+      const store = createTestStore(v.object({ name: v.string() }));
+      store.children.name.isEdited.value = true;
+
+      reset(store, { keepEdited: true });
+
+      expect(store.children.name.isEdited.value).toBe(true);
     });
   });
 

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -28,6 +28,10 @@ interface ResetBaseConfig {
    */
   readonly keepTouched?: boolean | undefined;
   /**
+   * Whether to keep the edited state during reset. Defaults to false.
+   */
+  readonly keepEdited?: boolean | undefined;
+  /**
    * Whether to keep the error messages during reset. Defaults to false.
    */
   readonly keepErrors?: boolean | undefined;
@@ -136,6 +140,11 @@ export function reset(
         // Reset is touched if it is not to be kept
         if (!config?.keepTouched) {
           internalFieldStore.isTouched.value = false;
+        }
+
+        // Reset is edited if it is not to be kept
+        if (!config?.keepEdited) {
+          internalFieldStore.isEdited.value = false;
         }
 
         // Reset start input to initial input

--- a/packages/methods/src/swap/swap.test.ts
+++ b/packages/methods/src/swap/swap.test.ts
@@ -61,6 +61,16 @@ describe('swap', () => {
     expect(store.children.items.isTouched.value).toBe(true);
   });
 
+  test('should mark array as edited after swap', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: ['a', 'b'] },
+    });
+
+    swap(store, { path: ['items'], at: 0, and: 1 });
+
+    expect(store.children.items.isEdited.value).toBe(true);
+  });
+
   test('should mark array as dirty after swap', () => {
     const store = createTestStore(v.object({ items: v.array(v.string()) }), {
       initialInput: { items: ['a', 'b'] },

--- a/packages/methods/src/swap/swap.ts
+++ b/packages/methods/src/swap/swap.ts
@@ -79,8 +79,9 @@ export function swap<
         internalArrayStore.children[config.and]
       );
 
-      // Mark field array as touched and update dirty state
+      // Mark field array as touched and edited and update dirty state
       internalArrayStore.isTouched.value = true;
+      internalArrayStore.isEdited.value = true;
       internalArrayStore.isDirty.value =
         internalArrayStore.startItems.value.join() !== newItems.join();
 

--- a/website/src/routes/(docs)/methods/api/(types)/ResetFieldConfig/index.mdx
+++ b/website/src/routes/(docs)/methods/api/(types)/ResetFieldConfig/index.mdx
@@ -23,6 +23,7 @@ Configuration interface for resetting field-specific input and errors. Used by t
 - `ResetFieldConfig`
   - `path` <Property {...properties.path} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `keepEdited` <Property {...properties.keepEdited} />
   - `keepErrors` <Property {...properties.keepErrors} />
   - `keepInput` <Property {...properties.keepInput} />
   - `keepTouched` <Property {...properties.keepTouched} />

--- a/website/src/routes/(docs)/methods/api/(types)/ResetFieldConfig/properties.ts
+++ b/website/src/routes/(docs)/methods/api/(types)/ResetFieldConfig/properties.ts
@@ -73,6 +73,10 @@ export const properties: Record<string, PropertyProps> = {
     },
     default: 'undefined',
   },
+  keepEdited: {
+    type: 'boolean',
+    default: { type: 'boolean', value: false },
+  },
   keepErrors: {
     type: 'boolean',
     default: { type: 'boolean', value: false },

--- a/website/src/routes/(docs)/methods/api/(types)/ResetFormConfig/index.mdx
+++ b/website/src/routes/(docs)/methods/api/(types)/ResetFormConfig/index.mdx
@@ -21,6 +21,7 @@ Configuration interface for resetting form input and errors. Used by the `reset`
 
 - `ResetFormConfig`
   - `initialInput` <Property {...properties.initialInput} />
+  - `keepEdited` <Property {...properties.keepEdited} />
   - `keepErrors` <Property {...properties.keepErrors} />
   - `keepInput` <Property {...properties.keepInput} />
   - `keepSubmitted` <Property {...properties.keepSubmitted} />

--- a/website/src/routes/(docs)/methods/api/(types)/ResetFormConfig/properties.ts
+++ b/website/src/routes/(docs)/methods/api/(types)/ResetFormConfig/properties.ts
@@ -30,6 +30,10 @@ export const properties: Record<string, PropertyProps> = {
     },
     default: 'undefined',
   },
+  keepEdited: {
+    type: 'boolean',
+    default: { type: 'boolean', value: false },
+  },
   keepErrors: {
     type: 'boolean',
     default: { type: 'boolean', value: false },

--- a/website/src/routes/(docs)/preact/api/(types)/FieldArrayStore/index.mdx
+++ b/website/src/routes/(docs)/preact/api/(types)/FieldArrayStore/index.mdx
@@ -25,5 +25,6 @@ Reactive field array store interface with properties for managing array fields.
   - `items` <Property {...properties.items} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />

--- a/website/src/routes/(docs)/preact/api/(types)/FieldArrayStore/properties.ts
+++ b/website/src/routes/(docs)/preact/api/(types)/FieldArrayStore/properties.ts
@@ -100,6 +100,14 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'isEdited',
+          value: {
+            type: 'custom',
+            name: 'ReadonlySignal',
+            generics: ['boolean'],
+          },
+        },
+        {
           key: 'isDirty',
           value: {
             type: 'custom',
@@ -186,6 +194,13 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: ['boolean'],
+    },
+  },
+  isEdited: {
     type: {
       type: 'custom',
       name: 'ReadonlySignal',

--- a/website/src/routes/(docs)/preact/api/(types)/FieldStore/index.mdx
+++ b/website/src/routes/(docs)/preact/api/(types)/FieldStore/index.mdx
@@ -25,6 +25,7 @@ Reactive field store interface with properties and element props for field manag
   - `input` <Property {...properties.input} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `onInput` <Property {...properties.onInput} />

--- a/website/src/routes/(docs)/preact/api/(types)/FieldStore/properties.ts
+++ b/website/src/routes/(docs)/preact/api/(types)/FieldStore/properties.ts
@@ -125,6 +125,14 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'isEdited',
+          value: {
+            type: 'custom',
+            name: 'ReadonlySignal',
+            generics: ['boolean'],
+          },
+        },
+        {
           key: 'isDirty',
           value: {
             type: 'custom',
@@ -285,6 +293,13 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: ['boolean'],
+    },
+  },
+  isEdited: {
     type: {
       type: 'custom',
       name: 'ReadonlySignal',

--- a/website/src/routes/(docs)/preact/api/(types)/FormStore/index.mdx
+++ b/website/src/routes/(docs)/preact/api/(types)/FormStore/index.mdx
@@ -24,6 +24,7 @@ Form store interface that provides reactive access to the state of a form create
   - `isSubmitted` <Property {...properties.isSubmitted} />
   - `isValidating` <Property {...properties.isValidating} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `errors` <Property {...properties.errors} />

--- a/website/src/routes/(docs)/preact/api/(types)/FormStore/properties.ts
+++ b/website/src/routes/(docs)/preact/api/(types)/FormStore/properties.ts
@@ -46,6 +46,14 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'isEdited',
+          value: {
+            type: 'custom',
+            name: 'ReadonlySignal',
+            generics: ['boolean'],
+          },
+        },
+        {
           key: 'isDirty',
           value: {
             type: 'custom',
@@ -112,6 +120,13 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: ['boolean'],
+    },
+  },
+  isEdited: {
     type: {
       type: 'custom',
       name: 'ReadonlySignal',

--- a/website/src/routes/(docs)/qwik/api/(types)/FieldArrayStore/index.mdx
+++ b/website/src/routes/(docs)/qwik/api/(types)/FieldArrayStore/index.mdx
@@ -25,5 +25,6 @@ Reactive field array store interface with properties for managing array fields.
   - `items` <Property {...properties.items} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />

--- a/website/src/routes/(docs)/qwik/api/(types)/FieldArrayStore/properties.ts
+++ b/website/src/routes/(docs)/qwik/api/(types)/FieldArrayStore/properties.ts
@@ -100,6 +100,14 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'isEdited',
+          value: {
+            type: 'custom',
+            name: 'ReadonlySignal',
+            generics: ['boolean'],
+          },
+        },
+        {
           key: 'isDirty',
           value: {
             type: 'custom',
@@ -186,6 +194,13 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: ['boolean'],
+    },
+  },
+  isEdited: {
     type: {
       type: 'custom',
       name: 'ReadonlySignal',

--- a/website/src/routes/(docs)/qwik/api/(types)/FieldStore/index.mdx
+++ b/website/src/routes/(docs)/qwik/api/(types)/FieldStore/index.mdx
@@ -25,6 +25,7 @@ Reactive field store interface with properties and element props for field manag
   - `input` <Property {...properties.input} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `onInput` <Property {...properties.onInput} />

--- a/website/src/routes/(docs)/qwik/api/(types)/FieldStore/properties.ts
+++ b/website/src/routes/(docs)/qwik/api/(types)/FieldStore/properties.ts
@@ -125,6 +125,14 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'isEdited',
+          value: {
+            type: 'custom',
+            name: 'ReadonlySignal',
+            generics: ['boolean'],
+          },
+        },
+        {
           key: 'isDirty',
           value: {
             type: 'custom',
@@ -291,6 +299,13 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: ['boolean'],
+    },
+  },
+  isEdited: {
     type: {
       type: 'custom',
       name: 'ReadonlySignal',

--- a/website/src/routes/(docs)/qwik/api/(types)/FormStore/index.mdx
+++ b/website/src/routes/(docs)/qwik/api/(types)/FormStore/index.mdx
@@ -24,6 +24,7 @@ Form store interface that provides reactive access to the state of a form create
   - `isSubmitted` <Property {...properties.isSubmitted} />
   - `isValidating` <Property {...properties.isValidating} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `errors` <Property {...properties.errors} />

--- a/website/src/routes/(docs)/qwik/api/(types)/FormStore/properties.ts
+++ b/website/src/routes/(docs)/qwik/api/(types)/FormStore/properties.ts
@@ -46,6 +46,14 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'isEdited',
+          value: {
+            type: 'custom',
+            name: 'ReadonlySignal',
+            generics: ['boolean'],
+          },
+        },
+        {
           key: 'isDirty',
           value: {
             type: 'custom',
@@ -112,6 +120,13 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: {
+      type: 'custom',
+      name: 'ReadonlySignal',
+      generics: ['boolean'],
+    },
+  },
+  isEdited: {
     type: {
       type: 'custom',
       name: 'ReadonlySignal',

--- a/website/src/routes/(docs)/react/api/(types)/FieldArrayStore/index.mdx
+++ b/website/src/routes/(docs)/react/api/(types)/FieldArrayStore/index.mdx
@@ -25,5 +25,6 @@ Reactive field array store interface with properties for managing array fields.
   - `items` <Property {...properties.items} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />

--- a/website/src/routes/(docs)/react/api/(types)/FieldArrayStore/properties.ts
+++ b/website/src/routes/(docs)/react/api/(types)/FieldArrayStore/properties.ts
@@ -78,6 +78,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -138,6 +142,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/react/api/(types)/FieldStore/index.mdx
+++ b/website/src/routes/(docs)/react/api/(types)/FieldStore/index.mdx
@@ -25,6 +25,7 @@ Reactive field store interface with properties and element props for field manag
   - `input` <Property {...properties.input} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `onChange` <Property {...properties.onChange} />

--- a/website/src/routes/(docs)/react/api/(types)/FieldStore/properties.ts
+++ b/website/src/routes/(docs)/react/api/(types)/FieldStore/properties.ts
@@ -103,6 +103,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -237,6 +241,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/react/api/(types)/FormStore/index.mdx
+++ b/website/src/routes/(docs)/react/api/(types)/FormStore/index.mdx
@@ -24,6 +24,7 @@ Form store interface that provides reactive access to the state of a form create
   - `isSubmitted` <Property {...properties.isSubmitted} />
   - `isValidating` <Property {...properties.isValidating} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `errors` <Property {...properties.errors} />

--- a/website/src/routes/(docs)/react/api/(types)/FormStore/properties.ts
+++ b/website/src/routes/(docs)/react/api/(types)/FormStore/properties.ts
@@ -30,6 +30,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -70,6 +74,9 @@ export const properties: Record<string, PropertyProps> = {
     type: 'boolean',
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/solid/api/(types)/FieldArrayStore/index.mdx
+++ b/website/src/routes/(docs)/solid/api/(types)/FieldArrayStore/index.mdx
@@ -25,5 +25,6 @@ Reactive field array store interface with properties for managing array fields.
   - `items` <Property {...properties.items} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />

--- a/website/src/routes/(docs)/solid/api/(types)/FieldArrayStore/properties.ts
+++ b/website/src/routes/(docs)/solid/api/(types)/FieldArrayStore/properties.ts
@@ -78,6 +78,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -138,6 +142,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/solid/api/(types)/FieldStore/index.mdx
+++ b/website/src/routes/(docs)/solid/api/(types)/FieldStore/index.mdx
@@ -25,6 +25,7 @@ Reactive field store interface with properties and element props for field manag
   - `input` <Property {...properties.input} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `onInput` <Property {...properties.onInput} />

--- a/website/src/routes/(docs)/solid/api/(types)/FieldStore/properties.ts
+++ b/website/src/routes/(docs)/solid/api/(types)/FieldStore/properties.ts
@@ -103,6 +103,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -237,6 +241,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/solid/api/(types)/FormStore/index.mdx
+++ b/website/src/routes/(docs)/solid/api/(types)/FormStore/index.mdx
@@ -24,6 +24,7 @@ Form store interface that provides reactive access to the state of a form create
   - `isSubmitted` <Property {...properties.isSubmitted} />
   - `isValidating` <Property {...properties.isValidating} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `errors` <Property {...properties.errors} />

--- a/website/src/routes/(docs)/solid/api/(types)/FormStore/properties.ts
+++ b/website/src/routes/(docs)/solid/api/(types)/FormStore/properties.ts
@@ -30,6 +30,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -70,6 +74,9 @@ export const properties: Record<string, PropertyProps> = {
     type: 'boolean',
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/svelte/api/(types)/FieldArrayStore/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(types)/FieldArrayStore/index.mdx
@@ -25,5 +25,6 @@ Reactive field array store interface with properties for managing array fields.
   - `items` <Property {...properties.items} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />

--- a/website/src/routes/(docs)/svelte/api/(types)/FieldArrayStore/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(types)/FieldArrayStore/properties.ts
@@ -78,6 +78,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -138,6 +142,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/svelte/api/(types)/FieldStore/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(types)/FieldStore/index.mdx
@@ -25,6 +25,7 @@ Reactive field store interface with properties and element props for field manag
   - `input` <Property {...properties.input} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `onInput` <Property {...properties.onInput} />

--- a/website/src/routes/(docs)/svelte/api/(types)/FieldStore/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(types)/FieldStore/properties.ts
@@ -103,6 +103,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -237,6 +241,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/svelte/api/(types)/FormStore/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(types)/FormStore/index.mdx
@@ -24,6 +24,7 @@ Form store interface that provides reactive access to the state of a form create
   - `isSubmitted` <Property {...properties.isSubmitted} />
   - `isValidating` <Property {...properties.isValidating} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `errors` <Property {...properties.errors} />

--- a/website/src/routes/(docs)/svelte/api/(types)/FormStore/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(types)/FormStore/properties.ts
@@ -30,6 +30,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -70,6 +74,9 @@ export const properties: Record<string, PropertyProps> = {
     type: 'boolean',
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/vue/api/(types)/FieldArrayStore/index.mdx
+++ b/website/src/routes/(docs)/vue/api/(types)/FieldArrayStore/index.mdx
@@ -25,5 +25,6 @@ Reactive field array store interface with properties for managing array fields.
   - `items` <Property {...properties.items} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />

--- a/website/src/routes/(docs)/vue/api/(types)/FieldArrayStore/properties.ts
+++ b/website/src/routes/(docs)/vue/api/(types)/FieldArrayStore/properties.ts
@@ -78,6 +78,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -138,6 +142,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/vue/api/(types)/FieldStore/index.mdx
+++ b/website/src/routes/(docs)/vue/api/(types)/FieldStore/index.mdx
@@ -25,6 +25,7 @@ Reactive field store interface with properties and element props for field manag
   - `input` <Property {...properties.input} />
   - `errors` <Property {...properties.errors} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `props` <Property {...properties.props} />

--- a/website/src/routes/(docs)/vue/api/(types)/FieldStore/properties.ts
+++ b/website/src/routes/(docs)/vue/api/(types)/FieldStore/properties.ts
@@ -103,6 +103,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -196,6 +200,9 @@ export const properties: Record<string, PropertyProps> = {
     },
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {

--- a/website/src/routes/(docs)/vue/api/(types)/FormStore/index.mdx
+++ b/website/src/routes/(docs)/vue/api/(types)/FormStore/index.mdx
@@ -24,6 +24,7 @@ Form store interface that provides reactive access to the state of a form create
   - `isSubmitted` <Property {...properties.isSubmitted} />
   - `isValidating` <Property {...properties.isValidating} />
   - `isTouched` <Property {...properties.isTouched} />
+  - `isEdited` <Property {...properties.isEdited} />
   - `isDirty` <Property {...properties.isDirty} />
   - `isValid` <Property {...properties.isValid} />
   - `errors` <Property {...properties.errors} />

--- a/website/src/routes/(docs)/vue/api/(types)/FormStore/properties.ts
+++ b/website/src/routes/(docs)/vue/api/(types)/FormStore/properties.ts
@@ -30,6 +30,10 @@ export const properties: Record<string, PropertyProps> = {
           value: 'boolean',
         },
         {
+          key: 'isEdited',
+          value: 'boolean',
+        },
+        {
           key: 'isDirty',
           value: 'boolean',
         },
@@ -70,6 +74,9 @@ export const properties: Record<string, PropertyProps> = {
     type: 'boolean',
   },
   isTouched: {
+    type: 'boolean',
+  },
+  isEdited: {
     type: 'boolean',
   },
   isDirty: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `isEdited` to fields, field arrays, and forms across all frameworks to track if a value was ever changed. This clarifies the difference between touched, dirty, and edited states.

- **New Features**
  - Added `isEdited` to `FieldStore`, `FieldArrayStore`, and `FormStore` and exposed it in `useField`, `useFieldArray`, and `useForm` for React, Preact, Vue, Svelte, Solid, and Qwik.
  - Behavior: set to true on input changes and array mutations (insert/move/remove/replace/swap); not set on focus; remains true after reverting to the initial value; reset to false on form reset (opt-in keep via `reset({ keepEdited: true })`).
  - Core updates: `getFieldBool` supports `isEdited`; `setFieldInput` marks touched and edited; array helpers (`copyItemState`, `resetItemState`, `swapItemState`) handle `isEdited`; methods set array `isEdited` on mutations.
  - Updated types, tests, CHANGELOGs, and website docs (API pages and `Reset*Config`) to include `isEdited` and `keepEdited`.

<sup>Written for commit 7758b8f10f78ed6e0d0cb4a566015cc3b3711a7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/formisch/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

