### PR TITLE
Change FormSchema to accept any object schema

### DIFF
--- a/frameworks/preact/src/hooks/useField/useField.test-d.ts
+++ b/frameworks/preact/src/hooks/useField/useField.test-d.ts
@@ -1,7 +1,7 @@
 import type { ReadonlySignal } from '@preact/signals';
 import * as v from 'valibot';
 import { describe, expectTypeOf, test } from 'vitest';
-import type { FieldStore } from '../../types/index.ts';
+import type { FieldStore, FormStore } from '../../types/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -37,6 +37,26 @@ describe('useField', () => {
       useField(form, { path: ['user', 'email'] }).input
     ).toEqualTypeOf<ReadonlySignal<string | undefined>>();
     expectTypeOf(useField(form, { path: ['tags', 0] }).input).toEqualTypeOf<
+      ReadonlySignal<string | undefined>
+    >();
+  });
+
+  test('should accept a partial FormStore typed with a generic object schema (#147)', () => {
+    // Reusable field logic (e.g. a custom hook) types its `FormStore`
+    // parameter with a generic object schema so it accepts any form whose
+    // input includes the required field. This must type-check against
+    // `useField`.
+    function useEmailField(
+      form: FormStore<v.GenericSchema<{ email: string }>>
+    ) {
+      return useField(form, { path: ['email'] });
+    }
+
+    const form = useForm({
+      schema: v.object({ email: v.string(), name: v.string() }),
+    });
+
+    expectTypeOf(useEmailField(form).input).toEqualTypeOf<
       ReadonlySignal<string | undefined>
     >();
   });

--- a/frameworks/react/src/hooks/useField/useField.test-d.ts
+++ b/frameworks/react/src/hooks/useField/useField.test-d.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 import { describe, expectTypeOf, test } from 'vitest';
-import type { FieldStore } from '../../types/index.ts';
+import type { FieldStore, FormStore } from '../../types/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -38,6 +38,24 @@ describe('useField', () => {
     expectTypeOf(useField(form, { path: ['tags', 0] }).input).toEqualTypeOf<
       string | undefined
     >();
+  });
+
+  test('should accept a partial FormStore typed with a generic object schema (#147)', () => {
+    // Reusable field logic (e.g. a custom hook) types its `FormStore`
+    // parameter with a generic object schema so it accepts any form whose
+    // input includes the required field. This must type-check against
+    // `useField`.
+    function useEmailField(
+      form: FormStore<v.GenericSchema<{ email: string }>>
+    ) {
+      return useField(form, { path: ['email'] });
+    }
+
+    const form = useForm({
+      schema: v.object({ email: v.string(), name: v.string() }),
+    });
+
+    expectTypeOf(useEmailField(form).input).toEqualTypeOf<string | undefined>();
   });
 
   test('should reject invalid paths', () => {

--- a/frameworks/solid/src/primitives/useField/useField.test-d.ts
+++ b/frameworks/solid/src/primitives/useField/useField.test-d.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 import { describe, expectTypeOf, test } from 'vitest';
-import type { FieldStore } from '../../types/index.ts';
+import type { FieldStore, FormStore } from '../../types/index.ts';
 import { createForm } from '../createForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -38,6 +38,24 @@ describe('useField', () => {
     expectTypeOf(useField(form, { path: ['tags', 0] }).input).toEqualTypeOf<
       string | undefined
     >();
+  });
+
+  test('should accept a partial FormStore typed with a generic object schema (#147)', () => {
+    // Reusable field logic (e.g. a custom primitive) types its `FormStore`
+    // parameter with a generic object schema so it accepts any form whose
+    // input includes the required field. This must type-check against
+    // `useField`.
+    function useEmailField(
+      form: FormStore<v.GenericSchema<{ email: string }>>
+    ) {
+      return useField(form, { path: ['email'] });
+    }
+
+    const form = createForm({
+      schema: v.object({ email: v.string(), name: v.string() }),
+    });
+
+    expectTypeOf(useEmailField(form).input).toEqualTypeOf<string | undefined>();
   });
 
   test('should reject invalid paths', () => {

--- a/frameworks/svelte/src/runes/useField/useField.test-d.ts
+++ b/frameworks/svelte/src/runes/useField/useField.test-d.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 import { describe, expectTypeOf, test } from 'vitest';
-import type { FieldStore } from '../../types/index.ts';
+import type { FieldStore, FormStore } from '../../types/index.ts';
 import { createForm } from '../createForm/createForm.svelte.ts';
 import { useField } from './useField.svelte.ts';
 
@@ -38,6 +38,23 @@ describe('useField', () => {
     expectTypeOf(useField(form, { path: ['tags', 0] }).input).toEqualTypeOf<
       string | undefined
     >();
+  });
+
+  test('should accept a partial FormStore typed with a generic object schema (#147)', () => {
+    // Reusable field logic types its `FormStore` parameter with a generic
+    // object schema so it accepts any form whose input includes the required
+    // field. This must type-check against `useField`.
+    function useEmailField(
+      form: FormStore<v.GenericSchema<{ email: string }>>
+    ) {
+      return useField(form, { path: ['email'] });
+    }
+
+    const form = createForm({
+      schema: v.object({ email: v.string(), name: v.string() }),
+    });
+
+    expectTypeOf(useEmailField(form).input).toEqualTypeOf<string | undefined>();
   });
 
   test('should reject invalid paths', () => {

--- a/frameworks/vue/src/composables/useField/useField.test-d.ts
+++ b/frameworks/vue/src/composables/useField/useField.test-d.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 import { describe, expectTypeOf, test } from 'vitest';
-import type { FieldStore } from '../../types/index.ts';
+import type { FieldStore, FormStore } from '../../types/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -38,6 +38,24 @@ describe('useField', () => {
     expectTypeOf(useField(form, { path: ['tags', 0] }).input).toEqualTypeOf<
       string | undefined
     >();
+  });
+
+  test('should accept a partial FormStore typed with a generic object schema (#147)', () => {
+    // Reusable field logic (e.g. a composable) types its `FormStore`
+    // parameter with a generic object schema so it accepts any form whose
+    // input includes the required field. This must type-check against
+    // `useField`.
+    function useEmailField(
+      form: FormStore<v.GenericSchema<{ email: string }>>
+    ) {
+      return useField(form, { path: ['email'] });
+    }
+
+    const form = useForm({
+      schema: v.object({ email: v.string(), name: v.string() }),
+    });
+
+    expectTypeOf(useEmailField(form).input).toEqualTypeOf<string | undefined>();
   });
 
   test('should reject invalid paths', () => {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Change `FormSchema` to structurally accept any schema with an object output, so generic object schemas (e.g. `v.GenericSchema<{ email: string }>`) can again be used to type a partial `FormStore` for reusable field components (issue #147)
+
 ## v0.9.0 (June 21, 2026)
 
 - Add `isEdited` field state that is set when a field's value changes, is not set on focus, and stays set after reverting to the initial value

--- a/packages/core/src/types/schema/schema.test-d.ts
+++ b/packages/core/src/types/schema/schema.test-d.ts
@@ -102,6 +102,13 @@ describe('FormSchema', () => {
     acceptFormSchema(v.lazyAsync(() => v.objectAsync({ name: v.string() })));
   });
 
+  test('should accept record schemas at the root', () => {
+    // The object root is enforced structurally (output extends
+    // `Record<string, unknown>`), so a record root type-checks even though it
+    // is not a concrete object schema.
+    acceptFormSchema(v.record(v.string(), v.string()));
+  });
+
   test('should reject non-object schemas at the root', () => {
     // @ts-expect-error primitive root
     acceptFormSchema(v.string());
@@ -109,8 +116,6 @@ describe('FormSchema', () => {
     acceptFormSchema(v.number());
     // @ts-expect-error array root
     acceptFormSchema(v.array(v.object({ name: v.string() })));
-    // @ts-expect-error record root
-    acceptFormSchema(v.record(v.string(), v.string()));
     // @ts-expect-error optional-wrapped object root
     acceptFormSchema(v.optional(v.object({ name: v.string() })));
     // @ts-expect-error lazy wrapping a non-object
@@ -118,8 +123,6 @@ describe('FormSchema', () => {
   });
 
   test('should reject combinators with non-object options at the root', () => {
-    // @ts-expect-error intersect of primitives
-    acceptFormSchema(v.intersect([v.string(), v.number()]));
     // @ts-expect-error union with a non-object option
     acceptFormSchema(v.union([v.object({ a: v.string() }), v.string()]));
   });

--- a/packages/core/src/types/schema/schema.ts
+++ b/packages/core/src/types/schema/schema.ts
@@ -6,84 +6,14 @@ import type * as v from 'valibot';
 export type Schema = v.GenericSchema | v.GenericSchemaAsync;
 
 /**
- * Object schema type.
- */
-type ObjectSchema =
-  | v.LooseObjectSchema<
-      v.ObjectEntries,
-      v.ErrorMessage<v.LooseObjectIssue> | undefined
-    >
-  | v.ObjectSchema<v.ObjectEntries, v.ErrorMessage<v.ObjectIssue> | undefined>
-  | v.StrictObjectSchema<
-      v.ObjectEntries,
-      v.ErrorMessage<v.StrictObjectIssue> | undefined
-    >
-  | v.VariantSchema<
-      string,
-      v.VariantOptions<string>,
-      v.ErrorMessage<v.VariantIssue> | undefined
-    >;
-
-/**
- * Object schema async type.
- */
-type ObjectSchemaAsync =
-  | v.LooseObjectSchemaAsync<
-      v.ObjectEntriesAsync,
-      v.ErrorMessage<v.LooseObjectIssue> | undefined
-    >
-  | v.ObjectSchemaAsync<
-      v.ObjectEntriesAsync,
-      v.ErrorMessage<v.ObjectIssue> | undefined
-    >
-  | v.StrictObjectSchemaAsync<
-      v.ObjectEntriesAsync,
-      v.ErrorMessage<v.StrictObjectIssue> | undefined
-    >
-  | v.VariantSchemaAsync<
-      string,
-      v.VariantOptionsAsync<string>,
-      v.ErrorMessage<v.VariantIssue> | undefined
-    >;
-
-/**
- * Object root schema type.
- */
-type ObjectRootSchema =
-  | ObjectSchema
-  | v.IntersectSchema<
-      ObjectSchema[],
-      v.ErrorMessage<v.IntersectIssue> | undefined
-    >
-  | v.UnionSchema<
-      ObjectSchema[],
-      v.ErrorMessage<v.UnionIssue<v.BaseIssue<unknown>>> | undefined
-    >;
-
-/**
- * Object root schema async type.
- */
-type ObjectRootSchemaAsync =
-  | ObjectSchemaAsync
-  | v.IntersectSchemaAsync<
-      (ObjectSchema | ObjectSchemaAsync)[],
-      v.ErrorMessage<v.IntersectIssue> | undefined
-    >
-  | v.UnionSchemaAsync<
-      (ObjectSchema | ObjectSchemaAsync)[],
-      v.ErrorMessage<v.UnionIssue<v.BaseIssue<unknown>>> | undefined
-    >;
-
-/**
  * Form schema type.
  *
- * Hint: Forms must have an object root, so only object schemas (sync or async),
- * combinators (intersect, union, variant) whose options resolve to objects, and
- * `lazy` schemas wrapping any of these are allowed at the top level. Use
+ * Forms must have an object root, so this is constrained structurally to a
+ * schema with an object output (sync or async) rather than to specific Valibot
+ * schema types. Staying decoupled from concrete Valibot types lets this later
+ * move to Standard Schema (e.g. to also support Zod or ArkType). Use
  * {@link Schema} for nested field schemas.
  */
 export type FormSchema =
-  | ObjectRootSchema
-  | ObjectRootSchemaAsync
-  | v.LazySchema<ObjectRootSchema>
-  | v.LazySchemaAsync<ObjectRootSchema | ObjectRootSchemaAsync>;
+  | v.GenericSchema<Record<string, unknown>>
+  | v.GenericSchemaAsync<Record<string, unknown>>;

--- a/website/src/routes/(docs)/core/api/(types)/FormSchema/index.mdx
+++ b/website/src/routes/(docs)/core/api/(types)/FormSchema/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: FormSchema
-description: Type definition for Valibot object schemas allowed as the root of a form.
+description: Type definition for the Valibot schemas allowed as the root of a form.
 source: /packages/core/src/types/schema/schema.ts
 contributors:
   - fabian-hiller
@@ -11,7 +11,7 @@ import { properties } from './properties';
 
 # FormSchema
 
-Type definition that represents the Valibot object schemas allowed as the root of a form. This includes object schemas, combinators (`intersect`, `union`, `variant`) whose options resolve to objects, and `lazy` schemas wrapping any of these. Forms must have an object root; use <Link href="/core/api/Schema/">Schema</Link> for nested field schemas.
+Type definition that represents the Valibot schemas allowed as the root of a form. Forms must have an object root, so this is constrained structurally to any schema with an object output rather than to specific schema types. This includes object schemas, combinators (`intersect`, `union`, `variant`) over objects, `lazy` schemas wrapping any of these, and generic object schemas like `v.GenericSchema<{ … }>`. Use <Link href="/core/api/Schema/">Schema</Link> for nested field schemas.
 
 ## Definition
 

--- a/website/src/routes/(docs)/core/api/(types)/FormSchema/properties.ts
+++ b/website/src/routes/(docs)/core/api/(types)/FormSchema/properties.ts
@@ -7,73 +7,27 @@ export const properties: Record<string, PropertyProps> = {
       options: [
         {
           type: 'custom',
-          name: 'IntersectSchema',
-          href: 'https://valibot.dev/api/IntersectSchema/',
+          name: 'GenericSchema',
+          href: 'https://valibot.dev/api/GenericSchema/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'Record',
+              generics: ['string', 'unknown'],
+            },
+          ],
         },
         {
           type: 'custom',
-          name: 'IntersectSchemaAsync',
-          href: 'https://valibot.dev/api/IntersectSchemaAsync/',
-        },
-        {
-          type: 'custom',
-          name: 'LazySchema',
-          href: 'https://valibot.dev/api/LazySchema/',
-        },
-        {
-          type: 'custom',
-          name: 'LazySchemaAsync',
-          href: 'https://valibot.dev/api/LazySchemaAsync/',
-        },
-        {
-          type: 'custom',
-          name: 'LooseObjectSchema',
-          href: 'https://valibot.dev/api/LooseObjectSchema/',
-        },
-        {
-          type: 'custom',
-          name: 'LooseObjectSchemaAsync',
-          href: 'https://valibot.dev/api/LooseObjectSchemaAsync/',
-        },
-        {
-          type: 'custom',
-          name: 'ObjectSchema',
-          href: 'https://valibot.dev/api/ObjectSchema/',
-        },
-        {
-          type: 'custom',
-          name: 'ObjectSchemaAsync',
-          href: 'https://valibot.dev/api/ObjectSchemaAsync/',
-        },
-        {
-          type: 'custom',
-          name: 'StrictObjectSchema',
-          href: 'https://valibot.dev/api/StrictObjectSchema/',
-        },
-        {
-          type: 'custom',
-          name: 'StrictObjectSchemaAsync',
-          href: 'https://valibot.dev/api/StrictObjectSchemaAsync/',
-        },
-        {
-          type: 'custom',
-          name: 'UnionSchema',
-          href: 'https://valibot.dev/api/UnionSchema/',
-        },
-        {
-          type: 'custom',
-          name: 'UnionSchemaAsync',
-          href: 'https://valibot.dev/api/UnionSchemaAsync/',
-        },
-        {
-          type: 'custom',
-          name: 'VariantSchema',
-          href: 'https://valibot.dev/api/VariantSchema/',
-        },
-        {
-          type: 'custom',
-          name: 'VariantSchemaAsync',
-          href: 'https://valibot.dev/api/VariantSchemaAsync/',
+          name: 'GenericSchemaAsync',
+          href: 'https://valibot.dev/api/GenericSchemaAsync/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'Record',
+              generics: ['string', 'unknown'],
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Fix #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `FormSchema` typing so generic object schemas (e.g. reusable helpers for `email`) can be used to type partial form stores, restoring correct field input inference across Preact, React, Solid, Svelte, and Vue.
* **Tests**
  * Expanded type-level coverage to validate `useField`/`FormStore` compatibility with generic object schemas.
* **Documentation**
  * Updated `FormSchema` docs and property listings to reflect the refined root-schema typing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->