### PR TITLE
Add new validation guide to docs in website

### DIFF
--- a/website/src/routes/(docs)/methods/api/(methods)/reset/index.mdx
+++ b/website/src/routes/(docs)/methods/api/(methods)/reset/index.mdx
@@ -32,7 +32,7 @@ reset<TSchema, TFieldPath>(form, config);
 
 When called without a config or with `path` set to `undefined`, the entire form is reset. When a `path` is provided, only that specific field and its nested fields are reset.
 
-By default, the form resets to its original initial input. However, you can pass a new `initialInput` in the config to update the form's baseline data. This is useful when remote data has changed and the form needs to reflect the updated values. Combined with `keepInput`, `keepTouched`, `keepErrors`, and `keepSubmitted`, you can update the initial state without overwriting the user's current edits.
+By default, the form resets to its original initial input. However, you can pass a new `initialInput` in the config to update the form's baseline data. This is useful when remote data has changed and the form needs to reflect the updated values. Combined with `keepInput`, `keepTouched`, `keepEdited`, `keepErrors`, and `keepSubmitted`, you can update the initial state without overwriting the user's current edits.
 
 #### More context on dirty tracking
 

--- a/website/src/routes/(docs)/preact/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(advanced-guides)/architecture/index.mdx
@@ -66,7 +66,7 @@ interface Signal<T> {
 }
 ```
 
-Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
+Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isEdited`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
 
 This is the source of the fine-grained reactivity. The shape of the store is pre-allocated at form creation, matching the shape of your Valibot schema, so methods never have to look up paths in a generic object. They walk a typed tree of stores and update individual signals.
 
@@ -117,9 +117,9 @@ The interesting work happens inside `createFormStore`. It calls [`initializeFiel
 - Wrapper schemas such as `v.optional`, `v.nullable`, `v.nonNullable` and `v.lazy` are unwrapped and recursed into.
 - `v.union`, `v.variant` and `v.intersect` initialize every option into the same store, which is what lets you address discriminated fields with a single field path.
 
-At every level, the same three signals are created: `errors`, `isTouched` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
+At every level, the same four signals are created: `errors`, `isTouched`, `isEdited` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
 
-The form object the wrapper returns sits on top of that internal store. Form-level signals are exposed directly, while derived state like `isTouched`, `isDirty` and `isValid` is wrapped in `computed` so it recomputes lazily as the underlying field signals change.
+The form object the wrapper returns sits on top of that internal store. Form-level signals are exposed directly, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is wrapped in `computed` so it recomputes lazily as the underlying field signals change.
 
 The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 

--- a/website/src/routes/(docs)/preact/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(advanced-guides)/validation/index.mdx
@@ -1,0 +1,136 @@
+---
+title: Validation
+description: >-
+  Learn how validation works in Formisch. This guide covers the validate and
+  revalidate config, how to show errors only at the right time using field
+  state like isEdited, and the isValidating state for async validation.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Validation
+
+Formisch validates your form against your Valibot schema — the same one that defines its types. This guide explains how validation runs under the hood, how the `validate` and `revalidate` config control its timing, how to display errors only when they are helpful, and how to react to asynchronous validation with `isValidating`.
+
+## How validation works
+
+Whenever validation is triggered, Formisch parses the **entire form** against your schema in a single pass. It then distributes the resulting issues to the individual fields: every field with an issue receives its error messages, and every field without one is cleared. A field is valid when it has no errors.
+
+> Validation always runs against the whole schema, even when a single field triggers it. This keeps cross-field rules (like a `password` and `confirmPassword` that must match) correct without any extra wiring. The result is still stored per field, so each `<input />` only re-renders when its own errors change.
+
+Because Formisch parses with Valibot's asynchronous API, schemas with async checks (for example, a server-side uniqueness check) work out of the box. While such a check is in flight, the form's `isValidating` state is `true` (see <Link href="#validating-state">below</Link>).
+
+## When validation runs
+
+Two config options control the timing of validation:
+
+- `validate`: when a field is validated for the **first** time. Defaults to `'submit'`.
+- `revalidate`: when a field is validated **again**, once it already has an error or the form has been submitted. Defaults to `'input'`.
+
+Both accept the following modes:
+
+- `'initial'`: immediately, when the form is created (only valid for `validate`, not `revalidate`).
+- `'touch'`: when the field is first focused.
+- `'input'`: on every keystroke.
+- `'change'`: on the field's change event.
+- `'blur'`: when the field loses focus.
+- `'submit'`: only when the form is submitted.
+
+```tsx
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The split between `validate` and `revalidate` is what makes good defaults possible. With the default `validate: 'submit'` and `revalidate: 'input'`, a field stays quiet until the user submits, and only then does it start correcting itself live as the user fixes it. The configuration above (`validate: 'blur'`) is a gentler variant: a field is first checked when the user leaves it, then re-checked on every keystroke once it has an error.
+
+## Showing errors at the right time
+
+`validate` and `revalidate` control **when validation runs** — but not **when errors are shown**. After a validation pass, every invalid field has its `errors` populated, and it is up to you to decide which ones to render.
+
+Showing every error the moment it appears can overwhelm the user, while showing them only after submit forces them to scroll back and fix fields they have already filled out. A balanced approach is to reveal a field's error once the user has actually changed it, and to reveal all remaining errors after the first submit attempt.
+
+Each field exposes several state flags to drive this decision:
+
+- `isTouched`: the field has been focused or changed.
+- `isEdited`: the field's value has been changed (but not merely focused), and stays `true` even if the value is changed back to its initial value.
+- `isDirty`: the field's current value differs from its initial value.
+
+The form additionally exposes `isSubmitted`, which becomes `true` after the first submit attempt. Combining `isEdited` with `isSubmitted` gives the balanced behavior described above:
+
+```tsx
+import { Field, Form, useForm } from '@formisch/preact';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8)),
+});
+
+export default function App() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    validate: 'input',
+  });
+
+  return (
+    <Form of={loginForm}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input.value} type="email" />
+            {(field.isEdited.value || loginForm.isSubmitted.value) &&
+              field.errors.value && <div>{field.errors.value[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <button type="submit">Login</button>
+    </Form>
+  );
+}
+```
+
+`isEdited` is the right flag for this. `isTouched` would reveal the error as soon as the user tabs through a field without changing it, and `isDirty` would hide the error again if the user clears an invalid value back to its initial state. `isEdited` avoids both: it turns on only after a real change and stays on. Pair it with `validate: 'input'` (or `'change'`) so the error appears as soon as the field becomes invalid, and with `isSubmitted` so that the errors of all fields — including the ones the user never touched — become visible after a submit attempt.
+
+## Validating state
+
+When your schema contains asynchronous checks, validation does not resolve instantly. The form's `isValidating` state is `true` while any validation is in flight, which you can use to show a loading indicator or to disable the submit button until validation settles.
+
+```tsx
+import { Form, useForm } from '@formisch/preact';
+import * as v from 'valibot';
+
+const SignUpSchema = v.object({
+  username: v.pipeAsync(
+    v.string(),
+    v.nonEmpty(),
+    v.checkAsync(isUsernameAvailable, 'Username is already taken.')
+  ),
+});
+
+export default function App() {
+  const signUpForm = useForm({
+    schema: SignUpSchema,
+    validate: 'blur',
+  });
+
+  return (
+    <Form of={signUpForm}>
+      {/* fields */}
+      <button type="submit" disabled={signUpForm.isValidating}>
+        {signUpForm.isValidating.value ? 'Checking...' : 'Sign up'}
+      </button>
+    </Form>
+  );
+}
+```
+
+`isValidating` and `isSubmitting` overlap but are not the same. `isValidating` is `true` whenever validation runs — triggered by a field event or as part of a submit. `isSubmitting` is `true` for the entire submission, which covers both validating the form and running your submit handler. So during a submit both are `true` while the form validates, and once validation passes only `isSubmitting` stays `true` while your handler runs.
+
+## Further reading
+
+To process your form's values once they pass validation, see the <Link href="/preact/guides/handle-submission/">handle submission</Link> guide. For working with the fields a user has changed, see the <Link href="/preact/guides/dirty-fields/">dirty fields</Link> guide.

--- a/website/src/routes/(docs)/preact/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(advanced-guides)/validation/index.mdx
@@ -78,7 +78,7 @@ export default function App() {
   });
 
   return (
-    <Form of={loginForm}>
+    <Form of={loginForm} onSubmit={(output) => console.log(output)}>
       <Field of={loginForm} path={['email']}>
         {(field) => (
           <div>
@@ -103,8 +103,9 @@ When your schema contains asynchronous checks, validation does not resolve insta
 ```tsx
 import { Form, useForm } from '@formisch/preact';
 import * as v from 'valibot';
+import { isUsernameAvailable } from '~/api';
 
-const SignUpSchema = v.object({
+const SignUpSchema = v.objectAsync({
   username: v.pipeAsync(
     v.string(),
     v.nonEmpty(),
@@ -119,7 +120,7 @@ export default function App() {
   });
 
   return (
-    <Form of={signUpForm}>
+    <Form of={signUpForm} onSubmit={(output) => console.log(output)}>
       {/* fields */}
       <button type="submit" disabled={signUpForm.isValidating}>
         {signUpForm.isValidating.value ? 'Checking...' : 'Sign up'}

--- a/website/src/routes/(docs)/preact/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(main-concepts)/add-form-fields/index.mdx
@@ -123,6 +123,7 @@ The field store provides access to the following properties (all properties exce
 - `input`: A signal containing the current input value of the field.
 - `errors`: A signal containing an array of error messages if validation fails.
 - `isTouched`: A signal indicating whether the field has been touched.
+- `isEdited`: A signal indicating whether the field's value has been changed.
 - `isDirty`: A signal indicating whether the current input differs from the initial input.
 - `isValid`: A signal indicating whether the field passes all validation rules.
 - `onInput`: Sets the field input value programmatically. Use this when the field cannot be connected to a native HTML element (e.g., complex custom inputs or component libraries that don't expose the underlying element).

--- a/website/src/routes/(docs)/preact/guides/menu.md
+++ b/website/src/routes/(docs)/preact/guides/menu.md
@@ -17,6 +17,7 @@
 
 ## Advanced guides
 
+- [Validation](/preact/guides/validation/)
 - [Special inputs](/preact/guides/special-inputs/)
 - [Controlled fields](/preact/guides/controlled-fields/)
 - [Nested fields](/preact/guides/nested-fields/)

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/architecture/index.mdx
@@ -62,7 +62,7 @@ interface Signal<T> {
 }
 ```
 
-Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
+Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isEdited`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
 
 This is the source of the fine-grained reactivity. The shape of the store is pre-allocated at form creation, matching the shape of your Valibot schema, so methods never have to look up paths in a generic object. They walk a typed tree of stores and update individual signals.
 
@@ -124,9 +124,9 @@ The interesting work happens inside `createFormStore`. It calls [`initializeFiel
 - Wrapper schemas such as `v.optional`, `v.nullable` and `v.nonNullable` are unwrapped and recursed into. (`v.lazy` is not supported in Qwik builds and throws at form creation.)
 - `v.union`, `v.variant` and `v.intersect` initialize every option into the same store, which is what lets you address discriminated fields with a single field path.
 
-At every level, the same three signals are created: `errors`, `isTouched` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
+At every level, the same four signals are created: `errors`, `isTouched`, `isEdited` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
 
-The form object the wrapper returns sits on top of that internal store. Form-level signals are exposed directly, while derived state like `isTouched`, `isDirty` and `isValid` is wrapped in `createComputed$` so it recomputes lazily as the underlying field signals change.
+The form object the wrapper returns sits on top of that internal store. Form-level signals are exposed directly, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is wrapped in `createComputed$` so it recomputes lazily as the underlying field signals change.
 
 The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/validation/index.mdx
@@ -1,0 +1,140 @@
+---
+title: Validation
+description: >-
+  Learn how validation works in Formisch. This guide covers the validate and
+  revalidate config, how to show errors only at the right time using field
+  state like isEdited, and the isValidating state for async validation.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Validation
+
+Formisch validates your form against your Valibot schema — the same one that defines its types. This guide explains how validation runs under the hood, how the `validate` and `revalidate` config control its timing, how to display errors only when they are helpful, and how to react to asynchronous validation with `isValidating`.
+
+## How validation works
+
+Whenever validation is triggered, Formisch parses the **entire form** against your schema in a single pass. It then distributes the resulting issues to the individual fields: every field with an issue receives its error messages, and every field without one is cleared. A field is valid when it has no errors.
+
+> Validation always runs against the whole schema, even when a single field triggers it. This keeps cross-field rules (like a `password` and `confirmPassword` that must match) correct without any extra wiring. The result is still stored per field, so each `<input />` only re-renders when its own errors change.
+
+Because Formisch parses with Valibot's asynchronous API, schemas with async checks (for example, a server-side uniqueness check) work out of the box. While such a check is in flight, the form's `isValidating` state is `true` (see <Link href="#validating-state">below</Link>).
+
+## When validation runs
+
+Two config options control the timing of validation:
+
+- `validate`: when a field is validated for the **first** time. Defaults to `'submit'`.
+- `revalidate`: when a field is validated **again**, once it already has an error or the form has been submitted. Defaults to `'input'`.
+
+Both accept the following modes:
+
+- `'initial'`: immediately, when the form is created (only valid for `validate`, not `revalidate`).
+- `'touch'`: when the field is first focused.
+- `'input'`: on every keystroke.
+- `'change'`: on the field's change event.
+- `'blur'`: when the field loses focus.
+- `'submit'`: only when the form is submitted.
+
+```tsx
+const loginForm = useForm$(() => ({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+}));
+```
+
+The split between `validate` and `revalidate` is what makes good defaults possible. With the default `validate: 'submit'` and `revalidate: 'input'`, a field stays quiet until the user submits, and only then does it start correcting itself live as the user fixes it. The configuration above (`validate: 'blur'`) is a gentler variant: a field is first checked when the user leaves it, then re-checked on every keystroke once it has an error.
+
+## Showing errors at the right time
+
+`validate` and `revalidate` control **when validation runs** — but not **when errors are shown**. After a validation pass, every invalid field has its `errors` populated, and it is up to you to decide which ones to render.
+
+Showing every error the moment it appears can overwhelm the user, while showing them only after submit forces them to scroll back and fix fields they have already filled out. A balanced approach is to reveal a field's error once the user has actually changed it, and to reveal all remaining errors after the first submit attempt.
+
+Each field exposes several state flags to drive this decision:
+
+- `isTouched`: the field has been focused or changed.
+- `isEdited`: the field's value has been changed (but not merely focused), and stays `true` even if the value is changed back to its initial value.
+- `isDirty`: the field's current value differs from its initial value.
+
+The form additionally exposes `isSubmitted`, which becomes `true` after the first submit attempt. Combining `isEdited` with `isSubmitted` gives the balanced behavior described above:
+
+```tsx
+import { Field, Form, useForm$ } from '@formisch/qwik';
+import { component$ } from '@qwik.dev/core';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8)),
+});
+
+export default component$(() => {
+  const loginForm = useForm$(() => ({
+    schema: LoginSchema,
+    validate: 'input',
+  }));
+
+  return (
+    <Form of={loginForm}>
+      <Field
+        of={loginForm}
+        path={['email']}
+        render$={(field) => (
+          <div>
+            <input {...field.props} value={field.input.value} type="email" />
+            {(field.isEdited.value || loginForm.isSubmitted.value) &&
+              field.errors.value && <div>{field.errors.value[0]}</div>}
+          </div>
+        )}
+      />
+      <button type="submit">Login</button>
+    </Form>
+  );
+});
+```
+
+`isEdited` is the right flag for this. `isTouched` would reveal the error as soon as the user tabs through a field without changing it, and `isDirty` would hide the error again if the user clears an invalid value back to its initial state. `isEdited` avoids both: it turns on only after a real change and stays on. Pair it with `validate: 'input'` (or `'change'`) so the error appears as soon as the field becomes invalid, and with `isSubmitted` so that the errors of all fields — including the ones the user never touched — become visible after a submit attempt.
+
+## Validating state
+
+When your schema contains asynchronous checks, validation does not resolve instantly. The form's `isValidating` state is `true` while any validation is in flight, which you can use to show a loading indicator or to disable the submit button until validation settles.
+
+```tsx
+import { Form, useForm$ } from '@formisch/qwik';
+import { component$ } from '@qwik.dev/core';
+import * as v from 'valibot';
+
+const SignUpSchema = v.object({
+  username: v.pipeAsync(
+    v.string(),
+    v.nonEmpty(),
+    v.checkAsync(isUsernameAvailable, 'Username is already taken.')
+  ),
+});
+
+export default component$(() => {
+  const signUpForm = useForm$(() => ({
+    schema: SignUpSchema,
+    validate: 'blur',
+  }));
+
+  return (
+    <Form of={signUpForm}>
+      {/* fields */}
+      <button type="submit" disabled={signUpForm.isValidating.value}>
+        {signUpForm.isValidating.value ? 'Checking...' : 'Sign up'}
+      </button>
+    </Form>
+  );
+});
+```
+
+`isValidating` and `isSubmitting` overlap but are not the same. `isValidating` is `true` whenever validation runs — triggered by a field event or as part of a submit. `isSubmitting` is `true` for the entire submission, which covers both validating the form and running your submit handler. So during a submit both are `true` while the form validates, and once validation passes only `isSubmitting` stays `true` while your handler runs.
+
+## Further reading
+
+To process your form's values once they pass validation, see the <Link href="/qwik/guides/handle-submission/">handle submission</Link> guide. For working with the fields a user has changed, see the <Link href="/qwik/guides/dirty-fields/">dirty fields</Link> guide.

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/validation/index.mdx
@@ -79,7 +79,7 @@ export default component$(() => {
   }));
 
   return (
-    <Form of={loginForm}>
+    <Form of={loginForm} onSubmit$={(output) => console.log(output)}>
       <Field
         of={loginForm}
         path={['email']}
@@ -107,8 +107,9 @@ When your schema contains asynchronous checks, validation does not resolve insta
 import { Form, useForm$ } from '@formisch/qwik';
 import { component$ } from '@qwik.dev/core';
 import * as v from 'valibot';
+import { isUsernameAvailable } from '~/api';
 
-const SignUpSchema = v.object({
+const SignUpSchema = v.objectAsync({
   username: v.pipeAsync(
     v.string(),
     v.nonEmpty(),
@@ -123,7 +124,7 @@ export default component$(() => {
   }));
 
   return (
-    <Form of={signUpForm}>
+    <Form of={signUpForm} onSubmit$={(output) => console.log(output)}>
       {/* fields */}
       <button type="submit" disabled={signUpForm.isValidating.value}>
         {signUpForm.isValidating.value ? 'Checking...' : 'Sign up'}

--- a/website/src/routes/(docs)/qwik/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(main-concepts)/add-form-fields/index.mdx
@@ -139,6 +139,7 @@ The field store provides access to the following properties as signals:
 - `input`: A signal containing the current input value of the field (access with `.value`).
 - `errors`: A signal containing an array of error messages if validation fails (access with `.value`).
 - `isTouched`: A signal indicating whether the field has been touched (access with `.value`).
+- `isEdited`: A signal indicating whether the field's value has been changed (access with `.value`).
 - `isDirty`: A signal indicating whether the current input differs from the initial input (access with `.value`).
 - `isValid`: A signal indicating whether the field passes all validation rules (access with `.value`).
 - `onInput`: Sets the field input value programmatically. Use this when the field cannot be connected to a native HTML element (e.g., complex custom inputs or component libraries that don't expose the underlying element).

--- a/website/src/routes/(docs)/qwik/guides/menu.md
+++ b/website/src/routes/(docs)/qwik/guides/menu.md
@@ -17,6 +17,7 @@
 
 ## Advanced guides
 
+- [Validation](/qwik/guides/validation/)
 - [Special inputs](/qwik/guides/special-inputs/)
 - [Controlled fields](/qwik/guides/controlled-fields/)
 - [Nested fields](/qwik/guides/nested-fields/)

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/architecture/index.mdx
@@ -79,7 +79,7 @@ interface Signal<T> {
 }
 ```
 
-Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
+Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isEdited`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
 
 This is the source of the fine-grained reactivity. The shape of the store is pre-allocated at form creation, matching the shape of your Valibot schema, so methods never have to look up paths in a generic object. They walk a typed tree of stores and update individual signals.
 
@@ -120,9 +120,9 @@ Next, `createFormStore` calls [`initializeFieldStore`](https://github.com/open-c
 - Wrapper schemas such as `v.optional`, `v.nullable`, `v.nonNullable` and `v.lazy` are unwrapped and recursed into.
 - `v.union`, `v.variant` and `v.intersect` initialize every option into the same store, which is what lets you address discriminated fields with a single field path.
 
-At every level, the same three signals are created: `errors`, `isTouched` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
+At every level, the same four signals are created: `errors`, `isTouched`, `isEdited` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
 
-Finally, the React wrapper builds the public form store you actually receive. It's a small object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isDirty` and `isValid` is computed on demand from the field tree. The whole object is memoized so it survives re-renders:
+Finally, the React wrapper builds the public form store you actually receive. It's a small object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is computed on demand from the field tree. The whole object is memoized so it survives re-renders:
 
 ```ts
 return useMemo(

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/validation/index.mdx
@@ -1,0 +1,137 @@
+---
+title: Validation
+description: >-
+  Learn how validation works in Formisch. This guide covers the validate and
+  revalidate config, how to show errors only at the right time using field
+  state like isEdited, and the isValidating state for async validation.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Validation
+
+Formisch validates your form against your Valibot schema — the same one that defines its types. This guide explains how validation runs under the hood, how the `validate` and `revalidate` config control its timing, how to display errors only when they are helpful, and how to react to asynchronous validation with `isValidating`.
+
+## How validation works
+
+Whenever validation is triggered, Formisch parses the **entire form** against your schema in a single pass. It then distributes the resulting issues to the individual fields: every field with an issue receives its error messages, and every field without one is cleared. A field is valid when it has no errors.
+
+> Validation always runs against the whole schema, even when a single field triggers it. This keeps cross-field rules (like a `password` and `confirmPassword` that must match) correct without any extra wiring. The result is still stored per field, so each `<input />` only re-renders when its own errors change.
+
+Because Formisch parses with Valibot's asynchronous API, schemas with async checks (for example, a server-side uniqueness check) work out of the box. While such a check is in flight, the form's `isValidating` state is `true` (see <Link href="#validating-state">below</Link>).
+
+## When validation runs
+
+Two config options control the timing of validation:
+
+- `validate`: when a field is validated for the **first** time. Defaults to `'submit'`.
+- `revalidate`: when a field is validated **again**, once it already has an error or the form has been submitted. Defaults to `'input'`.
+
+Both accept the following modes:
+
+- `'initial'`: immediately, when the form is created (only valid for `validate`, not `revalidate`).
+- `'touch'`: when the field is first focused.
+- `'input'`: on every keystroke.
+- `'change'`: on the field's change event.
+- `'blur'`: when the field loses focus.
+- `'submit'`: only when the form is submitted.
+
+```tsx
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The split between `validate` and `revalidate` is what makes good defaults possible. With the default `validate: 'submit'` and `revalidate: 'input'`, a field stays quiet until the user submits, and only then does it start correcting itself live as the user fixes it. The configuration above (`validate: 'blur'`) is a gentler variant: a field is first checked when the user leaves it, then re-checked on every keystroke once it has an error.
+
+## Showing errors at the right time
+
+`validate` and `revalidate` control **when validation runs** — but not **when errors are shown**. After a validation pass, every invalid field has its `errors` populated, and it is up to you to decide which ones to render.
+
+Showing every error the moment it appears can overwhelm the user, while showing them only after submit forces them to scroll back and fix fields they have already filled out. A balanced approach is to reveal a field's error once the user has actually changed it, and to reveal all remaining errors after the first submit attempt.
+
+Each field exposes several state flags to drive this decision:
+
+- `isTouched`: the field has been focused or changed.
+- `isEdited`: the field's value has been changed (but not merely focused), and stays `true` even if the value is changed back to its initial value.
+- `isDirty`: the field's current value differs from its initial value.
+
+The form additionally exposes `isSubmitted`, which becomes `true` after the first submit attempt. Combining `isEdited` with `isSubmitted` gives the balanced behavior described above:
+
+```tsx
+import { Field, Form, useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8)),
+});
+
+export default function App() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    validate: 'input',
+  });
+
+  return (
+    <Form of={loginForm}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="email" />
+            {(field.isEdited || loginForm.isSubmitted) && field.errors && (
+              <div>{field.errors[0]}</div>
+            )}
+          </div>
+        )}
+      </Field>
+      <button type="submit">Login</button>
+    </Form>
+  );
+}
+```
+
+`isEdited` is the right flag for this. `isTouched` would reveal the error as soon as the user tabs through a field without changing it, and `isDirty` would hide the error again if the user clears an invalid value back to its initial state. `isEdited` avoids both: it turns on only after a real change and stays on. Pair it with `validate: 'input'` (or `'change'`) so the error appears as soon as the field becomes invalid, and with `isSubmitted` so that the errors of all fields — including the ones the user never touched — become visible after a submit attempt.
+
+## Validating state
+
+When your schema contains asynchronous checks, validation does not resolve instantly. The form's `isValidating` state is `true` while any validation is in flight, which you can use to show a loading indicator or to disable the submit button until validation settles.
+
+```tsx
+import { Form, useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const SignUpSchema = v.object({
+  username: v.pipeAsync(
+    v.string(),
+    v.nonEmpty(),
+    v.checkAsync(isUsernameAvailable, 'Username is already taken.')
+  ),
+});
+
+export default function App() {
+  const signUpForm = useForm({
+    schema: SignUpSchema,
+    validate: 'blur',
+  });
+
+  return (
+    <Form of={signUpForm}>
+      {/* fields */}
+      <button type="submit" disabled={signUpForm.isValidating}>
+        {signUpForm.isValidating ? 'Checking...' : 'Sign up'}
+      </button>
+    </Form>
+  );
+}
+```
+
+`isValidating` and `isSubmitting` overlap but are not the same. `isValidating` is `true` whenever validation runs — triggered by a field event or as part of a submit. `isSubmitting` is `true` for the entire submission, which covers both validating the form and running your submit handler. So during a submit both are `true` while the form validates, and once validation passes only `isSubmitting` stays `true` while your handler runs.
+
+## Further reading
+
+To process your form's values once they pass validation, see the <Link href="/react/guides/handle-submission/">handle submission</Link> guide. For working with the fields a user has changed, see the <Link href="/react/guides/dirty-fields/">dirty fields</Link> guide.

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/validation/index.mdx
@@ -78,7 +78,7 @@ export default function App() {
   });
 
   return (
-    <Form of={loginForm}>
+    <Form of={loginForm} onSubmit={(output) => console.log(output)}>
       <Field of={loginForm} path={['email']}>
         {(field) => (
           <div>
@@ -104,8 +104,9 @@ When your schema contains asynchronous checks, validation does not resolve insta
 ```tsx
 import { Form, useForm } from '@formisch/react';
 import * as v from 'valibot';
+import { isUsernameAvailable } from '~/api';
 
-const SignUpSchema = v.object({
+const SignUpSchema = v.objectAsync({
   username: v.pipeAsync(
     v.string(),
     v.nonEmpty(),
@@ -120,7 +121,7 @@ export default function App() {
   });
 
   return (
-    <Form of={signUpForm}>
+    <Form of={signUpForm} onSubmit={(output) => console.log(output)}>
       {/* fields */}
       <button type="submit" disabled={signUpForm.isValidating}>
         {signUpForm.isValidating ? 'Checking...' : 'Sign up'}

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/add-form-fields/index.mdx
@@ -123,6 +123,7 @@ The field store provides access to the following properties. They are plain valu
 - `input`: The current input value of the field.
 - `errors`: The current array of error messages if validation fails.
 - `isTouched`: Whether the field has been touched.
+- `isEdited`: Whether the field's value has been changed.
 - `isDirty`: Whether the current input differs from the initial input.
 - `isValid`: Whether the field passes all validation rules.
 - `onChange`: Sets the field input value programmatically. Use this when the field cannot be connected to a native HTML element (e.g., complex custom inputs or component libraries that don't expose the underlying element).

--- a/website/src/routes/(docs)/react/guides/menu.md
+++ b/website/src/routes/(docs)/react/guides/menu.md
@@ -18,6 +18,7 @@
 
 ## Advanced guides
 
+- [Validation](/react/guides/validation/)
 - [Special inputs](/react/guides/special-inputs/)
 - [Controlled fields](/react/guides/controlled-fields/)
 - [Nested fields](/react/guides/nested-fields/)

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/architecture/index.mdx
@@ -74,7 +74,7 @@ interface Signal<T> {
 }
 ```
 
-Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the consumers of that one signal (typically a single `<input />`) re-render.
+Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isEdited`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the consumers of that one signal (typically a single `<input />`) re-render.
 
 This is the source of the fine-grained reactivity. The shape of the store is pre-allocated at form creation, matching the shape of your Valibot schema, so methods never have to look up paths in a generic object. They walk a typed tree of stores and update individual signals.
 
@@ -110,9 +110,9 @@ Next, `createFormStore` calls [`initializeFieldStore`](https://github.com/open-c
 - Wrapper schemas such as `v.optional`, `v.nullable`, `v.nonNullable` and `v.lazy` are unwrapped and recursed into.
 - `v.union`, `v.variant` and `v.intersect` initialize every option into the same store, which is what lets you address discriminated fields with a single field path.
 
-At every level, the same three signals are created: `errors`, `isTouched` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
+At every level, the same four signals are created: `errors`, `isTouched`, `isEdited` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
 
-Finally, the Solid wrapper builds the public form store you actually receive. It's a small reactive object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isDirty` and `isValid` is wrapped in `createMemo` so it recomputes lazily as the underlying field signals change:
+Finally, the Solid wrapper builds the public form store you actually receive. It's a small reactive object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is wrapped in `createMemo` so it recomputes lazily as the underlying field signals change:
 
 ```ts
 const getIsTouched = createMemo(() =>

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/validation/index.mdx
@@ -1,0 +1,137 @@
+---
+title: Validation
+description: >-
+  Learn how validation works in Formisch. This guide covers the validate and
+  revalidate config, how to show errors only at the right time using field
+  state like isEdited, and the isValidating state for async validation.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Validation
+
+Formisch validates your form against your Valibot schema — the same one that defines its types. This guide explains how validation runs under the hood, how the `validate` and `revalidate` config control its timing, how to display errors only when they are helpful, and how to react to asynchronous validation with `isValidating`.
+
+## How validation works
+
+Whenever validation is triggered, Formisch parses the **entire form** against your schema in a single pass. It then distributes the resulting issues to the individual fields: every field with an issue receives its error messages, and every field without one is cleared. A field is valid when it has no errors.
+
+> Validation always runs against the whole schema, even when a single field triggers it. This keeps cross-field rules (like a `password` and `confirmPassword` that must match) correct without any extra wiring. The result is still stored per field, so each `<input />` only re-renders when its own errors change.
+
+Because Formisch parses with Valibot's asynchronous API, schemas with async checks (for example, a server-side uniqueness check) work out of the box. While such a check is in flight, the form's `isValidating` state is `true` (see <Link href="#validating-state">below</Link>).
+
+## When validation runs
+
+Two config options control the timing of validation:
+
+- `validate`: when a field is validated for the **first** time. Defaults to `'submit'`.
+- `revalidate`: when a field is validated **again**, once it already has an error or the form has been submitted. Defaults to `'input'`.
+
+Both accept the following modes:
+
+- `'initial'`: immediately, when the form is created (only valid for `validate`, not `revalidate`).
+- `'touch'`: when the field is first focused.
+- `'input'`: on every keystroke.
+- `'change'`: on the field's change event.
+- `'blur'`: when the field loses focus.
+- `'submit'`: only when the form is submitted.
+
+```tsx
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The split between `validate` and `revalidate` is what makes good defaults possible. With the default `validate: 'submit'` and `revalidate: 'input'`, a field stays quiet until the user submits, and only then does it start correcting itself live as the user fixes it. The configuration above (`validate: 'blur'`) is a gentler variant: a field is first checked when the user leaves it, then re-checked on every keystroke once it has an error.
+
+## Showing errors at the right time
+
+`validate` and `revalidate` control **when validation runs** — but not **when errors are shown**. After a validation pass, every invalid field has its `errors` populated, and it is up to you to decide which ones to render.
+
+Showing every error the moment it appears can overwhelm the user, while showing them only after submit forces them to scroll back and fix fields they have already filled out. A balanced approach is to reveal a field's error once the user has actually changed it, and to reveal all remaining errors after the first submit attempt.
+
+Each field exposes several state flags to drive this decision:
+
+- `isTouched`: the field has been focused or changed.
+- `isEdited`: the field's value has been changed (but not merely focused), and stays `true` even if the value is changed back to its initial value.
+- `isDirty`: the field's current value differs from its initial value.
+
+The form additionally exposes `isSubmitted`, which becomes `true` after the first submit attempt. Combining `isEdited` with `isSubmitted` gives the balanced behavior described above:
+
+```tsx
+import { createForm, Field, Form } from '@formisch/solid';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8)),
+});
+
+export default function App() {
+  const loginForm = createForm({
+    schema: LoginSchema,
+    validate: 'input',
+  });
+
+  return (
+    <Form of={loginForm}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="email" />
+            {(field.isEdited || loginForm.isSubmitted) && field.errors && (
+              <div>{field.errors[0]}</div>
+            )}
+          </div>
+        )}
+      </Field>
+      <button type="submit">Login</button>
+    </Form>
+  );
+}
+```
+
+`isEdited` is the right flag for this. `isTouched` would reveal the error as soon as the user tabs through a field without changing it, and `isDirty` would hide the error again if the user clears an invalid value back to its initial state. `isEdited` avoids both: it turns on only after a real change and stays on. Pair it with `validate: 'input'` (or `'change'`) so the error appears as soon as the field becomes invalid, and with `isSubmitted` so that the errors of all fields — including the ones the user never touched — become visible after a submit attempt.
+
+## Validating state
+
+When your schema contains asynchronous checks, validation does not resolve instantly. The form's `isValidating` state is `true` while any validation is in flight, which you can use to show a loading indicator or to disable the submit button until validation settles.
+
+```tsx
+import { createForm, Form } from '@formisch/solid';
+import * as v from 'valibot';
+
+const SignUpSchema = v.object({
+  username: v.pipeAsync(
+    v.string(),
+    v.nonEmpty(),
+    v.checkAsync(isUsernameAvailable, 'Username is already taken.')
+  ),
+});
+
+export default function App() {
+  const signUpForm = createForm({
+    schema: SignUpSchema,
+    validate: 'blur',
+  });
+
+  return (
+    <Form of={signUpForm}>
+      {/* fields */}
+      <button type="submit" disabled={signUpForm.isValidating}>
+        {signUpForm.isValidating ? 'Checking...' : 'Sign up'}
+      </button>
+    </Form>
+  );
+}
+```
+
+`isValidating` and `isSubmitting` overlap but are not the same. `isValidating` is `true` whenever validation runs — triggered by a field event or as part of a submit. `isSubmitting` is `true` for the entire submission, which covers both validating the form and running your submit handler. So during a submit both are `true` while the form validates, and once validation passes only `isSubmitting` stays `true` while your handler runs.
+
+## Further reading
+
+To process your form's values once they pass validation, see the <Link href="/solid/guides/handle-submission/">handle submission</Link> guide. For working with the fields a user has changed, see the <Link href="/solid/guides/dirty-fields/">dirty fields</Link> guide.

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/validation/index.mdx
@@ -78,7 +78,7 @@ export default function App() {
   });
 
   return (
-    <Form of={loginForm}>
+    <Form of={loginForm} onSubmit={(output) => console.log(output)}>
       <Field of={loginForm} path={['email']}>
         {(field) => (
           <div>
@@ -104,8 +104,9 @@ When your schema contains asynchronous checks, validation does not resolve insta
 ```tsx
 import { createForm, Form } from '@formisch/solid';
 import * as v from 'valibot';
+import { isUsernameAvailable } from '~/api';
 
-const SignUpSchema = v.object({
+const SignUpSchema = v.objectAsync({
   username: v.pipeAsync(
     v.string(),
     v.nonEmpty(),
@@ -120,7 +121,7 @@ export default function App() {
   });
 
   return (
-    <Form of={signUpForm}>
+    <Form of={signUpForm} onSubmit={(output) => console.log(output)}>
       {/* fields */}
       <button type="submit" disabled={signUpForm.isValidating}>
         {signUpForm.isValidating ? 'Checking...' : 'Sign up'}

--- a/website/src/routes/(docs)/solid/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(main-concepts)/add-form-fields/index.mdx
@@ -123,6 +123,7 @@ The field store provides access to the following properties:
 - `input`: The current input value of the field.
 - `errors`: An array of error messages if validation fails.
 - `isTouched`: Whether the field has been touched.
+- `isEdited`: Whether the field's value has been changed.
 - `isDirty`: Whether the current input differs from the initial input.
 - `isValid`: Whether the field passes all validation rules.
 - `onInput`: Sets the field input value programmatically. Use this when the field cannot be connected to a native HTML element (e.g., complex custom inputs or component libraries that don't expose the underlying element).

--- a/website/src/routes/(docs)/solid/guides/menu.md
+++ b/website/src/routes/(docs)/solid/guides/menu.md
@@ -18,6 +18,7 @@
 
 ## Advanced guides
 
+- [Validation](/solid/guides/validation/)
 - [Special inputs](/solid/guides/special-inputs/)
 - [Controlled fields](/solid/guides/controlled-fields/)
 - [Nested fields](/solid/guides/nested-fields/)

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/architecture/index.mdx
@@ -72,7 +72,7 @@ interface Signal<T> {
 }
 ```
 
-Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
+Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isEdited`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
 
 This is the source of the fine-grained reactivity. The shape of the store is pre-allocated at form creation, matching the shape of your Valibot schema, so methods never have to look up paths in a generic object. They walk a typed tree of stores and update individual signals.
 
@@ -110,9 +110,9 @@ Next, `createFormStore` calls [`initializeFieldStore`](https://github.com/open-c
 - Wrapper schemas such as `v.optional`, `v.nullable`, `v.nonNullable` and `v.lazy` are unwrapped and recursed into.
 - `v.union`, `v.variant` and `v.intersect` initialize every option into the same store, which is what lets you address discriminated fields with a single field path.
 
-At every level, the same three signals are created: `errors`, `isTouched` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
+At every level, the same four signals are created: `errors`, `isTouched`, `isEdited` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
 
-Finally, the Svelte wrapper builds the public form store you actually receive. It's a small reactive object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isDirty` and `isValid` is declared with `$derived` so it recomputes lazily as the underlying field signals change:
+Finally, the Svelte wrapper builds the public form store you actually receive. It's a small reactive object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is declared with `$derived` so it recomputes lazily as the underlying field signals change:
 
 ```ts
 const isTouched = $derived(getFieldBool(internalFormStore, 'isTouched'));

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/validation/index.mdx
@@ -78,7 +78,7 @@ The form additionally exposes `isSubmitted`, which becomes `true` after the firs
   });
 </script>
 
-<Form of={loginForm}>
+<Form of={loginForm} onsubmit={(output) => console.log(output)}>
   <Field of={loginForm} path={['email']}>
     {#snippet children(field)}
       <input {...field.props} value={field.input} type="email" />
@@ -101,8 +101,9 @@ When your schema contains asynchronous checks, validation does not resolve insta
 <script lang="ts">
   import { createForm, Form } from '@formisch/svelte';
   import * as v from 'valibot';
+  import { isUsernameAvailable } from '~/api';
 
-  const SignUpSchema = v.object({
+  const SignUpSchema = v.objectAsync({
     username: v.pipeAsync(
       v.string(),
       v.nonEmpty(),
@@ -116,7 +117,7 @@ When your schema contains asynchronous checks, validation does not resolve insta
   });
 </script>
 
-<Form of={signUpForm}>
+<Form of={signUpForm} onsubmit={(output) => console.log(output)}>
   <!-- fields -->
   <button type="submit" disabled={signUpForm.isValidating}>
     {signUpForm.isValidating ? 'Checking...' : 'Sign up'}

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/validation/index.mdx
@@ -1,0 +1,131 @@
+---
+title: Validation
+description: >-
+  Learn how validation works in Formisch. This guide covers the validate and
+  revalidate config, how to show errors only at the right time using field
+  state like isEdited, and the isValidating state for async validation.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Validation
+
+Formisch validates your form against your Valibot schema — the same one that defines its types. This guide explains how validation runs under the hood, how the `validate` and `revalidate` config control its timing, how to display errors only when they are helpful, and how to react to asynchronous validation with `isValidating`.
+
+## How validation works
+
+Whenever validation is triggered, Formisch parses the **entire form** against your schema in a single pass. It then distributes the resulting issues to the individual fields: every field with an issue receives its error messages, and every field without one is cleared. A field is valid when it has no errors.
+
+> Validation always runs against the whole schema, even when a single field triggers it. This keeps cross-field rules (like a `password` and `confirmPassword` that must match) correct without any extra wiring. The result is still stored per field, so each `<input />` only re-renders when its own errors change.
+
+Because Formisch parses with Valibot's asynchronous API, schemas with async checks (for example, a server-side uniqueness check) work out of the box. While such a check is in flight, the form's `isValidating` state is `true` (see <Link href="#validating-state">below</Link>).
+
+## When validation runs
+
+Two config options control the timing of validation:
+
+- `validate`: when a field is validated for the **first** time. Defaults to `'submit'`.
+- `revalidate`: when a field is validated **again**, once it already has an error or the form has been submitted. Defaults to `'input'`.
+
+Both accept the following modes:
+
+- `'initial'`: immediately, when the form is created (only valid for `validate`, not `revalidate`).
+- `'touch'`: when the field is first focused.
+- `'input'`: on every keystroke.
+- `'change'`: on the field's change event.
+- `'blur'`: when the field loses focus.
+- `'submit'`: only when the form is submitted.
+
+```ts
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The split between `validate` and `revalidate` is what makes good defaults possible. With the default `validate: 'submit'` and `revalidate: 'input'`, a field stays quiet until the user submits, and only then does it start correcting itself live as the user fixes it. The configuration above (`validate: 'blur'`) is a gentler variant: a field is first checked when the user leaves it, then re-checked on every keystroke once it has an error.
+
+## Showing errors at the right time
+
+`validate` and `revalidate` control **when validation runs** — but not **when errors are shown**. After a validation pass, every invalid field has its `errors` populated, and it is up to you to decide which ones to render.
+
+Showing every error the moment it appears can overwhelm the user, while showing them only after submit forces them to scroll back and fix fields they have already filled out. A balanced approach is to reveal a field's error once the user has actually changed it, and to reveal all remaining errors after the first submit attempt.
+
+Each field exposes several state flags to drive this decision:
+
+- `isTouched`: the field has been focused or changed.
+- `isEdited`: the field's value has been changed (but not merely focused), and stays `true` even if the value is changed back to its initial value.
+- `isDirty`: the field's current value differs from its initial value.
+
+The form additionally exposes `isSubmitted`, which becomes `true` after the first submit attempt. Combining `isEdited` with `isSubmitted` gives the balanced behavior described above:
+
+```svelte
+<script lang="ts">
+  import { createForm, Field, Form } from '@formisch/svelte';
+  import * as v from 'valibot';
+
+  const LoginSchema = v.object({
+    email: v.pipe(v.string(), v.email()),
+    password: v.pipe(v.string(), v.minLength(8)),
+  });
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    validate: 'input',
+  });
+</script>
+
+<Form of={loginForm}>
+  <Field of={loginForm} path={['email']}>
+    {#snippet children(field)}
+      <input {...field.props} value={field.input} type="email" />
+      {#if (field.isEdited || loginForm.isSubmitted) && field.errors}
+        <div>{field.errors[0]}</div>
+      {/if}
+    {/snippet}
+  </Field>
+  <button type="submit">Login</button>
+</Form>
+```
+
+`isEdited` is the right flag for this. `isTouched` would reveal the error as soon as the user tabs through a field without changing it, and `isDirty` would hide the error again if the user clears an invalid value back to its initial state. `isEdited` avoids both: it turns on only after a real change and stays on. Pair it with `validate: 'input'` (or `'change'`) so the error appears as soon as the field becomes invalid, and with `isSubmitted` so that the errors of all fields — including the ones the user never touched — become visible after a submit attempt.
+
+## Validating state
+
+When your schema contains asynchronous checks, validation does not resolve instantly. The form's `isValidating` state is `true` while any validation is in flight, which you can use to show a loading indicator or to disable the submit button until validation settles.
+
+```svelte
+<script lang="ts">
+  import { createForm, Form } from '@formisch/svelte';
+  import * as v from 'valibot';
+
+  const SignUpSchema = v.object({
+    username: v.pipeAsync(
+      v.string(),
+      v.nonEmpty(),
+      v.checkAsync(isUsernameAvailable, 'Username is already taken.')
+    ),
+  });
+
+  const signUpForm = createForm({
+    schema: SignUpSchema,
+    validate: 'blur',
+  });
+</script>
+
+<Form of={signUpForm}>
+  <!-- fields -->
+  <button type="submit" disabled={signUpForm.isValidating}>
+    {signUpForm.isValidating ? 'Checking...' : 'Sign up'}
+  </button>
+</Form>
+```
+
+`isValidating` and `isSubmitting` overlap but are not the same. `isValidating` is `true` whenever validation runs — triggered by a field event or as part of a submit. `isSubmitting` is `true` for the entire submission, which covers both validating the form and running your submit handler. So during a submit both are `true` while the form validates, and once validation passes only `isSubmitting` stays `true` while your handler runs.
+
+## Further reading
+
+To process your form's values once they pass validation, see the <Link href="/svelte/guides/handle-submission/">handle submission</Link> guide. For working with the fields a user has changed, see the <Link href="/svelte/guides/dirty-fields/">dirty fields</Link> guide.

--- a/website/src/routes/(docs)/svelte/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(main-concepts)/add-form-fields/index.mdx
@@ -129,6 +129,7 @@ The field store provides access to the following properties:
 - `input`: The current input value of the field.
 - `errors`: An array of error messages if validation fails.
 - `isTouched`: Whether the field has been touched.
+- `isEdited`: Whether the field's value has been changed.
 - `isDirty`: Whether the current input differs from the initial input.
 - `isValid`: Whether the field passes all validation rules.
 - `onInput`: Sets the field input value programmatically. Use this when the field cannot be connected to a native HTML element (e.g., complex custom inputs or component libraries that don't expose the underlying element).

--- a/website/src/routes/(docs)/svelte/guides/menu.md
+++ b/website/src/routes/(docs)/svelte/guides/menu.md
@@ -18,6 +18,7 @@
 
 ## Advanced guides
 
+- [Validation](/svelte/guides/validation/)
 - [Special inputs](/svelte/guides/special-inputs/)
 - [Controlled fields](/svelte/guides/controlled-fields/)
 - [Nested fields](/svelte/guides/nested-fields/)

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/architecture/index.mdx
@@ -62,7 +62,7 @@ interface Signal<T> {
 }
 ```
 
-Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
+Reads track, writes notify. There is no central store object that gets diffed and no equality check on the consumer side. Each field carries its own signals for `errors`, `isTouched`, `isEdited`, `isDirty`, plus an `input` signal for value fields and a `children` collection for arrays and objects. When you call `setInput(form, { path: ['email'], input: 'a@b.c' })`, only the `input` signal of that one field is written, so only the components that read that one signal (typically a single `<input />`) re-render.
 
 This is the source of the fine-grained reactivity. The shape of the store is pre-allocated at form creation, matching the shape of your Valibot schema, so methods never have to look up paths in a generic object. They walk a typed tree of stores and update individual signals.
 
@@ -100,9 +100,9 @@ Next, `createFormStore` calls [`initializeFieldStore`](https://github.com/open-c
 - Wrapper schemas such as `v.optional`, `v.nullable`, `v.nonNullable` and `v.lazy` are unwrapped and recursed into.
 - `v.union`, `v.variant` and `v.intersect` initialize every option into the same store, which is what lets you address discriminated fields with a single field path.
 
-At every level, the same three signals are created: `errors`, `isTouched` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
+At every level, the same four signals are created: `errors`, `isTouched`, `isEdited` and `isDirty`. Once the field tree is built, three more signals are added to the form root: `isSubmitting`, `isSubmitted` and `isValidating`.
 
-Finally, the Vue wrapper builds the public form store you actually receive. It's a small reactive object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isDirty` and `isValid` is wrapped in `computed` so it recomputes lazily as the underlying field signals change:
+Finally, the Vue wrapper builds the public form store you actually receive. It's a small reactive object that sits on top of the internal store: form-level signals are exposed through getters that read `internalFormStore.isSubmitting.value` and friends, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is wrapped in `computed` so it recomputes lazily as the underlying field signals change:
 
 ```ts
 const isTouched = computed(() =>

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/validation/index.mdx
@@ -79,7 +79,7 @@ const loginForm = useForm({
 </script>
 
 <template>
-  <Form :of="loginForm">
+  <Form :of="loginForm" @submit="(output) => console.log(output)">
     <Field :of="loginForm" :path="['email']" v-slot="field">
       <input v-model="field.input" v-bind="field.props" type="email" />
       <div v-if="(field.isEdited || loginForm.isSubmitted) && field.errors">
@@ -101,8 +101,9 @@ When your schema contains asynchronous checks, validation does not resolve insta
 <script setup lang="ts">
 import { Form, useForm } from '@formisch/vue';
 import * as v from 'valibot';
+import { isUsernameAvailable } from '~/api';
 
-const SignUpSchema = v.object({
+const SignUpSchema = v.objectAsync({
   username: v.pipeAsync(
     v.string(),
     v.nonEmpty(),
@@ -117,7 +118,7 @@ const signUpForm = useForm({
 </script>
 
 <template>
-  <Form :of="signUpForm">
+  <Form :of="signUpForm" @submit="(output) => console.log(output)">
     <!-- fields -->
     <button type="submit" :disabled="signUpForm.isValidating">
       {{ signUpForm.isValidating ? 'Checking...' : 'Sign up' }}

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/validation/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/validation/index.mdx
@@ -1,0 +1,133 @@
+---
+title: Validation
+description: >-
+  Learn how validation works in Formisch. This guide covers the validate and
+  revalidate config, how to show errors only at the right time using field
+  state like isEdited, and the isValidating state for async validation.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Validation
+
+Formisch validates your form against your Valibot schema — the same one that defines its types. This guide explains how validation runs under the hood, how the `validate` and `revalidate` config control its timing, how to display errors only when they are helpful, and how to react to asynchronous validation with `isValidating`.
+
+## How validation works
+
+Whenever validation is triggered, Formisch parses the **entire form** against your schema in a single pass. It then distributes the resulting issues to the individual fields: every field with an issue receives its error messages, and every field without one is cleared. A field is valid when it has no errors.
+
+> Validation always runs against the whole schema, even when a single field triggers it. This keeps cross-field rules (like a `password` and `confirmPassword` that must match) correct without any extra wiring. The result is still stored per field, so each `<input />` only re-renders when its own errors change.
+
+Because Formisch parses with Valibot's asynchronous API, schemas with async checks (for example, a server-side uniqueness check) work out of the box. While such a check is in flight, the form's `isValidating` state is `true` (see <Link href="#validating-state">below</Link>).
+
+## When validation runs
+
+Two config options control the timing of validation:
+
+- `validate`: when a field is validated for the **first** time. Defaults to `'submit'`.
+- `revalidate`: when a field is validated **again**, once it already has an error or the form has been submitted. Defaults to `'input'`.
+
+Both accept the following modes:
+
+- `'initial'`: immediately, when the form is created (only valid for `validate`, not `revalidate`).
+- `'touch'`: when the field is first focused.
+- `'input'`: on every keystroke.
+- `'change'`: on the field's change event.
+- `'blur'`: when the field loses focus.
+- `'submit'`: only when the form is submitted.
+
+```ts
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The split between `validate` and `revalidate` is what makes good defaults possible. With the default `validate: 'submit'` and `revalidate: 'input'`, a field stays quiet until the user submits, and only then does it start correcting itself live as the user fixes it. The configuration above (`validate: 'blur'`) is a gentler variant: a field is first checked when the user leaves it, then re-checked on every keystroke once it has an error.
+
+## Showing errors at the right time
+
+`validate` and `revalidate` control **when validation runs** — but not **when errors are shown**. After a validation pass, every invalid field has its `errors` populated, and it is up to you to decide which ones to render.
+
+Showing every error the moment it appears can overwhelm the user, while showing them only after submit forces them to scroll back and fix fields they have already filled out. A balanced approach is to reveal a field's error once the user has actually changed it, and to reveal all remaining errors after the first submit attempt.
+
+Each field exposes several state flags to drive this decision:
+
+- `isTouched`: the field has been focused or changed.
+- `isEdited`: the field's value has been changed (but not merely focused), and stays `true` even if the value is changed back to its initial value.
+- `isDirty`: the field's current value differs from its initial value.
+
+The form additionally exposes `isSubmitted`, which becomes `true` after the first submit attempt. Combining `isEdited` with `isSubmitted` gives the balanced behavior described above:
+
+```vue
+<script setup lang="ts">
+import { Field, Form, useForm } from '@formisch/vue';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8)),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'input',
+});
+</script>
+
+<template>
+  <Form :of="loginForm">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <input v-model="field.input" v-bind="field.props" type="email" />
+      <div v-if="(field.isEdited || loginForm.isSubmitted) && field.errors">
+        {{ field.errors[0] }}
+      </div>
+    </Field>
+    <button type="submit">Login</button>
+  </Form>
+</template>
+```
+
+`isEdited` is the right flag for this. `isTouched` would reveal the error as soon as the user tabs through a field without changing it, and `isDirty` would hide the error again if the user clears an invalid value back to its initial state. `isEdited` avoids both: it turns on only after a real change and stays on. Pair it with `validate: 'input'` (or `'change'`) so the error appears as soon as the field becomes invalid, and with `isSubmitted` so that the errors of all fields — including the ones the user never touched — become visible after a submit attempt.
+
+## Validating state
+
+When your schema contains asynchronous checks, validation does not resolve instantly. The form's `isValidating` state is `true` while any validation is in flight, which you can use to show a loading indicator or to disable the submit button until validation settles.
+
+```vue
+<script setup lang="ts">
+import { Form, useForm } from '@formisch/vue';
+import * as v from 'valibot';
+
+const SignUpSchema = v.object({
+  username: v.pipeAsync(
+    v.string(),
+    v.nonEmpty(),
+    v.checkAsync(isUsernameAvailable, 'Username is already taken.')
+  ),
+});
+
+const signUpForm = useForm({
+  schema: SignUpSchema,
+  validate: 'blur',
+});
+</script>
+
+<template>
+  <Form :of="signUpForm">
+    <!-- fields -->
+    <button type="submit" :disabled="signUpForm.isValidating">
+      {{ signUpForm.isValidating ? 'Checking...' : 'Sign up' }}
+    </button>
+  </Form>
+</template>
+```
+
+`isValidating` and `isSubmitting` overlap but are not the same. `isValidating` is `true` whenever validation runs — triggered by a field event or as part of a submit. `isSubmitting` is `true` for the entire submission, which covers both validating the form and running your submit handler. So during a submit both are `true` while the form validates, and once validation passes only `isSubmitting` stays `true` while your handler runs.
+
+## Further reading
+
+To process your form's values once they pass validation, see the <Link href="/vue/guides/handle-submission/">handle submission</Link> guide. For working with the fields a user has changed, see the <Link href="/vue/guides/dirty-fields/">dirty fields</Link> guide.

--- a/website/src/routes/(docs)/vue/guides/(main-concepts)/add-form-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(main-concepts)/add-form-fields/index.mdx
@@ -124,6 +124,7 @@ The field store provides access to the following properties:
 - `input`: The current input value of the field.
 - `errors`: An array of error messages if validation fails.
 - `isTouched`: Whether the field has been touched.
+- `isEdited`: Whether the field's value has been changed.
 - `isDirty`: Whether the current input differs from the initial input.
 - `isValid`: Whether the field passes all validation rules.
 

--- a/website/src/routes/(docs)/vue/guides/menu.md
+++ b/website/src/routes/(docs)/vue/guides/menu.md
@@ -18,6 +18,7 @@
 
 ## Advanced guides
 
+- [Validation](/vue/guides/validation/)
 - [Special inputs](/vue/guides/special-inputs/)
 - [Controlled fields](/vue/guides/controlled-fields/)
 - [Nested fields](/vue/guides/nested-fields/)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Validation guide across all framework docs and updates field state docs to include isEdited and isValidating. Also improves per-framework examples and adds navigation links.

- **New Features**
  - Added a Validation guide for Preact, Qwik, React, Solid, Svelte, and Vue. Covers validate/revalidate timing, error display with isEdited + isSubmitted, and async validation via isValidating with refined, framework-specific examples.
  - Updated architecture and add-form-fields pages to document the new isEdited field state; added Validation to each framework’s guides menu.

- **Bug Fixes**
  - Updated the `reset` method docs to include the `keepEdited` option alongside `keepInput`, `keepTouched`, `keepErrors`, and `keepSubmitted`.

<sup>Written for commit 9630db4c7178c082c60140544cf3160f25ba9a55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/formisch/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

