### PR TITLE
Add emptyInput config to form config to default empty values

### DIFF
--- a/frameworks/preact/src/hooks/useField/useField.test.tsx
+++ b/frameworks/preact/src/hooks/useField/useField.test.tsx
@@ -23,7 +23,7 @@ describe('useField', () => {
 
       const field = result.current;
       expect(field.path.value).toEqual(['name']);
-      expect(field.input.value).toBe(undefined);
+      expect(field.input.value).toBe('');
       expect(field.errors.value).toBe(null);
       expect(field.isTouched.value).toBe(false);
       expect(field.isDirty.value).toBe(false);

--- a/frameworks/react/src/hooks/useField/useField.test.tsx
+++ b/frameworks/react/src/hooks/useField/useField.test.tsx
@@ -25,7 +25,7 @@ describe('useField', () => {
 
       const field = result.current;
       expect(field.path).toEqual(['name']);
-      expect(field.input).toBe(undefined);
+      expect(field.input).toBe('');
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
       expect(field.isEdited).toBe(false);

--- a/frameworks/solid/src/primitives/useField/useField.test.tsx
+++ b/frameworks/solid/src/primitives/useField/useField.test.tsx
@@ -22,7 +22,7 @@ describe('useField', () => {
 
       const field = result;
       expect(field.path).toEqual(['name']);
-      expect(field.input).toBe(undefined);
+      expect(field.input).toBe('');
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
       expect(field.isEdited).toBe(false);

--- a/frameworks/svelte/src/runes/useField/useField.test.ts
+++ b/frameworks/svelte/src/runes/useField/useField.test.ts
@@ -18,7 +18,7 @@ describe('useField', () => {
 
       const field = result.current;
       expect(field.path).toEqual(['name']);
-      expect(field.input).toBe(undefined);
+      expect(field.input).toBe('');
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
       expect(field.isEdited).toBe(false);

--- a/frameworks/vue/src/composables/useField/useField.test.ts
+++ b/frameworks/vue/src/composables/useField/useField.test.ts
@@ -17,7 +17,7 @@ describe('useField', () => {
 
       const field = result.current;
       expect(field.path).toEqual(['name']);
-      expect(field.input).toBe(undefined);
+      expect(field.input).toBe('');
       expect(field.errors).toBe(null);
       expect(field.isTouched).toBe(false);
       expect(field.isEdited).toBe(false);

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `emptyInput` form config to define the value a required field of a given type starts at when no initial input is provided, defaulting to `{ string: '' }` so an untouched string field matches the DOM and validates with its own message instead of a type mismatch (issue #53)
+
 ## v0.9.0 (June 21, 2026)
 
 - Add `isEdited` field state that is set when a field's value changes, is not set on focus, and stays set after reverting to the initial value

--- a/packages/core/src/array/copyItemState/copyItemState.test.ts
+++ b/packages/core/src/array/copyItemState/copyItemState.test.ts
@@ -22,7 +22,7 @@ describe('copyItemState', () => {
       sourceStore.isDirty.value = true;
       sourceStore.errors.value = ['Error'];
 
-      copyItemState(sourceStore, targetStore);
+      copyItemState(store, sourceStore, targetStore);
 
       expect(targetStore.input.value).toBe('modified');
       expect(targetStore.startInput.value).toBe('hello');
@@ -43,7 +43,7 @@ describe('copyItemState', () => {
       const mockElement = document.createElement('input');
       sourceStore.elements = [mockElement];
 
-      copyItemState(sourceStore, targetStore);
+      copyItemState(store, sourceStore, targetStore);
 
       expect(targetStore.elements).toEqual([mockElement]);
     });
@@ -75,7 +75,7 @@ describe('copyItemState', () => {
         sourceStore.children.name.isTouched.value = true;
         sourceStore.children.age.input.value = 25;
 
-        copyItemState(sourceStore, targetStore);
+        copyItemState(store, sourceStore, targetStore);
 
         expect(targetStore.children.name.input.value).toBe('Jane');
         expect(targetStore.children.name.isTouched.value).toBe(true);
@@ -109,7 +109,7 @@ describe('copyItemState', () => {
         sourceStore.children[0].input.value = 'modified-a';
         sourceStore.isTouched.value = true;
 
-        copyItemState(sourceStore, targetStore);
+        copyItemState(store, sourceStore, targetStore);
 
         expect(targetStore.items.value).toEqual(sourceStore.items.value);
         expect(targetStore.startItems.value).toEqual(
@@ -143,7 +143,7 @@ describe('copyItemState', () => {
       if (sourceStore.kind === 'array' && targetStore.kind === 'array') {
         expect(targetStore.children.length).toBe(1);
 
-        copyItemState(sourceStore, targetStore);
+        copyItemState(store, sourceStore, targetStore);
 
         expect(targetStore.children.length).toBe(3);
         expect(targetStore.children[2].input.value).toBe('c');
@@ -163,7 +163,7 @@ describe('copyItemState', () => {
       targetStore.errors.value = ['Old error'];
       sourceStore.errors.value = null;
 
-      copyItemState(sourceStore, targetStore);
+      copyItemState(store, sourceStore, targetStore);
 
       expect(targetStore.errors.value).toBe(null);
     });

--- a/packages/core/src/array/copyItemState/copyItemState.ts
+++ b/packages/core/src/array/copyItemState/copyItemState.ts
@@ -1,6 +1,9 @@
 import { initializeFieldStore } from '../../field/initializeFieldStore/index.ts';
 import { batch, untrack } from '../../framework/index.ts';
-import type { InternalFieldStore } from '../../types/index.ts';
+import type {
+  InternalFieldStore,
+  InternalFormStore,
+} from '../../types/index.ts';
 
 /**
  * Copies the deeply nested state (signal values) from one field store to
@@ -9,10 +12,12 @@ import type { InternalFieldStore } from '../../types/index.ts';
  * properties. Recursively walks through the field stores and copies all signal
  * values.
  *
+ * @param internalFormStore The form store providing the empty input config.
  * @param fromInternalFieldStore The source field store to copy from.
  * @param toInternalFieldStore The destination field store to copy to.
  */
 export function copyItemState(
+  internalFormStore: InternalFormStore,
   fromInternalFieldStore: InternalFieldStore,
   toInternalFieldStore: InternalFieldStore
 ): void {
@@ -69,6 +74,7 @@ export function copyItemState(
 
             // Initialize field store for new child
             initializeFieldStore(
+              internalFormStore,
               toInternalFieldStore.children[index],
               // @ts-expect-error
               toInternalFieldStore.schema.item,
@@ -79,6 +85,7 @@ export function copyItemState(
 
           // Recursively copy child state
           copyItemState(
+            internalFormStore,
             fromInternalFieldStore.children[index],
             toInternalFieldStore.children[index]
           );
@@ -93,6 +100,7 @@ export function copyItemState(
         for (const key in fromInternalFieldStore.children) {
           // Recursively copy child state
           copyItemState(
+            internalFormStore,
             fromInternalFieldStore.children[key],
             toInternalFieldStore.children[key]
           );

--- a/packages/core/src/array/resetItemState/resetItemState.test.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.test.ts
@@ -21,7 +21,7 @@ describe('resetItemState', () => {
       nameStore.errors.value = ['Error'];
       nameStore.elements = [document.createElement('input')];
 
-      resetItemState(nameStore, 'reset-value');
+      resetItemState(store, nameStore, 'reset-value');
 
       expect(nameStore.input.value).toBe('reset-value');
       expect(nameStore.startInput.value).toBe('reset-value');
@@ -41,7 +41,7 @@ describe('resetItemState', () => {
       const nameStore = store.children.name;
       nameStore.input.value = 'modified';
 
-      resetItemState(nameStore, undefined);
+      resetItemState(store, nameStore, undefined);
 
       expect(nameStore.input.value).toBe(undefined);
       expect(nameStore.startInput.value).toBe(undefined);
@@ -64,7 +64,7 @@ describe('resetItemState', () => {
         userStore.children.name.isTouched.value = true;
         userStore.children.age.input.value = 99;
 
-        resetItemState(userStore, { name: 'Jane', age: 25 });
+        resetItemState(store, userStore, { name: 'Jane', age: 25 });
 
         expect(userStore.input.value).toBe(true);
         expect(userStore.startInput.value).toBe(true);
@@ -85,7 +85,7 @@ describe('resetItemState', () => {
       expect(userStore.kind).toBe('object');
 
       if (userStore.kind === 'object') {
-        resetItemState(userStore, null);
+        resetItemState(store, userStore, null);
 
         expect(userStore.input.value).toBe(null);
         expect(userStore.startInput.value).toBe(null);
@@ -107,7 +107,7 @@ describe('resetItemState', () => {
         itemsStore.children[0].input.value = 'modified';
         itemsStore.isTouched.value = true;
 
-        resetItemState(itemsStore, ['x', 'y', 'z']);
+        resetItemState(store, itemsStore, ['x', 'y', 'z']);
 
         expect(itemsStore.input.value).toBe(true);
         expect(itemsStore.isTouched.value).toBe(false);
@@ -127,7 +127,7 @@ describe('resetItemState', () => {
       expect(itemsStore.kind).toBe('array');
 
       if (itemsStore.kind === 'array') {
-        resetItemState(itemsStore, null);
+        resetItemState(store, itemsStore, null);
 
         expect(itemsStore.items.value).toEqual([]);
         expect(itemsStore.startItems.value).toEqual([]);
@@ -147,7 +147,7 @@ describe('resetItemState', () => {
       expect(itemsStore.kind).toBe('array');
 
       if (itemsStore.kind === 'array') {
-        resetItemState(itemsStore, null);
+        resetItemState(store, itemsStore, null);
 
         expect(itemsStore.items.value).toEqual([]);
         // A nullish array preserves the explicit nullish value
@@ -166,7 +166,7 @@ describe('resetItemState', () => {
       if (itemsStore.kind === 'array') {
         const originalId = itemsStore.items.value[0];
 
-        resetItemState(itemsStore, ['new']);
+        resetItemState(store, itemsStore, ['new']);
 
         expect(itemsStore.items.value[0]).not.toBe(originalId);
       }
@@ -182,7 +182,7 @@ describe('resetItemState', () => {
       const nameStore = store.children.name;
       nameStore.errors.value = ['Error'];
 
-      resetItemState(nameStore, 'Jane', true);
+      resetItemState(store, nameStore, 'Jane', true);
 
       // Current input is updated and errors are cleared, but the start input is
       // preserved so the field is still detected as dirty
@@ -202,7 +202,7 @@ describe('resetItemState', () => {
       if (itemsStore.kind === 'array') {
         const startItems = itemsStore.startItems.value;
 
-        resetItemState(itemsStore, ['x', 'y', 'z'], true);
+        resetItemState(store, itemsStore, ['x', 'y', 'z'], true);
 
         // Current items grow to the new length while the start items are kept
         expect(itemsStore.items.value.length).toBe(3);
@@ -223,7 +223,7 @@ describe('resetItemState', () => {
       // Precondition: the store owns its array (elements === initialElements)
       expect(field.elements).toBe(field.initialElements);
 
-      resetItemState(field, 'b');
+      resetItemState(store, field, 'b');
 
       // Both stay the same (empty) array, so an element registered on remount
       // is reflected in initialElements for a later reset
@@ -244,7 +244,7 @@ describe('resetItemState', () => {
       field.elements = [document.createElement('input')];
       expect(field.elements).not.toBe(field.initialElements);
 
-      resetItemState(field, 'b');
+      resetItemState(store, field, 'b');
 
       // The reorder home baseline is preserved
       expect(field.initialElements).toBe(home);
@@ -262,7 +262,7 @@ describe('resetItemState', () => {
 
       if (itemsStore.kind === 'array') {
         // Reset with more items than children exist
-        resetItemState(itemsStore, ['x', 'y', 'z']);
+        resetItemState(store, itemsStore, ['x', 'y', 'z']);
 
         // Should initialize missing children so every item has a field store
         expect(itemsStore.items.value.length).toBe(3);
@@ -286,7 +286,9 @@ describe('resetItemState', () => {
       if (pairStore.kind === 'array') {
         // Reset with more items than the tuple defines (tuples have no
         // `schema.item`, so the extra entry must not be initialized)
-        expect(() => resetItemState(pairStore, ['x', 2, 3])).not.toThrow();
+        expect(() =>
+          resetItemState(store, pairStore, ['x', 2, 3])
+        ).not.toThrow();
 
         // The tuple keeps its fixed length, ignoring the extra entry
         expect(pairStore.items.value).toHaveLength(2);
@@ -307,20 +309,21 @@ describe('resetItemState', () => {
 
       if (pairStore.kind === 'array') {
         // Reset without input, e.g. replacing an item that omits the tuple key
-        resetItemState(pairStore, undefined);
+        resetItemState(store, pairStore, undefined);
 
-        // The tuple stays present with its fixed children reset to undefined,
+        // The tuple stays present with its fixed children reset to their empty
+        // input (an empty string for the string, undefined for the number),
         // instead of collapsing to an empty array
         expect(pairStore.input.value).toBe(true);
         expect(pairStore.items.value).toHaveLength(2);
         expect(pairStore.children).toHaveLength(2);
-        expect(pairStore.children[0].input.value).toBeUndefined();
+        expect(pairStore.children[0].input.value).toBe('');
         expect(pairStore.children[1].input.value).toBeUndefined();
 
-        // An explicit null input normalizes to undefined children too, so it
-        // stays consistent with the initial state
-        resetItemState(pairStore, null);
-        expect(pairStore.children[0].input.value).toBeUndefined();
+        // An explicit null input normalizes to the empty input too, so it stays
+        // consistent with the initial state
+        resetItemState(store, pairStore, null);
+        expect(pairStore.children[0].input.value).toBe('');
         expect(pairStore.children[1].input.value).toBeUndefined();
       }
     });

--- a/packages/core/src/array/resetItemState/resetItemState.ts
+++ b/packages/core/src/array/resetItemState/resetItemState.ts
@@ -1,6 +1,11 @@
 import { initializeFieldStore } from '../../field/initializeFieldStore/index.ts';
 import { batch, createId } from '../../framework/index.ts';
-import type { FieldElement, InternalFieldStore } from '../../types/index.ts';
+import type {
+  EmptyInput,
+  FieldElement,
+  InternalFieldStore,
+  InternalFormStore,
+} from '../../types/index.ts';
 
 /**
  * Resets the state of a field store (signal values) deeply nested. Sets
@@ -9,6 +14,7 @@ import type { FieldElement, InternalFieldStore } from '../../types/index.ts';
  * the new input value. Keeps the `initialInput` and `initialItems` state
  * unchanged for form reset functionality.
  *
+ * @param internalFormStore The form store providing the empty input config.
  * @param internalFieldStore The field store to reset.
  * @param input The new input value (can be any type including array or object).
  * @param keepStart Whether to keep `startInput` and `startItems` as the dirty
@@ -16,6 +22,7 @@ import type { FieldElement, InternalFieldStore } from '../../types/index.ts';
  * is reused for an in-place edit so its dirty state is detected correctly.
  */
 export function resetItemState(
+  internalFormStore: InternalFormStore,
   internalFieldStore: InternalFieldStore,
   input: unknown,
   keepStart = false
@@ -99,6 +106,7 @@ export function resetItemState(
             if (internalFieldStore.children[index]) {
               // Recursively reset child with corresponding input
               resetItemState(
+                internalFormStore,
                 internalFieldStore.children[index],
                 itemInput,
                 keepStart
@@ -112,6 +120,7 @@ export function resetItemState(
 
               // Initialize field store for new child
               initializeFieldStore(
+                internalFormStore,
                 internalFieldStore.children[index],
                 // @ts-expect-error
                 internalFieldStore.schema.item,
@@ -138,6 +147,7 @@ export function resetItemState(
         for (const key in internalFieldStore.children) {
           // Recursively reset child with corresponding input
           resetItemState(
+            internalFormStore,
             internalFieldStore.children[key],
             // @ts-expect-error
             input?.[key],
@@ -148,13 +158,23 @@ export function resetItemState(
 
       // Otherwise, if field store is value, handle primitive type reset
     } else {
+      // Fall back to the empty input for this field's type when no input is
+      // provided so the reset value stays consistent with the initial input.
+      // Optional and nullable fields stay `undefined` as they accept it.
+      const valueInput =
+        input === undefined && !internalFieldStore.isNullish
+          ? internalFormStore.emptyInput[
+              internalFieldStore.schema.type as keyof EmptyInput
+            ]
+          : input;
+
       // Set start input unless it is kept as the dirty baseline
       if (!keepStart) {
-        internalFieldStore.startInput.value = input;
+        internalFieldStore.startInput.value = valueInput;
       }
 
       // Set current input
-      internalFieldStore.input.value = input;
+      internalFieldStore.input.value = valueInput;
     }
   });
 }

--- a/packages/core/src/array/swapItemState/swapItemState.test.ts
+++ b/packages/core/src/array/swapItemState/swapItemState.test.ts
@@ -19,7 +19,7 @@ describe('swapItemState', () => {
       secondStore.isDirty.value = true;
       secondStore.isEdited.value = true;
 
-      swapItemState(firstStore, secondStore);
+      swapItemState(store, firstStore, secondStore);
 
       expect(firstStore.input.value).toBe('world');
       expect(secondStore.input.value).toBe('hello');
@@ -46,7 +46,7 @@ describe('swapItemState', () => {
       firstStore.elements = [input1];
       secondStore.elements = [input2];
 
-      swapItemState(firstStore, secondStore);
+      swapItemState(store, firstStore, secondStore);
 
       expect(firstStore.elements).toEqual([input2]);
       expect(secondStore.elements).toEqual([input1]);
@@ -77,7 +77,7 @@ describe('swapItemState', () => {
       if (firstStore.kind === 'object' && secondStore.kind === 'object') {
         firstStore.children.name.isTouched.value = true;
 
-        swapItemState(firstStore, secondStore);
+        swapItemState(store, firstStore, secondStore);
 
         expect(firstStore.children.name.input.value).toBe('Jane');
         expect(secondStore.children.name.input.value).toBe('John');
@@ -112,7 +112,7 @@ describe('swapItemState', () => {
         const firstItems = firstStore.items.value;
         const secondItems = secondStore.items.value;
 
-        swapItemState(firstStore, secondStore);
+        swapItemState(store, firstStore, secondStore);
 
         expect(firstStore.items.value).toEqual(secondItems);
         expect(secondStore.items.value).toEqual(firstItems);
@@ -145,7 +145,7 @@ describe('swapItemState', () => {
         expect(firstStore.children.length).toBe(1);
         expect(secondStore.children.length).toBe(3);
 
-        swapItemState(firstStore, secondStore);
+        swapItemState(store, firstStore, secondStore);
 
         // Both should now have 3 children (max of both)
         expect(firstStore.children.length).toBe(3);
@@ -177,7 +177,7 @@ describe('swapItemState', () => {
         expect(firstStore.children.length).toBe(3);
         expect(secondStore.children.length).toBe(1);
 
-        swapItemState(firstStore, secondStore);
+        swapItemState(store, firstStore, secondStore);
 
         // Both should now have 3 children (max of both)
         expect(firstStore.children.length).toBe(3);
@@ -198,7 +198,7 @@ describe('swapItemState', () => {
       const firstStore = store.children.first;
       const secondStore = store.children.second;
 
-      swapItemState(firstStore, secondStore);
+      swapItemState(store, firstStore, secondStore);
 
       expect(firstStore.startInput.value).toBe('start-second');
       expect(secondStore.startInput.value).toBe('start-first');
@@ -232,7 +232,7 @@ describe('swapItemState', () => {
         if (child0.kind === 'object' && child1.kind === 'object') {
           child0.children.name.isTouched.value = true;
 
-          swapItemState(child0, child1);
+          swapItemState(store, child0, child1);
 
           expect(child0.children.name.input.value).toBe('Bob');
           expect(child0.children.score.input.value).toBe(50);
@@ -258,7 +258,7 @@ describe('swapItemState', () => {
 
         child0.isTouched.value = true;
 
-        swapItemState(child0, child2);
+        swapItemState(store, child0, child2);
 
         expect(child0.input.value).toBe('third');
         expect(child2.input.value).toBe('first');

--- a/packages/core/src/array/swapItemState/swapItemState.ts
+++ b/packages/core/src/array/swapItemState/swapItemState.ts
@@ -1,6 +1,9 @@
 import { initializeFieldStore } from '../../field/initializeFieldStore/index.ts';
 import { batch, untrack } from '../../framework/index.ts';
-import type { InternalFieldStore } from '../../types/index.ts';
+import type {
+  InternalFieldStore,
+  InternalFormStore,
+} from '../../types/index.ts';
 
 /**
  * Swaps the deeply nested state (signal values) between two field stores. This
@@ -8,10 +11,12 @@ import type { InternalFieldStore } from '../../types/index.ts';
  * `isEdited`, `isDirty`, and for arrays `startItems` and `items` properties.
  * Recursively walks through the field stores and swaps all signal values.
  *
+ * @param internalFormStore The form store providing the empty input config.
  * @param firstInternalFieldStore The first field store to swap.
  * @param secondInternalFieldStore The second field store to swap.
  */
 export function swapItemState(
+  internalFormStore: InternalFormStore,
   firstInternalFieldStore: InternalFieldStore,
   secondInternalFieldStore: InternalFieldStore
 ): void {
@@ -92,6 +97,7 @@ export function swapItemState(
 
             // Initialize field store for new child
             initializeFieldStore(
+              internalFormStore,
               firstInternalFieldStore.children[index],
               // @ts-expect-error
               firstInternalFieldStore.schema.item,
@@ -108,6 +114,7 @@ export function swapItemState(
 
             // Initialize field store for new child
             initializeFieldStore(
+              internalFormStore,
               secondInternalFieldStore.children[index],
               // @ts-expect-error
               secondInternalFieldStore.schema.item,
@@ -118,6 +125,7 @@ export function swapItemState(
 
           // Recursively swap children
           swapItemState(
+            internalFormStore,
             firstInternalFieldStore.children[index],
             secondInternalFieldStore.children[index]
           );
@@ -132,6 +140,7 @@ export function swapItemState(
         for (const key in firstInternalFieldStore.children) {
           // Recursively swap children
           swapItemState(
+            internalFormStore,
             firstInternalFieldStore.children[key],
             secondInternalFieldStore.children[key]
           );

--- a/packages/core/src/field/getFieldInput/getFieldInput.test.ts
+++ b/packages/core/src/field/getFieldInput/getFieldInput.test.ts
@@ -20,8 +20,8 @@ describe('getFieldInput', () => {
     });
 
     test('should return undefined for uninitialized field', () => {
-      const store = createTestStore(v.object({ name: v.string() }));
-      expect(getFieldInput(store.children.name)).toBeUndefined();
+      const store = createTestStore(v.object({ age: v.number() }));
+      expect(getFieldInput(store.children.age)).toBeUndefined();
     });
   });
 

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.test.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.test.ts
@@ -20,10 +20,118 @@ describe('initializeFieldStore', () => {
       expect(field.isEdited.value).toBe(false);
       expect(field.isDirty.value).toBe(false);
     });
+  });
 
-    test('should initialize with undefined input', () => {
+  describe('empty input config', () => {
+    test('should default required string to empty string', () => {
       const store = createTestStore(v.object({ name: v.string() }));
+      expect(store.children.name.input.value).toBe('');
+      expect(store.children.name.initialInput.value).toBe('');
+      expect(store.children.name.startInput.value).toBe('');
+    });
+
+    test('should default required piped string to empty string', () => {
+      const store = createTestStore(
+        v.object({ name: v.pipe(v.string(), v.nonEmpty()) })
+      );
+      expect(store.children.name.input.value).toBe('');
+    });
+
+    test('should not default required non-string to empty string', () => {
+      const store = createTestStore(v.object({ age: v.number() }));
+      expect(store.children.age.input.value).toBeUndefined();
+    });
+
+    test('should keep optional string as undefined', () => {
+      const store = createTestStore(v.object({ name: v.optional(v.string()) }));
       expect(store.children.name.input.value).toBeUndefined();
+    });
+
+    test('should keep nullable string as undefined', () => {
+      const store = createTestStore(v.object({ name: v.nullable(v.string()) }));
+      expect(store.children.name.input.value).toBeUndefined();
+    });
+
+    test('should use explicit initial input over empty string default', () => {
+      const store = createTestStore(v.object({ name: v.string() }), {
+        initialInput: { name: 'John' },
+      });
+      expect(store.children.name.input.value).toBe('John');
+    });
+
+    test('should default nested required string to empty string', () => {
+      const store = createTestStore(
+        v.object({ user: v.object({ name: v.string() }) })
+      );
+      const userStore = store.children.user;
+      expect(userStore.kind).toBe('object');
+      if (userStore.kind === 'object') {
+        expect(userStore.children.name.input.value).toBe('');
+      }
+    });
+
+    test('should default number and boolean to undefined', () => {
+      const store = createTestStore(
+        v.object({ age: v.number(), active: v.boolean() })
+      );
+      expect(store.children.age.input.value).toBeUndefined();
+      expect(store.children.active.input.value).toBeUndefined();
+    });
+
+    test('should apply configured empty input per type', () => {
+      const date = new Date('2020-01-01');
+      const store = createTestStore(
+        v.object({
+          name: v.string(),
+          age: v.number(),
+          active: v.boolean(),
+          birthday: v.date(),
+        }),
+        { emptyInput: { number: 0, boolean: false, date } }
+      );
+      expect(store.children.name.input.value).toBe('');
+      expect(store.children.age.input.value).toBe(0);
+      expect(store.children.active.input.value).toBe(false);
+      expect(store.children.birthday.input.value).toBe(date);
+    });
+
+    test('should opt out of the empty string default', () => {
+      const store = createTestStore(v.object({ name: v.string() }), {
+        emptyInput: { string: undefined },
+      });
+      expect(store.children.name.input.value).toBeUndefined();
+    });
+
+    test('should apply configured empty input to nested and array children', () => {
+      const store = createTestStore(
+        v.object({
+          user: v.object({ age: v.number() }),
+          scores: v.array(v.number()),
+        }),
+        { initialInput: { scores: [undefined] }, emptyInput: { number: 0 } }
+      );
+      const userStore = store.children.user;
+      expect(userStore.kind).toBe('object');
+      if (userStore.kind === 'object') {
+        expect(userStore.children.age.input.value).toBe(0);
+      }
+      const scoresStore = store.children.scores;
+      expect(scoresStore.kind).toBe('array');
+      if (scoresStore.kind === 'array') {
+        expect(scoresStore.children[0].input.value).toBe(0);
+      }
+    });
+
+    test('should store whether a value field is nullish for resetting', () => {
+      const store = createTestStore(
+        v.object({ name: v.string(), nickname: v.optional(v.string()) })
+      );
+      const nameStore = store.children.name;
+      const nicknameStore = store.children.nickname;
+      if (nameStore.kind === 'value' && nicknameStore.kind === 'value') {
+        expect(nameStore.isNullish).toBe(false);
+        expect(nicknameStore.isNullish).toBe(true);
+      }
     });
   });
 

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.test.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.test.ts
@@ -52,6 +52,20 @@ describe('initializeFieldStore', () => {
       expect(store.children.name.input.value).toBeUndefined();
     });
 
+    test('should keep a non-optional inside an optional as undefined', () => {
+      const store = createTestStore(
+        v.object({ name: v.optional(v.nonOptional(v.string())) })
+      );
+      expect(store.children.name.input.value).toBeUndefined();
+    });
+
+    test('should keep a non-nullish inside a nullish as undefined', () => {
+      const store = createTestStore(
+        v.object({ name: v.nullish(v.nonNullish(v.string())) })
+      );
+      expect(store.children.name.input.value).toBeUndefined();
+    });
+
     test('should use explicit initial input over empty string default', () => {
       const store = createTestStore(v.object({ name: v.string() }), {
         initialInput: { name: 'John' },

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -1,8 +1,10 @@
 import * as v from 'valibot';
 import { createId, createSignal, framework } from '../../framework/index.ts';
 import type {
+  EmptyInput,
   FieldElement,
   InternalFieldStore,
+  InternalFormStore,
   Path,
 } from '../../types/index.ts';
 
@@ -12,6 +14,8 @@ export type FieldSchema =
       v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
       v.ErrorMessage<v.ArrayIssue> | undefined
     >
+  | v.BooleanSchema<any>
+  | v.DateSchema<any>
   | v.ExactOptionalSchema<any, any>
   | v.IntersectSchema<any, any>
   | v.LazySchema<any>
@@ -22,6 +26,7 @@ export type FieldSchema =
   | v.NonOptionalSchema<any, any>
   | v.NullableSchema<any, any>
   | v.NullishSchema<any, any>
+  | v.NumberSchema<any>
   | v.ObjectSchema<v.ObjectEntries, v.ErrorMessage<v.ObjectIssue> | undefined>
   | v.ObjectWithRestSchema<
       v.ObjectEntries,
@@ -33,6 +38,7 @@ export type FieldSchema =
   | v.RecordSchema<any, any, any>
   | v.StrictObjectSchema<any, any>
   | v.StrictTupleSchema<any, any>
+  | v.StringSchema<any>
   | v.TupleSchema<v.TupleItems, v.ErrorMessage<v.TupleIssue> | undefined>
   | v.TupleWithRestSchema<any, any, any>
   | v.UndefinedableSchema<any, any>
@@ -44,6 +50,7 @@ export type FieldSchema =
  * array, object, and value schemas, setting up all necessary signals and
  * children. Supports wrapped schemas and schema options.
  *
+ * @param internalFormStore The form store providing the empty input config.
  * @param internalFieldStore The partial field store to initialize.
  * @param schema The Valibot schema defining the field structure.
  * @param initialInput The initial input value.
@@ -51,6 +58,7 @@ export type FieldSchema =
  * @param nullish Whether the schema is wrapped in a nullish schema.
  */
 export function initializeFieldStore(
+  internalFormStore: InternalFormStore,
   internalFieldStore: Partial<InternalFieldStore>,
   schema: FieldSchema,
   initialInput: unknown,
@@ -70,6 +78,7 @@ export function initializeFieldStore(
     // Otherwise, if schema is lazy, unwrap and initialize
   } else if (schema.type === 'lazy') {
     initializeFieldStore(
+      internalFormStore,
       internalFieldStore,
       schema.getter(undefined),
       initialInput,
@@ -86,6 +95,7 @@ export function initializeFieldStore(
     schema.type === 'undefinedable'
   ) {
     initializeFieldStore(
+      internalFormStore,
       internalFieldStore,
       schema.wrapped,
       initialInput === undefined ? v.getDefault(schema) : initialInput,
@@ -100,6 +110,7 @@ export function initializeFieldStore(
     schema.type === 'non_optional'
   ) {
     initializeFieldStore(
+      internalFormStore,
       internalFieldStore,
       schema.wrapped,
       initialInput,
@@ -119,6 +130,7 @@ export function initializeFieldStore(
     // is therefore not fully represented. See #95 for the long-term fix.
     for (const schemaOption of schema.options) {
       initializeFieldStore(
+        internalFormStore,
         internalFieldStore,
         schemaOption,
         initialInput,
@@ -135,6 +147,9 @@ export function initializeFieldStore(
     // Hint: Each field store receives its own freshly built path array (see the
     // `[...path, key]` calls below), so it can be stored directly.
     internalFieldStore.path = path;
+
+    // Store whether property is nullish so resetting can stay consistent
+    internalFieldStore.isNullish = nullish;
 
     // Initialize elements array
     // Hint: `initialElements` and `elements` start as the same array so that
@@ -189,6 +204,7 @@ export function initializeFieldStore(
 
               // Initialize field store for child
               initializeFieldStore(
+                internalFormStore,
                 internalFieldStore.children[index],
                 schema.item as FieldSchema,
                 // @ts-expect-error
@@ -208,6 +224,7 @@ export function initializeFieldStore(
 
             // Initialize field store for child
             initializeFieldStore(
+              internalFormStore,
               internalFieldStore.children[index],
               schema.items[index] as FieldSchema,
               // @ts-expect-error
@@ -216,9 +233,6 @@ export function initializeFieldStore(
             );
           }
         }
-
-        // Store whether array is nullish so resetting can stay consistent
-        internalFieldStore.isNullish = nullish;
 
         // Set array input (nullish or true)
         const arrayInput =
@@ -263,6 +277,7 @@ export function initializeFieldStore(
 
           // Initialize field store for child
           initializeFieldStore(
+            internalFormStore,
             internalFieldStore.children[key],
             schema.entries[key] as FieldSchema,
             // @ts-expect-error
@@ -270,9 +285,6 @@ export function initializeFieldStore(
             [...path, key]
           );
         }
-
-        // Store whether object is nullish so resetting can stay consistent
-        internalFieldStore.isNullish = nullish;
 
         // Set object input (nullish or true)
         const objectInput =
@@ -296,14 +308,19 @@ export function initializeFieldStore(
 
       // Initialize value-specific properties
       if (internalFieldStore.kind === 'value') {
-        // Set initial input
-        internalFieldStore.initialInput = createSignal(initialInput);
+        // Resolve the empty input for this field's type from the configured map
+        // (e.g. `''` for a string), so an untouched empty field matches the DOM
+        // and validates with its own message instead of a type mismatch.
+        // Optional and nullable fields stay `undefined` as they accept it.
+        const valueInput =
+          initialInput === undefined && !nullish
+            ? internalFormStore.emptyInput[schema.type as keyof EmptyInput]
+            : initialInput;
 
-        // Set start input
-        internalFieldStore.startInput = createSignal(initialInput);
-
-        // Set current input
-        internalFieldStore.input = createSignal(initialInput);
+        // Set initial, start and current input
+        internalFieldStore.initialInput = createSignal(valueInput);
+        internalFieldStore.startInput = createSignal(valueInput);
+        internalFieldStore.input = createSignal(valueInput);
       }
     }
   }

--- a/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
+++ b/packages/core/src/field/initializeFieldStore/initializeFieldStore.ts
@@ -109,12 +109,16 @@ export function initializeFieldStore(
     schema.type === 'non_nullish' ||
     schema.type === 'non_optional'
   ) {
+    // Forward the nullish flag so an outer optional or nullable wrapper still
+    // keeps the field at `undefined`/`null` instead of its empty input (e.g.
+    // `v.optional(v.nonOptional(v.string()))`)
     initializeFieldStore(
       internalFormStore,
       internalFieldStore,
       schema.wrapped,
       initialInput,
-      path
+      path,
+      nullish
     );
 
     // Otherwise, if schema has options, initialize for each option

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -11,10 +11,12 @@ import { initializeFieldStore } from '../initializeFieldStore/index.ts';
  * Sets the input for a nested field store and all its children, updating
  * touched and dirty states accordingly. Handles dynamic array resizing.
  *
+ * @param internalFormStore The form store providing the empty input config.
  * @param internalFieldStore The field store to update.
  * @param input The new input value.
  */
 function setNestedInput(
+  internalFormStore: InternalFormStore,
   internalFieldStore: InternalFieldStore,
   input: unknown
 ): void {
@@ -52,6 +54,7 @@ function setNestedInput(
         // like a direct edit on a never-shrunk array would be.
         if (internalFieldStore.children[index]) {
           resetItemState(
+            internalFormStore,
             internalFieldStore.children[index],
             // @ts-expect-error
             arrayInput[index],
@@ -66,6 +69,7 @@ function setNestedInput(
 
           // Initialize field store for new child
           initializeFieldStore(
+            internalFormStore,
             internalFieldStore.children[index],
             // @ts-expect-error
             internalFieldStore.schema.item,
@@ -88,6 +92,7 @@ function setNestedInput(
     for (let index = 0; index < length; index++) {
       // Recursively set nested input
       setNestedInput(
+        internalFormStore,
         internalFieldStore.children[index],
         // @ts-expect-error
         arrayInput[index]
@@ -109,6 +114,7 @@ function setNestedInput(
     for (const key in internalFieldStore.children) {
       // Recursively set nested input
       setNestedInput(
+        internalFormStore,
         internalFieldStore.children[key],
         // @ts-expect-error
         input?.[key]
@@ -173,7 +179,7 @@ export function setFieldInput(
       }
 
       // Set nested input on target field
-      setNestedInput(internalFieldStore, input);
+      setNestedInput(internalFormStore, internalFieldStore, input);
     });
   });
 }

--- a/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.test.ts
+++ b/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.test.ts
@@ -7,7 +7,7 @@ describe('setInitialFieldInput', () => {
   describe('value fields', () => {
     test('should set initial input', () => {
       const store = createTestStore(v.object({ name: v.string() }));
-      setInitialFieldInput(store.children.name, 'John');
+      setInitialFieldInput(store, store.children.name, 'John');
       expect(store.children.name.initialInput.value).toBe('John');
     });
   });
@@ -17,7 +17,7 @@ describe('setInitialFieldInput', () => {
       const store = createTestStore(
         v.object({ user: v.object({ name: v.string() }) })
       );
-      setInitialFieldInput(store.children.user, { name: 'John' });
+      setInitialFieldInput(store, store.children.user, { name: 'John' });
       const userStore = store.children.user;
       expect(userStore.kind).toBe('object');
       if (userStore.kind === 'object') {
@@ -31,7 +31,7 @@ describe('setInitialFieldInput', () => {
         v.object({ user: v.nullish(v.object({ name: v.string() })) }),
         { initialInput: { user: { name: 'John' } } }
       );
-      setInitialFieldInput(store.children.user, null);
+      setInitialFieldInput(store, store.children.user, null);
       expect(store.children.user.initialInput.value).toBeNull();
       // Current input is not affected by setting the initial input
       expect(store.children.user.input.value).toBe(true);
@@ -43,7 +43,7 @@ describe('setInitialFieldInput', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {
         initialInput: { items: ['a'] },
       });
-      setInitialFieldInput(store.children.items, ['x', 'y']);
+      setInitialFieldInput(store, store.children.items, ['x', 'y']);
       const itemsStore = store.children.items;
       expect(itemsStore.kind).toBe('array');
       if (itemsStore.kind === 'array') {
@@ -56,7 +56,7 @@ describe('setInitialFieldInput', () => {
       const store = createTestStore(v.object({ items: v.array(v.string()) }), {
         initialInput: { items: ['a'] },
       });
-      setInitialFieldInput(store.children.items, ['x', 'y', 'z']);
+      setInitialFieldInput(store, store.children.items, ['x', 'y', 'z']);
       const itemsStore = store.children.items;
       expect(itemsStore.kind).toBe('array');
       if (itemsStore.kind === 'array') {
@@ -70,7 +70,7 @@ describe('setInitialFieldInput', () => {
         v.object({ items: v.nullish(v.array(v.string())) }),
         { initialInput: { items: ['a'] } }
       );
-      setInitialFieldInput(store.children.items, null);
+      setInitialFieldInput(store, store.children.items, null);
       expect(store.children.items.initialInput.value).toBeNull();
       // Current input is not affected by setting the initial input
       expect(store.children.items.input.value).toBe(true);
@@ -81,7 +81,7 @@ describe('setInitialFieldInput', () => {
         initialInput: { items: ['a', 'b'] },
       });
       const itemsStore = store.children.items;
-      setInitialFieldInput(itemsStore, ['x', 'y']);
+      setInitialFieldInput(store, itemsStore, ['x', 'y']);
       expect(itemsStore.kind).toBe('array');
       if (itemsStore.kind === 'array') {
         expect(itemsStore.children[0].initialInput.value).toBe('x');
@@ -99,7 +99,7 @@ describe('setInitialFieldInput', () => {
       if (pairStore.kind === 'array') {
         // Tuples have no `item` schema, so the extra entry must be ignored
         expect(() =>
-          setInitialFieldInput(pairStore, ['x', 2, 3])
+          setInitialFieldInput(store, pairStore, ['x', 2, 3])
         ).not.toThrow();
         expect(pairStore.initialItems.value).toHaveLength(2);
         expect(pairStore.children[0].initialInput.value).toBe('x');

--- a/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.ts
+++ b/packages/core/src/field/setInitialFieldInput/setInitialFieldInput.ts
@@ -1,5 +1,9 @@
 import { batch, createId } from '../../framework/index.ts';
-import type { InternalFieldStore } from '../../types/index.ts';
+import type {
+  EmptyInput,
+  InternalFieldStore,
+  InternalFormStore,
+} from '../../types/index.ts';
 import { initializeFieldStore } from '../initializeFieldStore/index.ts';
 
 /**
@@ -7,10 +11,12 @@ import { initializeFieldStore } from '../initializeFieldStore/index.ts';
  * For arrays, initializes missing children if needed. Updates `initialInput`
  * and `initialItems` properties.
  *
+ * @param internalFormStore The form store providing the empty input config.
  * @param internalFieldStore The field store to update.
  * @param initialInput The initial input value.
  */
 export function setInitialFieldInput(
+  internalFormStore: InternalFormStore,
   internalFieldStore: InternalFieldStore,
   initialInput: unknown
 ): void {
@@ -47,6 +53,7 @@ export function setInitialFieldInput(
 
           // Initialize field store for new child
           initializeFieldStore(
+            internalFormStore,
             internalFieldStore.children[index],
             // @ts-expect-error
             internalFieldStore.schema.item,
@@ -64,6 +71,7 @@ export function setInitialFieldInput(
       for (let index = 0; index < internalFieldStore.children.length; index++) {
         // Recursively set initial input for child
         setInitialFieldInput(
+          internalFormStore,
           internalFieldStore.children[index],
           // @ts-expect-error
           initialArrayInput[index]
@@ -80,6 +88,7 @@ export function setInitialFieldInput(
       for (const key in internalFieldStore.children) {
         // Recursively set initial input for child
         setInitialFieldInput(
+          internalFormStore,
           internalFieldStore.children[key],
           // @ts-expect-error
           initialInput?.[key]
@@ -88,8 +97,15 @@ export function setInitialFieldInput(
 
       // Otherwise, handle value field initial input
     } else {
-      // Set initial input
-      internalFieldStore.initialInput.value = initialInput;
+      // Fall back to the empty input for this field's type when no input is
+      // provided so the initial input stays consistent with form
+      // initialization. Optional and nullable fields stay `undefined`.
+      internalFieldStore.initialInput.value =
+        initialInput === undefined && !internalFieldStore.isNullish
+          ? internalFormStore.emptyInput[
+              internalFieldStore.schema.type as keyof EmptyInput
+            ]
+          : initialInput;
     }
   });
 }

--- a/packages/core/src/form/createFormStore/createFormStore.ts
+++ b/packages/core/src/form/createFormStore/createFormStore.ts
@@ -24,6 +24,7 @@ export const DEFAULT_EMPTY_INPUT: EmptyInput = { string: '' };
  *
  * @returns The internal form store.
  */
+// @__NO_SIDE_EFFECTS__
 export function createFormStore(
   config: FormConfig,
   parse: (input: unknown) => Promise<v.SafeParseResult<FormSchema>>

--- a/packages/core/src/form/createFormStore/createFormStore.ts
+++ b/packages/core/src/form/createFormStore/createFormStore.ts
@@ -2,10 +2,17 @@ import type * as v from 'valibot';
 import { type FieldSchema, initializeFieldStore } from '../../field/index.ts';
 import { createSignal } from '../../framework/index.ts';
 import type {
+  EmptyInput,
   FormConfig,
   FormSchema,
   InternalFormStore,
 } from '../../types/index.ts';
+
+/**
+ * The default empty input of a form. Required string fields start as an empty
+ * string, while every other type starts as `undefined`.
+ */
+export const DEFAULT_EMPTY_INPUT: EmptyInput = { string: '' };
 
 /**
  * Creates a new internal form store from the provided configuration.
@@ -24,13 +31,9 @@ export function createFormStore(
   // Create partial store object
   const store: Partial<InternalFormStore> = {};
 
-  // Initialize field store hierarchy from schema
-  initializeFieldStore(
-    store,
-    config.schema as FieldSchema,
-    config.initialInput,
-    []
-  );
+  // Merge configured empty input on top of the defaults before initializing so
+  // the field stores can read it from the form store
+  store.emptyInput = { ...DEFAULT_EMPTY_INPUT, ...config.emptyInput };
 
   // Set form config and validation
   store.validators = 0;
@@ -42,6 +45,15 @@ export function createFormStore(
   store.isSubmitting = createSignal(false);
   store.isSubmitted = createSignal(false);
   store.isValidating = createSignal(false);
+
+  // Initialize field store hierarchy from schema
+  initializeFieldStore(
+    store as InternalFormStore,
+    store,
+    config.schema as FieldSchema,
+    config.initialInput,
+    []
+  );
 
   // Return initialized store
   return store as InternalFormStore;

--- a/packages/core/src/types/field/field.qwik.ts
+++ b/packages/core/src/types/field/field.qwik.ts
@@ -25,6 +25,15 @@ export interface InternalBaseStore {
    */
   schema: NoSerialize<Schema>;
   /**
+   * Whether the schema is wrapped in a nullish schema.
+   *
+   * Hint: This indicates whether a missing input should be represented as the
+   * nullish value (`null`/`undefined`) instead of a present empty fallback
+   * (`true` for arrays and objects, or the empty input for values). It keeps
+   * resetting consistent with the initial state.
+   */
+  isNullish: boolean;
+  /**
    * The initial elements of the field.
    *
    * Hint: This may look unused, but do not remove it. `copyItemState` and
@@ -70,14 +79,7 @@ export interface InternalArrayStore extends InternalBaseStore {
    * The kind of field store.
    */
   kind: 'array';
-  /**
-   * Whether the array schema is wrapped in a nullish schema.
-   *
-   * Hint: This indicates whether a missing input should be represented as the
-   * nullish value (`null`/`undefined`) or as a present but empty array
-   * (`true`). It keeps resetting consistent with the initial state.
-   */
-  isNullish: boolean;
+
   /**
    * The children of the array field.
    */
@@ -133,14 +135,6 @@ export interface InternalObjectStore extends InternalBaseStore {
    * The kind of field store.
    */
   kind: 'object';
-  /**
-   * Whether the object schema is wrapped in a nullish schema.
-   *
-   * Hint: This indicates whether a missing input should be represented as the
-   * nullish value (`null`/`undefined`) or as a present but empty object
-   * (`true`). It keeps resetting consistent with the initial state.
-   */
-  isNullish: boolean;
   /**
    * The children of the object field.
    */

--- a/packages/core/src/types/field/field.ts
+++ b/packages/core/src/types/field/field.ts
@@ -31,6 +31,15 @@ export interface InternalBaseStore {
    */
   schema: Schema;
   /**
+   * Whether the schema is wrapped in a nullish schema.
+   *
+   * Hint: This indicates whether a missing input should be represented as the
+   * nullish value (`null`/`undefined`) instead of a present empty fallback
+   * (`true` for arrays and objects, or the empty input for values). It keeps
+   * resetting consistent with the initial state.
+   */
+  isNullish: boolean;
+  /**
    * The initial elements of the field.
    *
    * Hint: This may look unused, but do not remove it. `copyItemState` and
@@ -76,14 +85,7 @@ export interface InternalArrayStore extends InternalBaseStore {
    * The kind of field store.
    */
   kind: 'array';
-  /**
-   * Whether the array schema is wrapped in a nullish schema.
-   *
-   * Hint: This indicates whether a missing input should be represented as the
-   * nullish value (`null`/`undefined`) or as a present but empty array
-   * (`true`). It keeps resetting consistent with the initial state.
-   */
-  isNullish: boolean;
+
   /**
    * The children of the array field.
    */
@@ -139,14 +141,6 @@ export interface InternalObjectStore extends InternalBaseStore {
    * The kind of field store.
    */
   kind: 'object';
-  /**
-   * Whether the object schema is wrapped in a nullish schema.
-   *
-   * Hint: This indicates whether a missing input should be represented as the
-   * nullish value (`null`/`undefined`) or as a present but empty object
-   * (`true`). It keeps resetting consistent with the initial state.
-   */
-  isNullish: boolean;
   /**
    * The children of the object field.
    */

--- a/packages/core/src/types/form/form.qwik.ts
+++ b/packages/core/src/types/form/form.qwik.ts
@@ -6,6 +6,7 @@ import type { FormSchema } from '../schema/index.ts';
 import type { Signal } from '../signal/index.ts';
 import type { DeepPartial } from '../utils/index.ts';
 import type {
+  EmptyInput,
   SubmitEventHandler,
   SubmitHandler,
   ValidationMode,
@@ -23,6 +24,11 @@ export interface FormConfig<TSchema extends FormSchema = FormSchema> {
    * The initial input of the form.
    */
   readonly initialInput?: DeepPartial<v.InferInput<TSchema>> | undefined;
+  /**
+   * The empty input of the form, keyed by field type. Merged on top of the
+   * defaults, so `{ string: '' }` stays in effect unless overridden.
+   */
+  readonly emptyInput?: EmptyInput | undefined;
   /**
    * The validation mode of the form.
    */
@@ -47,6 +53,10 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
    * The number of active validators.
    */
   validators: number;
+  /**
+   * The resolved empty input of the form, keyed by field type.
+   */
+  emptyInput: EmptyInput;
   /**
    * The validation mode of the form.
    */
@@ -86,4 +96,4 @@ export interface BaseFormStore<TSchema extends FormSchema = FormSchema> {
   readonly [INTERNAL]: InternalFormStore<TSchema>;
 }
 
-export type { ValidationMode, SubmitHandler, SubmitEventHandler };
+export type { EmptyInput, ValidationMode, SubmitHandler, SubmitEventHandler };

--- a/packages/core/src/types/form/form.react.ts
+++ b/packages/core/src/types/form/form.react.ts
@@ -5,6 +5,7 @@ import type { MaybePromise } from '../utils/index.ts';
 
 // Re-export all other types from the base form module
 export type {
+  EmptyInput,
   ValidationMode,
   FormConfig,
   InternalFormStore,

--- a/packages/core/src/types/form/form.ts
+++ b/packages/core/src/types/form/form.ts
@@ -17,6 +17,35 @@ export type ValidationMode =
   | 'submit';
 
 /**
+ * Empty input interface.
+ *
+ * Defines the value a required field of a given type starts at when no initial
+ * input is provided. Optional and nullable fields are not affected, as they
+ * accept `undefined`. Only required fields whose input is `undefined` fall back
+ * to these values.
+ */
+export interface EmptyInput {
+  /**
+   * The empty input of a string field. Defaults to an empty string so that an
+   * untouched field matches the DOM and validates with its own message instead
+   * of a type mismatch. Set to `undefined` to opt out.
+   */
+  readonly string?: string | undefined;
+  /**
+   * The empty input of a number field. Defaults to `undefined`.
+   */
+  readonly number?: number | undefined;
+  /**
+   * The empty input of a boolean field. Defaults to `undefined`.
+   */
+  readonly boolean?: boolean | undefined;
+  /**
+   * The empty input of a date field. Defaults to `undefined`.
+   */
+  readonly date?: Date | undefined;
+}
+
+/**
  * Form config interface.
  */
 export interface FormConfig<TSchema extends FormSchema = FormSchema> {
@@ -28,6 +57,11 @@ export interface FormConfig<TSchema extends FormSchema = FormSchema> {
    * The initial input of the form.
    */
   readonly initialInput?: DeepPartial<v.InferInput<TSchema>> | undefined;
+  /**
+   * The empty input of the form, keyed by field type. Merged on top of the
+   * defaults, so `{ string: '' }` stays in effect unless overridden.
+   */
+  readonly emptyInput?: EmptyInput | undefined;
   /**
    * The validation mode of the form.
    */
@@ -52,6 +86,10 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
    * The number of active validators.
    */
   validators: number;
+  /**
+   * The resolved empty input of the form, keyed by field type.
+   */
+  emptyInput: EmptyInput;
   /**
    * The validation mode of the form.
    */

--- a/packages/core/src/vitest/utils.ts
+++ b/packages/core/src/vitest/utils.ts
@@ -2,6 +2,7 @@ import type * as v from 'valibot';
 import { vi } from 'vitest';
 import { createFormStore } from '../form/createFormStore/createFormStore.ts';
 import type {
+  EmptyInput,
   FormSchema,
   InternalFormStore,
   ValidationMode,
@@ -14,6 +15,7 @@ interface CreateTestStoreConfig {
   validate?: ValidationMode | undefined;
   revalidate?: Exclude<ValidationMode, 'initial'> | undefined;
   initialInput?: unknown | undefined;
+  emptyInput?: EmptyInput | undefined;
   issues?: [v.BaseIssue<unknown>, ...v.BaseIssue<unknown>[]] | undefined;
 }
 
@@ -29,7 +31,7 @@ export function createTestStore<TSchema extends FormSchema>(
   schema: TSchema,
   config: CreateTestStoreConfig = {}
 ): InternalFormStore<TSchema> {
-  const { validate, revalidate, initialInput, issues } = config;
+  const { validate, revalidate, initialInput, emptyInput, issues } = config;
 
   const result: v.SafeParseResult<TSchema> = issues
     ? {
@@ -52,6 +54,7 @@ export function createTestStore<TSchema extends FormSchema>(
     {
       schema,
       initialInput: initialInput as v.InferInput<TSchema>,
+      emptyInput,
       validate,
       revalidate,
     },

--- a/packages/methods/src/insert/insert.test.ts
+++ b/packages/methods/src/insert/insert.test.ts
@@ -19,6 +19,42 @@ describe('insert', () => {
     }
   });
 
+  test('should default a new item without input to its empty input', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [{ name: 'a' }] } }
+    );
+
+    insert(store, { path: ['items'] });
+
+    const itemsStore = store.children.items;
+    expect(itemsStore.kind).toBe('array');
+    if (itemsStore.kind === 'array') {
+      const newItem = itemsStore.children[1];
+      if (newItem.kind === 'object') {
+        expect(newItem.children.name.input.value).toBe('');
+      }
+    }
+  });
+
+  test('should apply configured empty input to a new item', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ score: v.number() })) }),
+      { initialInput: { items: [{ score: 1 }] }, emptyInput: { number: 0 } }
+    );
+
+    insert(store, { path: ['items'] });
+
+    const itemsStore = store.children.items;
+    expect(itemsStore.kind).toBe('array');
+    if (itemsStore.kind === 'array') {
+      const newItem = itemsStore.children[1];
+      if (newItem.kind === 'object') {
+        expect(newItem.children.score.input.value).toBe(0);
+      }
+    }
+  });
+
   test('should insert item at specific index and shift children', () => {
     const store = createTestStore(v.object({ items: v.array(v.string()) }), {
       initialInput: { items: ['a', 'b'] },
@@ -63,7 +99,7 @@ describe('insert', () => {
     expect(itemsStore.kind).toBe('array');
     if (itemsStore.kind === 'array') {
       // Pre-initialize slot at index 2 and also at index 0 to make resetItemState branch execute
-      initializeChildSlot(itemsStore, 2);
+      initializeChildSlot(store, itemsStore, 2);
 
       // Store reference to original child at index 0
       const originalChild = itemsStore.children[0];

--- a/packages/methods/src/insert/insert.ts
+++ b/packages/methods/src/insert/insert.ts
@@ -93,6 +93,7 @@ export function insert<
           // @ts-expect-error
           internalArrayStore.children[index] = {};
           initializeFieldStore(
+            internalFormStore,
             internalArrayStore.children[index],
             // @ts-expect-error
             internalArrayStore.schema.item,
@@ -101,6 +102,7 @@ export function insert<
           );
         }
         copyItemState(
+          internalFormStore,
           internalArrayStore.children[index - 1],
           internalArrayStore.children[index]
         );
@@ -110,6 +112,7 @@ export function insert<
         // @ts-expect-error
         internalArrayStore.children[insertIndex] = {};
         initializeFieldStore(
+          internalFormStore,
           internalArrayStore.children[insertIndex],
           // @ts-expect-error
           internalArrayStore.schema.item,
@@ -118,6 +121,7 @@ export function insert<
         );
       } else {
         resetItemState(
+          internalFormStore,
           internalArrayStore.children[insertIndex],
           config.initialInput
         );

--- a/packages/methods/src/move/move.ts
+++ b/packages/methods/src/move/move.ts
@@ -77,6 +77,7 @@ export function move<
       // Create temporary internal field store
       const tempInternalFieldStore = {} as InternalFieldStore;
       initializeFieldStore(
+        internalFormStore,
         tempInternalFieldStore,
         // @ts-expect-error
         internalArrayStore.schema.item,
@@ -86,6 +87,7 @@ export function move<
 
       // Copy item state that gets overwritten to temporary store
       copyItemState(
+        internalFormStore,
         internalArrayStore.children[config.from],
         tempInternalFieldStore
       );
@@ -94,6 +96,7 @@ export function move<
         // Move child stores between 'from' and 'to' one index down
         for (let index = config.from; index < config.to; index++) {
           copyItemState(
+            internalFormStore,
             internalArrayStore.children[index + 1],
             internalArrayStore.children[index]
           );
@@ -102,6 +105,7 @@ export function move<
         // Move child stores between 'to' and 'from' one index up
         for (let index = config.from; index > config.to; index--) {
           copyItemState(
+            internalFormStore,
             internalArrayStore.children[index - 1],
             internalArrayStore.children[index]
           );
@@ -110,6 +114,7 @@ export function move<
 
       // Copy item state from temporary store to new position
       copyItemState(
+        internalFormStore,
         tempInternalFieldStore,
         internalArrayStore.children[config.to]
       );

--- a/packages/methods/src/remove/remove.ts
+++ b/packages/methods/src/remove/remove.ts
@@ -65,6 +65,7 @@ export function remove<
       // Move all child stores after the removed item one index down
       for (let index = config.at; index < items.length - 1; index++) {
         copyItemState(
+          internalFormStore,
           internalArrayStore.children[index + 1],
           internalArrayStore.children[index]
         );

--- a/packages/methods/src/replace/replace.test.ts
+++ b/packages/methods/src/replace/replace.test.ts
@@ -167,7 +167,7 @@ describe('replace', () => {
       initialInput: { type: 'array', array: ['foo', 'bar'] },
     });
     expect(getFieldInput(store)).toStrictEqual({
-      a: [{ type: 'array', string: undefined, array: ['foo', 'bar'] }],
+      a: [{ type: 'array', string: '', array: ['foo', 'bar'] }],
     });
 
     // Switch to the "array" variant but omit the array key -> stays `[]`
@@ -177,7 +177,7 @@ describe('replace', () => {
       initialInput: { type: 'array' },
     });
     expect(getFieldInput(store)).toStrictEqual({
-      a: [{ type: 'array', string: undefined, array: [] }],
+      a: [{ type: 'array', string: '', array: [] }],
     });
   });
 
@@ -191,10 +191,30 @@ describe('replace', () => {
 
     replace(store, { path: ['a'], at: 0, initialInput: {} });
 
-    // An omitted non-nullish tuple keeps its fixed positions (reset to
-    // `undefined`) instead of collapsing to an empty array
+    // An omitted non-nullish tuple keeps its fixed positions (reset to their
+    // empty input: an empty string for the string, undefined for the number)
+    // instead of collapsing to an empty array
     expect(getFieldInput(store)).toStrictEqual({
-      a: [{ pair: [undefined, undefined] }],
+      a: [{ pair: ['', undefined] }],
+    });
+  });
+
+  test('should reset an omitted required field to its empty input but keep an optional field undefined', () => {
+    const store = createTestStore(
+      v.object({
+        a: v.array(
+          v.object({ name: v.string(), nickname: v.optional(v.string()) })
+        ),
+      }),
+      { initialInput: { a: [{ name: 'x', nickname: 'y' }] } }
+    );
+
+    replace(store, { path: ['a'], at: 0, initialInput: { name: 'z' } });
+
+    // The required string falls back to its empty input, while the optional
+    // string stays undefined as it accepts it
+    expect(getFieldInput(store)).toStrictEqual({
+      a: [{ name: 'z', nickname: undefined }],
     });
   });
 });

--- a/packages/methods/src/replace/replace.test.ts
+++ b/packages/methods/src/replace/replace.test.ts
@@ -209,12 +209,12 @@ describe('replace', () => {
       { initialInput: { a: [{ name: 'x', nickname: 'y' }] } }
     );
 
-    replace(store, { path: ['a'], at: 0, initialInput: { name: 'z' } });
+    replace(store, { path: ['a'], at: 0, initialInput: {} });
 
-    // The required string falls back to its empty input, while the optional
-    // string stays undefined as it accepts it
+    // The omitted required string falls back to its empty input, while the
+    // omitted optional string stays undefined as it accepts it
     expect(getFieldInput(store)).toStrictEqual({
-      a: [{ name: 'z', nickname: undefined }],
+      a: [{ name: '', nickname: undefined }],
     });
   });
 });

--- a/packages/methods/src/replace/replace.ts
+++ b/packages/methods/src/replace/replace.ts
@@ -74,6 +74,7 @@ export function replace<
 
       // Replace input of field array item
       resetItemState(
+        internalFormStore,
         internalArrayStore.children[config.at],
         config.initialInput
       );

--- a/packages/methods/src/reset/reset.test.ts
+++ b/packages/methods/src/reset/reset.test.ts
@@ -295,7 +295,7 @@ describe('reset', () => {
       expect(store.children.name.initialInput.value).toBeNull();
     });
 
-    test('should reset field to undefined when initialInput is explicitly undefined', () => {
+    test('should reset field to its empty input when initialInput is explicitly undefined', () => {
       const store = createTestStore(v.object({ name: v.string() }), {
         initialInput: { name: 'John' },
       });
@@ -303,8 +303,10 @@ describe('reset', () => {
 
       reset(store, { path: ['name'], initialInput: undefined });
 
-      expect(store.children.name.input.value).toBeUndefined();
-      expect(store.children.name.initialInput.value).toBeUndefined();
+      // A required string falls back to its empty input, staying consistent
+      // with form initialization
+      expect(store.children.name.input.value).toBe('');
+      expect(store.children.name.initialInput.value).toBe('');
     });
 
     test('should keep existing initial input when initialInput key is omitted', () => {

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -120,7 +120,11 @@ export function reset(
 
       // If initial input is provided, set it
       if (config && 'initialInput' in config) {
-        setInitialFieldInput(internalFieldStore, config.initialInput);
+        setInitialFieldInput(
+          internalFormStore,
+          internalFieldStore,
+          config.initialInput
+        );
       }
 
       // Reset state of fields by walking field store

--- a/packages/methods/src/swap/swap.ts
+++ b/packages/methods/src/swap/swap.ts
@@ -75,6 +75,7 @@ export function swap<
 
       // Swap child stores directly
       swapItemState(
+        internalFormStore,
         internalArrayStore.children[config.at],
         internalArrayStore.children[config.and]
       );

--- a/packages/methods/src/vitest/utils.ts
+++ b/packages/methods/src/vitest/utils.ts
@@ -1,6 +1,7 @@
 import {
   type BaseFormStore,
   createFormStore,
+  type EmptyInput,
   type FormSchema,
   initializeFieldStore,
   INTERNAL,
@@ -18,6 +19,7 @@ interface CreateTestStoreConfig<TSchema extends FormSchema> {
   validate?: ValidationMode | undefined;
   revalidate?: Exclude<ValidationMode, 'initial'> | undefined;
   initialInput?: v.InferInput<TSchema> | undefined;
+  emptyInput?: EmptyInput | undefined;
   issues?: [v.BaseIssue<unknown>, ...v.BaseIssue<unknown>[]] | undefined;
 }
 
@@ -37,6 +39,7 @@ export function createTestStore<TSchema extends FormSchema>(
     validate = 'submit',
     revalidate = 'input',
     initialInput,
+    emptyInput,
     issues,
   } = config;
 
@@ -61,6 +64,7 @@ export function createTestStore<TSchema extends FormSchema>(
     {
       schema,
       initialInput,
+      emptyInput,
       validate,
       revalidate,
     },
@@ -158,10 +162,12 @@ export function schemaIssue(message: string): v.BaseIssue<unknown> {
  * Pre-initializes a child slot in an array store to enable testing
  * of insert operations at specific indices.
  *
+ * @param internalFormStore The internal form store.
  * @param arrayStore The internal array store.
  * @param index The index to initialize.
  */
 export function initializeChildSlot(
+  internalFormStore: InternalFormStore,
   arrayStore: InternalArrayStore,
   index: number
 ): void {
@@ -169,6 +175,7 @@ export function initializeChildSlot(
     // @ts-expect-error - Creating empty object to be initialized
     arrayStore.children[index] = {};
     initializeFieldStore(
+      internalFormStore,
       arrayStore.children[index],
       // @ts-expect-error - Accessing schema item
       arrayStore.schema.item,

--- a/playgrounds/preact/src/routes/login/index.tsx
+++ b/playgrounds/preact/src/routes/login/index.tsx
@@ -4,12 +4,12 @@ import { FormFooter, FormHeader, TextInput } from '../../components';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/playgrounds/preact/src/routes/payment/index.tsx
+++ b/playgrounds/preact/src/routes/payment/index.tsx
@@ -5,10 +5,7 @@ import { FormFooter, FormHeader, Select, TextInput } from '../../components';
 
 const PaymentFormSchema = v.intersect([
   v.object({
-    owner: v.pipe(
-      v.string('Please enter your name.'),
-      v.nonEmpty('Please enter your name.')
-    ),
+    owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
   }),
   v.variant(
     'type',
@@ -17,12 +14,12 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('card'),
         card: v.object({
           number: v.pipe(
-            v.string('Please enter your card number.'),
+            v.string(),
             v.nonEmpty('Please enter your card number.'),
             v.creditCard('The card number is badly formatted.')
           ),
           expiration: v.pipe(
-            v.string('Please enter the expiration date.'),
+            v.string(),
             v.nonEmpty('Please enter the expiration date.'),
             v.regex(
               /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -35,7 +32,7 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('paypal'),
         paypal: v.object({
           email: v.pipe(
-            v.string('Please enter your PayPal email.'),
+            v.string(),
             v.nonEmpty('Please enter your PayPal email.'),
             v.email('The email address is badly formatted.')
           ),

--- a/playgrounds/preact/src/routes/todos/index.tsx
+++ b/playgrounds/preact/src/routes/todos/index.tsx
@@ -22,21 +22,12 @@ import {
 } from '../../components';
 
 const TodoFormSchema = v.object({
-  heading: v.pipe(
-    v.string('Please enter a heading.'),
-    v.nonEmpty('Please enter a heading.')
-  ),
+  heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
   todos: v.pipe(
     v.array(
       v.object({
-        label: v.pipe(
-          v.string('Please enter a label.'),
-          v.nonEmpty('Please enter a label.')
-        ),
-        deadline: v.pipe(
-          v.string('Please enter a deadline.'),
-          v.nonEmpty('Please enter a deadline.')
-        ),
+        label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+        deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
       })
     ),
     v.nonEmpty('Please add at least one todo.'),

--- a/playgrounds/qwik/src/routes/login/index.tsx
+++ b/playgrounds/qwik/src/routes/login/index.tsx
@@ -6,12 +6,12 @@ import { FormFooter, FormHeader, TextInput } from '~/components';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/playgrounds/qwik/src/routes/payment/index.tsx
+++ b/playgrounds/qwik/src/routes/payment/index.tsx
@@ -6,10 +6,7 @@ import { FormFooter, FormHeader, Select, TextInput } from '~/components';
 
 const PaymentFormSchema = v.intersect([
   v.object({
-    owner: v.pipe(
-      v.string('Please enter your name.'),
-      v.nonEmpty('Please enter your name.')
-    ),
+    owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
   }),
   v.variant(
     'type',
@@ -18,12 +15,12 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('card'),
         card: v.object({
           number: v.pipe(
-            v.string('Please enter your card number.'),
+            v.string(),
             v.nonEmpty('Please enter your card number.'),
             v.creditCard('The card number is badly formatted.')
           ),
           expiration: v.pipe(
-            v.string('Please enter the expiration date.'),
+            v.string(),
             v.nonEmpty('Please enter the expiration date.'),
             v.regex(
               /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -36,7 +33,7 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('paypal'),
         paypal: v.object({
           email: v.pipe(
-            v.string('Please enter your PayPal email.'),
+            v.string(),
             v.nonEmpty('Please enter your PayPal email.'),
             v.email('The email address is badly formatted.')
           ),

--- a/playgrounds/qwik/src/routes/todos/index.tsx
+++ b/playgrounds/qwik/src/routes/todos/index.tsx
@@ -23,21 +23,12 @@ import {
 } from '~/components';
 
 const TodoFormSchema = v.object({
-  heading: v.pipe(
-    v.string('Please enter a heading.'),
-    v.nonEmpty('Please enter a heading.')
-  ),
+  heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
   todos: v.pipe(
     v.array(
       v.object({
-        label: v.pipe(
-          v.string('Please enter a label.'),
-          v.nonEmpty('Please enter a label.')
-        ),
-        deadline: v.pipe(
-          v.string('Please enter a deadline.'),
-          v.nonEmpty('Please enter a deadline.')
-        ),
+        label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+        deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
       })
     ),
     v.nonEmpty('Please add at least one todo.'),

--- a/playgrounds/react/src/routes/login/index.tsx
+++ b/playgrounds/react/src/routes/login/index.tsx
@@ -4,12 +4,12 @@ import { FormFooter, FormHeader, TextInput } from '../../components';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/playgrounds/react/src/routes/payment/index.tsx
+++ b/playgrounds/react/src/routes/payment/index.tsx
@@ -4,10 +4,7 @@ import { FormFooter, FormHeader, Select, TextInput } from '../../components';
 
 const PaymentFormSchema = v.intersect([
   v.object({
-    owner: v.pipe(
-      v.string('Please enter your name.'),
-      v.nonEmpty('Please enter your name.')
-    ),
+    owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
   }),
   v.variant(
     'type',
@@ -16,12 +13,12 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('card'),
         card: v.object({
           number: v.pipe(
-            v.string('Please enter your card number.'),
+            v.string(),
             v.nonEmpty('Please enter your card number.'),
             v.creditCard('The card number is badly formatted.')
           ),
           expiration: v.pipe(
-            v.string('Please enter the expiration date.'),
+            v.string(),
             v.nonEmpty('Please enter the expiration date.'),
             v.regex(
               /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -34,7 +31,7 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('paypal'),
         paypal: v.object({
           email: v.pipe(
-            v.string('Please enter your PayPal email.'),
+            v.string(),
             v.nonEmpty('Please enter your PayPal email.'),
             v.email('The email address is badly formatted.')
           ),

--- a/playgrounds/react/src/routes/todos/index.tsx
+++ b/playgrounds/react/src/routes/todos/index.tsx
@@ -21,21 +21,12 @@ import {
 } from '../../components';
 
 const TodoFormSchema = v.object({
-  heading: v.pipe(
-    v.string('Please enter a heading.'),
-    v.nonEmpty('Please enter a heading.')
-  ),
+  heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
   todos: v.pipe(
     v.array(
       v.object({
-        label: v.pipe(
-          v.string('Please enter a label.'),
-          v.nonEmpty('Please enter a label.')
-        ),
-        deadline: v.pipe(
-          v.string('Please enter a deadline.'),
-          v.nonEmpty('Please enter a deadline.')
-        ),
+        label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+        deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
       })
     ),
     v.nonEmpty('Please add at least one todo.'),
@@ -93,7 +84,7 @@ export default function Page() {
                         {(field) => (
                           <TextInput
                             {...field.props}
-                            className="w-full p-0! md:w-auto md:flex-1"
+                            className="p-0! w-full md:w-auto md:flex-1"
                             input={field.input}
                             errors={field.errors}
                             type="text"
@@ -107,7 +98,7 @@ export default function Page() {
                         {(field) => (
                           <TextInput
                             {...field.props}
-                            className="flex-1 p-0!"
+                            className="p-0! flex-1"
                             type="date"
                             input={field.input}
                             errors={field.errors}

--- a/playgrounds/solid/src/routes/login/index.tsx
+++ b/playgrounds/solid/src/routes/login/index.tsx
@@ -4,12 +4,12 @@ import { FormFooter, FormHeader, TextInput, Title } from '~/components';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/playgrounds/solid/src/routes/payment/index.tsx
+++ b/playgrounds/solid/src/routes/payment/index.tsx
@@ -5,10 +5,7 @@ import { FormFooter, FormHeader, Select, TextInput, Title } from '~/components';
 
 const PaymentFormSchema = v.intersect([
   v.object({
-    owner: v.pipe(
-      v.string('Please enter your name.'),
-      v.nonEmpty('Please enter your name.')
-    ),
+    owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
   }),
   v.variant(
     'type',
@@ -17,12 +14,12 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('card'),
         card: v.object({
           number: v.pipe(
-            v.string('Please enter your card number.'),
+            v.string(),
             v.nonEmpty('Please enter your card number.'),
             v.creditCard('The card number is badly formatted.')
           ),
           expiration: v.pipe(
-            v.string('Please enter the expiration date.'),
+            v.string(),
             v.nonEmpty('Please enter the expiration date.'),
             v.regex(
               /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -35,7 +32,7 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('paypal'),
         paypal: v.object({
           email: v.pipe(
-            v.string('Please enter your PayPal email.'),
+            v.string(),
             v.nonEmpty('Please enter your PayPal email.'),
             v.email('The email address is badly formatted.')
           ),

--- a/playgrounds/solid/src/routes/todos/index.tsx
+++ b/playgrounds/solid/src/routes/todos/index.tsx
@@ -23,21 +23,12 @@ import {
 } from '~/components';
 
 const TodoFormSchema = v.object({
-  heading: v.pipe(
-    v.string('Please enter a heading.'),
-    v.nonEmpty('Please enter a heading.')
-  ),
+  heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
   todos: v.pipe(
     v.array(
       v.object({
-        label: v.pipe(
-          v.string('Please enter a label.'),
-          v.nonEmpty('Please enter a label.')
-        ),
-        deadline: v.pipe(
-          v.string('Please enter a deadline.'),
-          v.nonEmpty('Please enter a deadline.')
-        ),
+        label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+        deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
       })
     ),
     v.nonEmpty('Please add at least one todo.'),

--- a/playgrounds/svelte/src/routes/login/+page.svelte
+++ b/playgrounds/svelte/src/routes/login/+page.svelte
@@ -5,12 +5,12 @@
 
   const LoginSchema = v.object({
     email: v.pipe(
-      v.string('Please enter your email.'),
+      v.string(),
       v.nonEmpty('Please enter your email.'),
       v.email('The email address is badly formatted.')
     ),
     password: v.pipe(
-      v.string('Please enter your password.'),
+      v.string(),
       v.nonEmpty('Please enter your password.'),
       v.minLength(8, 'Your password must have 8 characters or more.')
     ),

--- a/playgrounds/svelte/src/routes/payment/+page.svelte
+++ b/playgrounds/svelte/src/routes/payment/+page.svelte
@@ -5,10 +5,7 @@
 
   const PaymentFormSchema = v.intersect([
     v.object({
-      owner: v.pipe(
-        v.string('Please enter your name.'),
-        v.nonEmpty('Please enter your name.')
-      ),
+      owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
     }),
     v.variant(
       'type',
@@ -17,12 +14,12 @@
           type: v.literal('card'),
           card: v.object({
             number: v.pipe(
-              v.string('Please enter your card number.'),
+              v.string(),
               v.nonEmpty('Please enter your card number.'),
               v.creditCard('The card number is badly formatted.')
             ),
             expiration: v.pipe(
-              v.string('Please enter the expiration date.'),
+              v.string(),
               v.nonEmpty('Please enter the expiration date.'),
               v.regex(
                 /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -35,7 +32,7 @@
           type: v.literal('paypal'),
           paypal: v.object({
             email: v.pipe(
-              v.string('Please enter your PayPal email.'),
+              v.string(),
               v.nonEmpty('Please enter your PayPal email.'),
               v.email('The email address is badly formatted.')
             ),

--- a/playgrounds/svelte/src/routes/todos/+page.svelte
+++ b/playgrounds/svelte/src/routes/todos/+page.svelte
@@ -22,21 +22,12 @@
   } from '$lib/components';
 
   const TodoFormSchema = v.object({
-    heading: v.pipe(
-      v.string('Please enter a heading.'),
-      v.nonEmpty('Please enter a heading.')
-    ),
+    heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
     todos: v.pipe(
       v.array(
         v.object({
-          label: v.pipe(
-            v.string('Please enter a label.'),
-            v.nonEmpty('Please enter a label.')
-          ),
-          deadline: v.pipe(
-            v.string('Please enter a deadline.'),
-            v.nonEmpty('Please enter a deadline.')
-          ),
+          label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+          deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
         })
       ),
       v.nonEmpty('Please add at least one todo.'),

--- a/playgrounds/vue/src/views/LoginView.vue
+++ b/playgrounds/vue/src/views/LoginView.vue
@@ -5,12 +5,12 @@ import { FormFooter, FormHeader, TextInput } from '../components';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/playgrounds/vue/src/views/PaymentView.vue
+++ b/playgrounds/vue/src/views/PaymentView.vue
@@ -6,10 +6,7 @@ import { FormFooter, FormHeader, Select, TextInput } from '../components';
 
 const PaymentFormSchema = v.intersect([
   v.object({
-    owner: v.pipe(
-      v.string('Please enter your name.'),
-      v.nonEmpty('Please enter your name.')
-    ),
+    owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
   }),
   v.variant(
     'type',
@@ -18,12 +15,12 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('card'),
         card: v.object({
           number: v.pipe(
-            v.string('Please enter your card number.'),
+            v.string(),
             v.nonEmpty('Please enter your card number.'),
             v.creditCard('The card number is badly formatted.')
           ),
           expiration: v.pipe(
-            v.string('Please enter the expiration date.'),
+            v.string(),
             v.nonEmpty('Please enter the expiration date.'),
             v.regex(
               /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -36,7 +33,7 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('paypal'),
         paypal: v.object({
           email: v.pipe(
-            v.string('Please enter your PayPal email.'),
+            v.string(),
             v.nonEmpty('Please enter your PayPal email.'),
             v.email('The email address is badly formatted.')
           ),

--- a/playgrounds/vue/src/views/TodosView.vue
+++ b/playgrounds/vue/src/views/TodosView.vue
@@ -21,21 +21,12 @@ import {
 } from '../components';
 
 const TodoFormSchema = v.object({
-  heading: v.pipe(
-    v.string('Please enter a heading.'),
-    v.nonEmpty('Please enter a heading.')
-  ),
+  heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
   todos: v.pipe(
     v.array(
       v.object({
-        label: v.pipe(
-          v.string('Please enter a label.'),
-          v.nonEmpty('Please enter a label.')
-        ),
-        deadline: v.pipe(
-          v.string('Please enter a deadline.'),
-          v.nonEmpty('Please enter a deadline.')
-        ),
+        label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+        deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
       })
     ),
     v.nonEmpty('Please add at least one todo.'),

--- a/website/src/routes/(docs)/core/api/(types)/EmptyInput/index.mdx
+++ b/website/src/routes/(docs)/core/api/(types)/EmptyInput/index.mdx
@@ -1,0 +1,36 @@
+---
+title: EmptyInput
+description: Type definition that specifies the empty input a required field starts at, keyed by field type.
+source: /packages/core/src/types/form/form.ts
+contributors:
+  - fabian-hiller
+---
+
+import { ApiList, Link, Property } from '~/components';
+import { properties } from './properties';
+
+# EmptyInput
+
+Empty input interface that defines the value a required field of a given type starts at when no initial input is provided. Optional and nullable fields are not affected, as they accept `undefined`.
+
+## Definition
+
+- `EmptyInput`
+  - `string` <Property {...properties.string} />
+  - `number` <Property {...properties.number} />
+  - `boolean` <Property {...properties.boolean} />
+  - `date` <Property {...properties.date} />
+
+### Explanation
+
+Only required fields whose input is `undefined` fall back to these values. The `string` property defaults to an empty string so that an untouched field matches the DOM and validates with its own message instead of a type mismatch. The other properties default to `undefined`.
+
+## Related
+
+### Primitives
+
+<ApiList items={[{ text: 'useForm', href: '/react/api/useForm/' }]} />
+
+### Types
+
+<ApiList items={[{ text: 'FormConfig', href: '/react/api/FormConfig/' }]} />

--- a/website/src/routes/(docs)/core/api/(types)/EmptyInput/properties.ts
+++ b/website/src/routes/(docs)/core/api/(types)/EmptyInput/properties.ts
@@ -1,0 +1,67 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  EmptyInput: {
+    type: {
+      type: 'object',
+      entries: [
+        {
+          key: 'string',
+          optional: true,
+          value: {
+            type: 'union',
+            options: ['string', 'undefined'],
+          },
+        },
+        {
+          key: 'number',
+          optional: true,
+          value: {
+            type: 'union',
+            options: ['number', 'undefined'],
+          },
+        },
+        {
+          key: 'boolean',
+          optional: true,
+          value: {
+            type: 'union',
+            options: ['boolean', 'undefined'],
+          },
+        },
+        {
+          key: 'date',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [{ type: 'custom', name: 'Date' }, 'undefined'],
+          },
+        },
+      ],
+    },
+  },
+  string: {
+    type: {
+      type: 'union',
+      options: ['string', 'undefined'],
+    },
+  },
+  number: {
+    type: {
+      type: 'union',
+      options: ['number', 'undefined'],
+    },
+  },
+  boolean: {
+    type: {
+      type: 'union',
+      options: ['boolean', 'undefined'],
+    },
+  },
+  date: {
+    type: {
+      type: 'union',
+      options: [{ type: 'custom', name: 'Date' }, 'undefined'],
+    },
+  },
+};

--- a/website/src/routes/(docs)/preact/api/(types)/FormConfig/index.mdx
+++ b/website/src/routes/(docs)/preact/api/(types)/FormConfig/index.mdx
@@ -22,9 +22,10 @@ Form config interface that defines the configuration options for creating a form
 - `FormConfig`
   - `schema` <Property {...properties.schema} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />
 
 ### Explanation
 
-The `FormConfig` object is passed to <Link href="../useForm/">`useForm`</Link> with a required `schema` property and optional properties for `initialInput`, `validate`, and `revalidate` to control form behavior and validation timing.
+The `FormConfig` object is passed to <Link href="../useForm/">`useForm`</Link> with a required `schema` property and optional properties for `initialInput`, `emptyInput`, `validate`, and `revalidate` to control form behavior and validation timing.

--- a/website/src/routes/(docs)/preact/api/(types)/FormConfig/properties.ts
+++ b/website/src/routes/(docs)/preact/api/(types)/FormConfig/properties.ts
@@ -49,6 +49,21 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'emptyInput',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'EmptyInput',
+                href: '/core/api/EmptyInput/',
+              },
+              'undefined',
+            ],
+          },
+        },
+        {
           key: 'validate',
           optional: true,
           value: {
@@ -108,6 +123,19 @@ export const properties: Record<string, PropertyProps> = {
               ],
             },
           ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  emptyInput: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'EmptyInput',
+          href: '/core/api/EmptyInput/',
         },
         'undefined',
       ],

--- a/website/src/routes/(docs)/preact/api/menu.md
+++ b/website/src/routes/(docs)/preact/api/menu.md
@@ -42,6 +42,7 @@
 
 - [DeepErrorEntry](/methods/api/DeepErrorEntry/)
 - [DeepPartial](/core/api/DeepPartial/)
+- [EmptyInput](/core/api/EmptyInput/)
 - [FieldArrayStore](/preact/api/FieldArrayStore/)
 - [FieldElement](/core/api/FieldElement/)
 - [FieldElementProps](/preact/api/FieldElementProps/)

--- a/website/src/routes/(docs)/preact/guides/(main-concepts)/create-your-form/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(main-concepts)/create-your-form/index.mdx
@@ -42,6 +42,7 @@ The <Link href="/preact/api/useForm/">`useForm`</Link> hook accepts a configurat
 
 - `schema`: Your Valibot schema that defines the form
 - `initialInput`: Initial values for your form fields (optional)
+- `emptyInput`: The empty value each field type starts at when a required field has no initial input (optional, defaults to `{ string: '' }`)
 - `validate`: When validation first occurs (optional, defaults to `'submit'`)
 - `revalidate`: When revalidation occurs after initial validation (optional, defaults to `'input'`)
 
@@ -60,7 +61,26 @@ Formisch tracks two inputs for every field: the **initial input** (baseline for 
 
 `isDirty` becomes `true` when a field's current input differs from its initial input. Use <Link href="/methods/api/setInput/">`setInput`</Link> to update the current input (client state), and use <Link href="/methods/api/reset/">`reset`</Link> to update the initial input (baseline) when your server data changes or is refreshed.
 
-### Multiple forms
+### Empty input
+
+By default, a required string field starts as an empty string (`''`) instead of `undefined`, matching an empty text input. This way an empty field shows the validation message you defined for it (for example from `v.nonEmpty()`) without you setting an `initialInput` for every field.
+
+You can configure the empty value per field type, or opt out by setting a type to `undefined`:
+
+```tsx
+const loginForm = useForm({
+  schema: LoginSchema,
+  emptyInput: {
+    string: '', // the default
+    number: 0, // required numbers start at 0 instead of undefined
+    boolean: false, // checkboxes start unchecked
+  },
+});
+```
+
+Optional and nullable fields are never affected and keep starting as `undefined`, since they accept it. The supported types are `string`, `number`, `boolean` and `date`, and the default is `{ string: '' }`.
+
+## Multiple forms
 
 When a page contains multiple forms, you can create separate form stores for each one:
 
@@ -91,6 +111,8 @@ export default function App() {
   );
 }
 ```
+
+If you need a multi-step form (wizard), see the [multi-step form discussion](https://github.com/open-circle/formisch/discussions/108) for patterns and approaches.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/preact/guides/(main-concepts)/define-your-form/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(main-concepts)/define-your-form/index.mdx
@@ -28,12 +28,12 @@ import * as v from 'valibot';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/(docs)/qwik/api/(types)/FormConfig/index.mdx
+++ b/website/src/routes/(docs)/qwik/api/(types)/FormConfig/index.mdx
@@ -22,9 +22,10 @@ Form config interface that defines the configuration options returned from the c
 - `FormConfig`
   - `schema` <Property {...properties.schema} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />
 
 ### Explanation
 
-The `FormConfig` object is returned from the configuration function passed to <Link href="../useForm$/">`useForm$`</Link>. It has a required `schema` property and optional properties for `initialInput`, `validate`, and `revalidate` to control form behavior and validation timing.
+The `FormConfig` object is returned from the configuration function passed to <Link href="../useForm$/">`useForm$`</Link>. It has a required `schema` property and optional properties for `initialInput`, `emptyInput`, `validate`, and `revalidate` to control form behavior and validation timing.

--- a/website/src/routes/(docs)/qwik/api/(types)/FormConfig/properties.ts
+++ b/website/src/routes/(docs)/qwik/api/(types)/FormConfig/properties.ts
@@ -49,6 +49,21 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'emptyInput',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'EmptyInput',
+                href: '/core/api/EmptyInput/',
+              },
+              'undefined',
+            ],
+          },
+        },
+        {
           key: 'validate',
           optional: true,
           value: {
@@ -108,6 +123,19 @@ export const properties: Record<string, PropertyProps> = {
               ],
             },
           ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  emptyInput: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'EmptyInput',
+          href: '/core/api/EmptyInput/',
         },
         'undefined',
       ],

--- a/website/src/routes/(docs)/qwik/api/menu.md
+++ b/website/src/routes/(docs)/qwik/api/menu.md
@@ -42,6 +42,7 @@
 
 - [DeepErrorEntry](/methods/api/DeepErrorEntry/)
 - [DeepPartial](/core/api/DeepPartial/)
+- [EmptyInput](/core/api/EmptyInput/)
 - [FieldArrayStore](/qwik/api/FieldArrayStore/)
 - [FieldElement](/core/api/FieldElement/)
 - [FieldElementProps](/qwik/api/FieldElementProps/)

--- a/website/src/routes/(docs)/qwik/guides/(main-concepts)/create-your-form/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(main-concepts)/create-your-form/index.mdx
@@ -43,6 +43,7 @@ The <Link href="/qwik/api/useForm$/">`useForm$`</Link> hook accepts a configurat
 
 - `schema`: Your Valibot schema that defines the form
 - `initialInput`: Initial values for your form fields (optional)
+- `emptyInput`: The empty value each field type starts at when a required field has no initial input (optional, defaults to `{ string: '' }`)
 - `validate`: When validation first occurs (optional, defaults to `'submit'`)
 - `revalidate`: When revalidation occurs after initial validation (optional, defaults to `'input'`)
 
@@ -61,7 +62,26 @@ Formisch tracks two inputs for every field: the **initial input** (baseline for 
 
 `isDirty` becomes `true` when a field's current input differs from its initial input. Use <Link href="/methods/api/setInput/">`setInput`</Link> to update the current input (client state), and use <Link href="/methods/api/reset/">`reset`</Link> to update the initial input (baseline) when your server data changes or is refreshed.
 
-### Multiple forms
+### Empty input
+
+By default, a required string field starts as an empty string (`''`) instead of `undefined`, matching an empty text input. This way an empty field shows the validation message you defined for it (for example from `v.nonEmpty()`) without you setting an `initialInput` for every field.
+
+You can configure the empty value per field type, or opt out by setting a type to `undefined`:
+
+```tsx
+const loginForm = useForm$(() => ({
+  schema: LoginSchema,
+  emptyInput: {
+    string: '', // the default
+    number: 0, // required numbers start at 0 instead of undefined
+    boolean: false, // checkboxes start unchecked
+  },
+}));
+```
+
+Optional and nullable fields are never affected and keep starting as `undefined`, since they accept it. The supported types are `string`, `number`, `boolean` and `date`, and the default is `{ string: '' }`.
+
+## Multiple forms
 
 When a page contains multiple forms, you can create separate form stores for each one:
 
@@ -93,6 +113,8 @@ export default component$(() => {
   );
 });
 ```
+
+If you need a multi-step form (wizard), see the [multi-step form discussion](https://github.com/open-circle/formisch/discussions/108) for patterns and approaches.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/qwik/guides/(main-concepts)/define-your-form/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(main-concepts)/define-your-form/index.mdx
@@ -28,12 +28,12 @@ import * as v from 'valibot';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/(docs)/react/api/(types)/FormConfig/index.mdx
+++ b/website/src/routes/(docs)/react/api/(types)/FormConfig/index.mdx
@@ -22,9 +22,10 @@ Form config interface that defines the configuration options for creating a form
 - `FormConfig`
   - `schema` <Property {...properties.schema} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />
 
 ### Explanation
 
-The `FormConfig` object is passed to <Link href="../useForm/">`useForm`</Link> with a required `schema` property and optional properties for `initialInput`, `validate`, and `revalidate` to control form behavior and validation timing.
+The `FormConfig` object is passed to <Link href="../useForm/">`useForm`</Link> with a required `schema` property and optional properties for `initialInput`, `emptyInput`, `validate`, and `revalidate` to control form behavior and validation timing.

--- a/website/src/routes/(docs)/react/api/(types)/FormConfig/properties.ts
+++ b/website/src/routes/(docs)/react/api/(types)/FormConfig/properties.ts
@@ -49,6 +49,21 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'emptyInput',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'EmptyInput',
+                href: '/core/api/EmptyInput/',
+              },
+              'undefined',
+            ],
+          },
+        },
+        {
           key: 'validate',
           optional: true,
           value: {
@@ -108,6 +123,19 @@ export const properties: Record<string, PropertyProps> = {
               ],
             },
           ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  emptyInput: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'EmptyInput',
+          href: '/core/api/EmptyInput/',
         },
         'undefined',
       ],

--- a/website/src/routes/(docs)/react/api/menu.md
+++ b/website/src/routes/(docs)/react/api/menu.md
@@ -42,6 +42,7 @@
 
 - [DeepErrorEntry](/methods/api/DeepErrorEntry/)
 - [DeepPartial](/core/api/DeepPartial/)
+- [EmptyInput](/core/api/EmptyInput/)
 - [FieldArrayStore](/react/api/FieldArrayStore/)
 - [FieldElement](/core/api/FieldElement/)
 - [FieldElementProps](/react/api/FieldElementProps/)

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/create-your-form/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/create-your-form/index.mdx
@@ -42,6 +42,7 @@ The <Link href="/react/api/useForm/">`useForm`</Link> hook accepts a configurati
 
 - `schema`: Your Valibot schema that defines the form
 - `initialInput`: Initial values for your form fields (optional)
+- `emptyInput`: The empty value each field type starts at when a required field has no initial input (optional, defaults to `{ string: '' }`)
 - `validate`: When validation first occurs (optional, defaults to `'submit'`)
 - `revalidate`: When revalidation occurs after initial validation (optional, defaults to `'input'`)
 
@@ -60,7 +61,26 @@ Formisch tracks two inputs for every field: the **initial input** (baseline for 
 
 `isDirty` becomes `true` when a field's current input differs from its initial input. Use <Link href="/methods/api/setInput/">`setInput`</Link> to update the current input (client state), and use <Link href="/methods/api/reset/">`reset`</Link> to update the initial input (baseline) when your server data changes or is refreshed.
 
-### Multiple forms
+### Empty input
+
+By default, a required string field starts as an empty string (`''`) instead of `undefined`, matching an empty text input. This way an empty field shows the validation message you defined for it (for example from `v.nonEmpty()`) without you setting an `initialInput` for every field.
+
+You can configure the empty value per field type, or opt out by setting a type to `undefined`:
+
+```tsx
+const loginForm = useForm({
+  schema: LoginSchema,
+  emptyInput: {
+    string: '', // the default
+    number: 0, // required numbers start at 0 instead of undefined
+    boolean: false, // checkboxes start unchecked
+  },
+});
+```
+
+Optional and nullable fields are never affected and keep starting as `undefined`, since they accept it. The supported types are `string`, `number`, `boolean` and `date`, and the default is `{ string: '' }`.
+
+## Multiple forms
 
 When a page contains multiple forms, you can create separate form stores for each one:
 
@@ -91,6 +111,8 @@ export default function App() {
   );
 }
 ```
+
+If you need a multi-step form (wizard), see the [multi-step form discussion](https://github.com/open-circle/formisch/discussions/108) for patterns and approaches.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/define-your-form/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/define-your-form/index.mdx
@@ -28,12 +28,12 @@ import * as v from 'valibot';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/(docs)/solid/api/(types)/FormConfig/index.mdx
+++ b/website/src/routes/(docs)/solid/api/(types)/FormConfig/index.mdx
@@ -22,9 +22,10 @@ Form config interface that defines the configuration options for creating a form
 - `FormConfig`
   - `schema` <Property {...properties.schema} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />
 
 ### Explanation
 
-The `FormConfig` object is passed to <Link href="../createForm/">`createForm`</Link> with a required `schema` property and optional properties for `initialInput`, `validate`, and `revalidate` to control form behavior and validation timing.
+The `FormConfig` object is passed to <Link href="../createForm/">`createForm`</Link> with a required `schema` property and optional properties for `initialInput`, `emptyInput`, `validate`, and `revalidate` to control form behavior and validation timing.

--- a/website/src/routes/(docs)/solid/api/(types)/FormConfig/properties.ts
+++ b/website/src/routes/(docs)/solid/api/(types)/FormConfig/properties.ts
@@ -49,6 +49,21 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'emptyInput',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'EmptyInput',
+                href: '/core/api/EmptyInput/',
+              },
+              'undefined',
+            ],
+          },
+        },
+        {
           key: 'validate',
           optional: true,
           value: {
@@ -108,6 +123,19 @@ export const properties: Record<string, PropertyProps> = {
               ],
             },
           ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  emptyInput: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'EmptyInput',
+          href: '/core/api/EmptyInput/',
         },
         'undefined',
       ],

--- a/website/src/routes/(docs)/solid/api/menu.md
+++ b/website/src/routes/(docs)/solid/api/menu.md
@@ -42,6 +42,7 @@
 
 - [DeepErrorEntry](/methods/api/DeepErrorEntry/)
 - [DeepPartial](/core/api/DeepPartial/)
+- [EmptyInput](/core/api/EmptyInput/)
 - [FieldArrayStore](/solid/api/FieldArrayStore/)
 - [FieldElement](/core/api/FieldElement/)
 - [FieldElementProps](/solid/api/FieldElementProps/)

--- a/website/src/routes/(docs)/solid/guides/(main-concepts)/create-your-form/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(main-concepts)/create-your-form/index.mdx
@@ -42,6 +42,7 @@ The <Link href="/solid/api/createForm/">`createForm`</Link> primitive accepts a 
 
 - `schema`: Your Valibot schema that defines the form
 - `initialInput`: Initial values for your form fields (optional)
+- `emptyInput`: The empty value each field type starts at when a required field has no initial input (optional, defaults to `{ string: '' }`)
 - `validate`: When validation first occurs (optional, defaults to `'submit'`)
 - `revalidate`: When revalidation occurs after initial validation (optional, defaults to `'input'`)
 
@@ -60,7 +61,26 @@ Formisch tracks two inputs for every field: the **initial input** (baseline for 
 
 `isDirty` becomes `true` when a field's current input differs from its initial input. Use <Link href="/methods/api/setInput/">`setInput`</Link> to update the current input (client state), and use <Link href="/methods/api/reset/">`reset`</Link> to update the initial input (baseline) when your server data changes or is refreshed.
 
-### Multiple forms
+### Empty input
+
+By default, a required string field starts as an empty string (`''`) instead of `undefined`, matching an empty text input. This way an empty field shows the validation message you defined for it (for example from `v.nonEmpty()`) without you setting an `initialInput` for every field.
+
+You can configure the empty value per field type, or opt out by setting a type to `undefined`:
+
+```tsx
+const loginForm = createForm({
+  schema: LoginSchema,
+  emptyInput: {
+    string: '', // the default
+    number: 0, // required numbers start at 0 instead of undefined
+    boolean: false, // checkboxes start unchecked
+  },
+});
+```
+
+Optional and nullable fields are never affected and keep starting as `undefined`, since they accept it. The supported types are `string`, `number`, `boolean` and `date`, and the default is `{ string: '' }`.
+
+## Multiple forms
 
 When a page contains multiple forms, you can create separate form stores for each one:
 
@@ -91,6 +111,8 @@ export default function App() {
   );
 }
 ```
+
+If you need a multi-step form (wizard), see the [multi-step form discussion](https://github.com/open-circle/formisch/discussions/108) for patterns and approaches.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/solid/guides/(main-concepts)/define-your-form/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(main-concepts)/define-your-form/index.mdx
@@ -28,12 +28,12 @@ import * as v from 'valibot';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/(docs)/svelte/api/(types)/FormConfig/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(types)/FormConfig/index.mdx
@@ -22,9 +22,10 @@ Form config interface that defines the configuration options for creating a form
 - `FormConfig`
   - `schema` <Property {...properties.schema} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />
 
 ### Explanation
 
-The `FormConfig` object is passed to <Link href="../createForm/">`createForm`</Link> with a required `schema` property and optional properties for `initialInput`, `validate`, and `revalidate` to control form behavior and validation timing.
+The `FormConfig` object is passed to <Link href="../createForm/">`createForm`</Link> with a required `schema` property and optional properties for `initialInput`, `emptyInput`, `validate`, and `revalidate` to control form behavior and validation timing.

--- a/website/src/routes/(docs)/svelte/api/(types)/FormConfig/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(types)/FormConfig/properties.ts
@@ -49,6 +49,21 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'emptyInput',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'EmptyInput',
+                href: '/core/api/EmptyInput/',
+              },
+              'undefined',
+            ],
+          },
+        },
+        {
           key: 'validate',
           optional: true,
           value: {
@@ -108,6 +123,19 @@ export const properties: Record<string, PropertyProps> = {
               ],
             },
           ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  emptyInput: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'EmptyInput',
+          href: '/core/api/EmptyInput/',
         },
         'undefined',
       ],

--- a/website/src/routes/(docs)/svelte/api/menu.md
+++ b/website/src/routes/(docs)/svelte/api/menu.md
@@ -42,6 +42,7 @@
 
 - [DeepErrorEntry](/methods/api/DeepErrorEntry/)
 - [DeepPartial](/core/api/DeepPartial/)
+- [EmptyInput](/core/api/EmptyInput/)
 - [FieldArrayStore](/svelte/api/FieldArrayStore/)
 - [FieldElement](/core/api/FieldElement/)
 - [FieldElementProps](/svelte/api/FieldElementProps/)

--- a/website/src/routes/(docs)/svelte/guides/(main-concepts)/create-your-form/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(main-concepts)/create-your-form/index.mdx
@@ -44,6 +44,7 @@ The <Link href="/svelte/api/createForm/">`createForm`</Link> rune accepts a conf
 
 - `schema`: Your Valibot schema that defines the form
 - `initialInput`: Initial values for your form fields (optional)
+- `emptyInput`: The empty value each field type starts at when a required field has no initial input (optional, defaults to `{ string: '' }`)
 - `validate`: When validation first occurs (optional, defaults to `'submit'`)
 - `revalidate`: When revalidation occurs after initial validation (optional, defaults to `'input'`)
 
@@ -62,7 +63,26 @@ Formisch tracks two inputs for every field: the **initial input** (baseline for 
 
 `isDirty` becomes `true` when a field's current input differs from its initial input. Use <Link href="/methods/api/setInput/">`setInput`</Link> to update the current input (client state), and use <Link href="/methods/api/reset/">`reset`</Link> to update the initial input (baseline) when your server data changes or is refreshed.
 
-### Multiple forms
+### Empty input
+
+By default, a required string field starts as an empty string (`''`) instead of `undefined`, matching an empty text input. This way an empty field shows the validation message you defined for it (for example from `v.nonEmpty()`) without you setting an `initialInput` for every field.
+
+You can configure the empty value per field type, or opt out by setting a type to `undefined`:
+
+```ts
+const loginForm = createForm({
+  schema: LoginSchema,
+  emptyInput: {
+    string: '', // the default
+    number: 0, // required numbers start at 0 instead of undefined
+    boolean: false, // checkboxes start unchecked
+  },
+});
+```
+
+Optional and nullable fields are never affected and keep starting as `undefined`, since they accept it. The supported types are `string`, `number`, `boolean` and `date`, and the default is `{ string: '' }`.
+
+## Multiple forms
 
 When a page contains multiple forms, you can create separate form stores for each one:
 
@@ -89,6 +109,8 @@ When a page contains multiple forms, you can create separate form stores for eac
 <Form of={loginForm}><!-- … --></Form>
 <Form of={registerForm}><!-- … --></Form>
 ```
+
+If you need a multi-step form (wizard), see the [multi-step form discussion](https://github.com/open-circle/formisch/discussions/108) for patterns and approaches.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/svelte/guides/(main-concepts)/define-your-form/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(main-concepts)/define-your-form/index.mdx
@@ -28,12 +28,12 @@ import * as v from 'valibot';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/(docs)/vue/api/(types)/FormConfig/index.mdx
+++ b/website/src/routes/(docs)/vue/api/(types)/FormConfig/index.mdx
@@ -22,9 +22,10 @@ Form config interface that defines the configuration options for creating a form
 - `FormConfig`
   - `schema` <Property {...properties.schema} />
   - `initialInput` <Property {...properties.initialInput} />
+  - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />
 
 ### Explanation
 
-The `FormConfig` object is passed to <Link href="../useForm/">`useForm`</Link> with a required `schema` property and optional properties for `initialInput`, `validate`, and `revalidate` to control form behavior and validation timing.
+The `FormConfig` object is passed to <Link href="../useForm/">`useForm`</Link> with a required `schema` property and optional properties for `initialInput`, `emptyInput`, `validate`, and `revalidate` to control form behavior and validation timing.

--- a/website/src/routes/(docs)/vue/api/(types)/FormConfig/properties.ts
+++ b/website/src/routes/(docs)/vue/api/(types)/FormConfig/properties.ts
@@ -49,6 +49,21 @@ export const properties: Record<string, PropertyProps> = {
           },
         },
         {
+          key: 'emptyInput',
+          optional: true,
+          value: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'EmptyInput',
+                href: '/core/api/EmptyInput/',
+              },
+              'undefined',
+            ],
+          },
+        },
+        {
           key: 'validate',
           optional: true,
           value: {
@@ -108,6 +123,19 @@ export const properties: Record<string, PropertyProps> = {
               ],
             },
           ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  emptyInput: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'EmptyInput',
+          href: '/core/api/EmptyInput/',
         },
         'undefined',
       ],

--- a/website/src/routes/(docs)/vue/api/menu.md
+++ b/website/src/routes/(docs)/vue/api/menu.md
@@ -42,6 +42,7 @@
 
 - [DeepErrorEntry](/methods/api/DeepErrorEntry/)
 - [DeepPartial](/core/api/DeepPartial/)
+- [EmptyInput](/core/api/EmptyInput/)
 - [FieldArrayStore](/vue/api/FieldArrayStore/)
 - [FieldElement](/core/api/FieldElement/)
 - [FieldElementProps](/vue/api/FieldElementProps/)

--- a/website/src/routes/(docs)/vue/guides/(main-concepts)/create-your-form/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(main-concepts)/create-your-form/index.mdx
@@ -46,6 +46,7 @@ The <Link href="/vue/api/useForm/">`useForm`</Link> composable accepts a configu
 
 - `schema`: Your Valibot schema that defines the form
 - `initialInput`: Initial values for your form fields (optional)
+- `emptyInput`: The empty value each field type starts at when a required field has no initial input (optional, defaults to `{ string: '' }`)
 - `validate`: When validation first occurs (optional, defaults to `'submit'`)
 - `revalidate`: When revalidation occurs after initial validation (optional, defaults to `'input'`)
 
@@ -64,7 +65,26 @@ Formisch tracks two inputs for every field: the **initial input** (baseline for 
 
 `isDirty` becomes `true` when a field's current input differs from its initial input. Use <Link href="/methods/api/setInput/">`setInput`</Link> to update the current input (client state), and use <Link href="/methods/api/reset/">`reset`</Link> to update the initial input (baseline) when your server data changes or is refreshed.
 
-### Multiple forms
+### Empty input
+
+By default, a required string field starts as an empty string (`''`) instead of `undefined`, matching an empty text input. This way an empty field shows the validation message you defined for it (for example from `v.nonEmpty()`) without you setting an `initialInput` for every field.
+
+You can configure the empty value per field type, or opt out by setting a type to `undefined`:
+
+```ts
+const loginForm = useForm({
+  schema: LoginSchema,
+  emptyInput: {
+    string: '', // the default
+    number: 0, // required numbers start at 0 instead of undefined
+    boolean: false, // checkboxes start unchecked
+  },
+});
+```
+
+Optional and nullable fields are never affected and keep starting as `undefined`, since they accept it. The supported types are `string`, `number`, `boolean` and `date`, and the default is `{ string: '' }`.
+
+## Multiple forms
 
 When a page contains multiple forms, you can create separate form stores for each one:
 
@@ -93,6 +113,8 @@ const registerForm = useForm({ schema: RegisterSchema });
   <Form :of="registerForm"><!-- … --></Form>
 </template>
 ```
+
+If you need a multi-step form (wizard), see the [multi-step form discussion](https://github.com/open-circle/formisch/discussions/108) for patterns and approaches.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/vue/guides/(main-concepts)/define-your-form/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(main-concepts)/define-your-form/index.mdx
@@ -28,12 +28,12 @@ import * as v from 'valibot';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/playground/login/index.tsx
+++ b/website/src/routes/playground/login/index.tsx
@@ -7,12 +7,12 @@ import { FormStoreContext } from '../layout';
 
 const LoginSchema = v.object({
   email: v.pipe(
-    v.string('Please enter your email.'),
+    v.string(),
     v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
-    v.string('Please enter your password.'),
+    v.string(),
     v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),

--- a/website/src/routes/playground/payment/index.tsx
+++ b/website/src/routes/playground/payment/index.tsx
@@ -7,10 +7,7 @@ import { FormStoreContext } from '../layout';
 
 const PaymentFormSchema = v.intersect([
   v.object({
-    owner: v.pipe(
-      v.string('Please enter your name.'),
-      v.nonEmpty('Please enter your name.')
-    ),
+    owner: v.pipe(v.string(), v.nonEmpty('Please enter your name.')),
   }),
   v.variant(
     'type',
@@ -19,12 +16,12 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('card'),
         card: v.object({
           number: v.pipe(
-            v.string('Please enter your card number.'),
+            v.string(),
             v.nonEmpty('Please enter your card number.'),
             v.creditCard('The card number is badly formatted.')
           ),
           expiration: v.pipe(
-            v.string('Please enter the expiration date.'),
+            v.string(),
             v.nonEmpty('Please enter the expiration date.'),
             v.regex(
               /^(?:0[1-9]|1[0-2])\/(?:2[5-9]|3[0-9])$/,
@@ -37,7 +34,7 @@ const PaymentFormSchema = v.intersect([
         type: v.literal('paypal'),
         paypal: v.object({
           email: v.pipe(
-            v.string('Please enter your PayPal email.'),
+            v.string(),
             v.nonEmpty('Please enter your PayPal email.'),
             v.email('The email address is badly formatted.')
           ),

--- a/website/src/routes/playground/todos/index.tsx
+++ b/website/src/routes/playground/todos/index.tsx
@@ -30,21 +30,12 @@ import {
 import { FormStoreContext } from '../layout';
 
 const TodoFormSchema = v.object({
-  heading: v.pipe(
-    v.string('Please enter a heading.'),
-    v.nonEmpty('Please enter a heading.')
-  ),
+  heading: v.pipe(v.string(), v.nonEmpty('Please enter a heading.')),
   todos: v.pipe(
     v.array(
       v.object({
-        label: v.pipe(
-          v.string('Please enter a label.'),
-          v.nonEmpty('Please enter a label.')
-        ),
-        deadline: v.pipe(
-          v.string('Please enter a deadline.'),
-          v.nonEmpty('Please enter a deadline.')
-        ),
+        label: v.pipe(v.string(), v.nonEmpty('Please enter a label.')),
+        deadline: v.pipe(v.string(), v.nonEmpty('Please enter a deadline.')),
       })
     ),
     v.nonEmpty('Please add at least one todo.'),


### PR DESCRIPTION
Fix #53

- **Add emptyInput config to form config to default empty values**
- **Remove duplicated custom error message that is no longer needed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `emptyInput` form configuration and the `EmptyInput` type to customize per-field empty start values (defaulting required strings to `''` when no initial input is provided).
* **Bug Fixes**
  * Required string fields now consistently initialize/reset to the configured empty value when initial input is omitted or `undefined`, including during common array operations.
* **Documentation**
  * Added `EmptyInput` docs and updated `FormConfig` docs across all framework variants; refreshed validation examples so “Please enter …” messages come from `nonEmpty` validators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->