### PR TITLE
Add form library migration guides to website

### DIFF
--- a/.agents/skills/repo-website-guide-create/SKILL.md
+++ b/.agents/skills/repo-website-guide-create/SKILL.md
@@ -28,6 +28,7 @@ website/src/routes/{framework}/guides/
 - `(get-started)` - Introductory content
 - `(main-concepts)` - Core library concepts
 - `(advanced-guides)` - Advanced features
+- `(migration-guides)` - Migration from other form libraries
 
 ## Step-by-Step Process
 
@@ -38,6 +39,7 @@ Determine the appropriate category:
 - **(get-started)**: Introduction, Installation, LLMs.txt
 - **(main-concepts)**: Define form, Create form, Add fields, Handle submission
 - **(advanced-guides)**: Controlled fields, Field arrays, TypeScript
+- **(migration-guides)**: Migrate from React Hook Form, Migrate from TanStack Form
 
 ### Step 2: Create Guide Directory
 

--- a/website/src/routes/(docs)/react/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(get-started)/comparison/index.mdx
@@ -47,11 +47,11 @@ Three reasons to pick Formisch over the alternatives above:
 
 **Formisch** makes the most sense for new projects in TypeScript-heavy codebases, especially when you expect forms to grow in complexity. The schema-first design means there is a single source of truth for types, runtime validation, and form structure, so there is less to keep aligned over time. The main consideration is that Formisch currently supports only [Valibot](https://valibot.dev) as the schema library.
 
-## Migrating from React Hook Form
+## Migrating to Formisch
 
-Migrating from React Hook Form to Formisch is a genuine rewrite of the form layer, not a drop-in replacement. The mental model is different: instead of starting from a component and attaching form behavior to it, you start from a schema and build the component around it. The two libraries can coexist in the same application, so you can migrate one form at a time.
+Migrating to Formisch is a genuine rewrite of the form layer, not a drop-in replacement. The mental model is different: instead of starting from a component and attaching form behavior to it, you start from a schema and build the component around it. The libraries can coexist in the same application, so you can migrate one form at a time.
 
-For a side-by-side mapping of common React Hook Form APIs to their Formisch equivalents, see the migration section of the <Link href="/blog/react-form-library-comparison/">comparison article</Link>.
+We provide a dedicated migration guide for each library, with a side-by-side example, step-by-step instructions, and an API mapping table: <Link href="/react/guides/migrate-from-react-hook-form/">migrate from React Hook Form</Link> and <Link href="/react/guides/migrate-from-tanstack-form/">migrate from TanStack Form</Link>.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/react/guides/(migration-guides)/migrate-from-react-hook-form/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(migration-guides)/migrate-from-react-hook-form/index.mdx
@@ -1,0 +1,441 @@
+---
+title: Migrate from React Hook Form
+description: >-
+  Learn how to migrate your forms from React Hook Form to Formisch. This guide
+  maps React Hook Form APIs to their Formisch equivalents and walks through the
+  migration step by step.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from React Hook Form
+
+This guide walks you through migrating your forms from [React Hook Form](https://react-hook-form.com) to Formisch. It covers the mental-model shift, a complete side-by-side example, a step-by-step migration path, and a mapping of React Hook Form APIs to their Formisch equivalents.
+
+Migrating is a rewrite of the form layer, not a drop-in replacement. The mental model is different: instead of starting from a component and attaching form behavior to it, you start from a Valibot schema and build the component around it. The good news is that forms are naturally isolated units, so the rewrite happens one form at a time.
+
+Both libraries can coexist in the same application without conflicts. You can install Formisch next to React Hook Form, migrate a single form, and remove React Hook Form once the last one is converted. Since both libraries export a hook named `useForm`, the import path determines which one a component uses.
+
+## Key differences
+
+React Hook Form is component-first. You declare a TypeScript generic for your form values, register inputs by string name, and attach validation either as per-field rules or through a resolver. Formisch is schema-first: a single Valibot schema is the source of types, validation rules, and form structure all at once. There is no separate generic to declare and no `defaultValues` object to keep aligned with your validation.
+
+The most important differences at a glance:
+
+- **Type source**: React Hook Form types come from a generic you declare on `useForm<FormValues>()`. Formisch infers all types, including field paths and the validated output, from the schema.
+- **Validation location**: React Hook Form spreads validation across `register` rules, `Controller` rules, or a resolver. Formisch defines all validation in the schema, next to the structure it validates.
+- **Validation timing**: React Hook Form uses the `mode` and `reValidateMode` options. Formisch uses the equivalent `validate` and `revalidate` options with slightly different mode names.
+- **Validation scope**: React Hook Form validates individual fields as they trigger. Formisch always parses the entire form against the schema in a single pass and distributes the resulting errors to the individual fields. Cross-field rules work without extra wiring, and each field still only re-renders when its own errors change.
+- **Reactivity**: React Hook Form makes re-render scope your responsibility through `watch`, `useWatch`, and the `formState` Proxy with its destructuring rules. Formisch is built on fine-grained signals, so components automatically re-render when the state they read changes. There is no subscription API to manage.
+- **Field binding**: React Hook Form registers inputs by string name (`register('user.email')`). Formisch connects fields through the headless <Link href="/react/api/Field/">`Field`</Link> component with a type-safe path array (`path={['user', 'email']}`).
+
+If you already validate with `valibotResolver` from `@hookform/resolvers`, you are halfway there: your Valibot schema carries over to Formisch unchanged.
+
+## Side-by-side example
+
+The following login form has two validated fields, displays error messages, disables the submit button while submitting, and processes the values on submission. Both versions implement identical behavior.
+
+### React Hook Form
+
+```tsx
+import { type SubmitHandler, useForm } from 'react-hook-form';
+
+interface LoginValues {
+  email: string;
+  password: string;
+}
+
+export default function LoginPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginValues>({
+    defaultValues: { email: '', password: '' },
+  });
+
+  const onSubmit: SubmitHandler<LoginValues> = async (values) => {
+    // Process the validated form values
+    console.log(values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input
+        type="email"
+        {...register('email', {
+          required: 'Please enter your email.',
+          pattern: {
+            value: /^\S+@\S+\.\S+$/u,
+            message: 'The email address is badly formatted.',
+          },
+        })}
+      />
+      {errors.email && <div>{errors.email.message}</div>}
+      <input
+        type="password"
+        {...register('password', {
+          required: 'Please enter your password.',
+          minLength: {
+            value: 8,
+            message: 'Your password must have 8 characters or more.',
+          },
+        })}
+      />
+      {errors.password && <div>{errors.password.message}</div>}
+      <button type="submit" disabled={isSubmitting}>
+        Login
+      </button>
+    </form>
+  );
+}
+```
+
+### Formisch
+
+```tsx
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({ schema: LoginSchema });
+
+  const onSubmit: SubmitHandler<typeof LoginSchema> = async (values) => {
+    // Process the validated form values
+    console.log(values);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={onSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="email" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="password" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+Notice how the validation rules moved out of the JSX and into the schema, and how the `LoginValues` interface disappeared because the schema provides the types. Error messages live on each field store instead of a central `errors` object.
+
+## Migration steps
+
+### Install Formisch
+
+Add Formisch and Valibot alongside React Hook Form. Both form libraries can run in parallel during the migration.
+
+```bash
+npm install @formisch/react valibot
+```
+
+See the <Link href="/react/guides/installation/">installation</Link> guide for other package managers.
+
+### Move validation into a Valibot schema
+
+Translate your `register` rules or resolver schema into a single Valibot schema. Each rule has a direct counterpart: `required` becomes `v.nonEmpty()`, `minLength` becomes `v.minLength()`, and `pattern` usually becomes a dedicated action like `v.email()` or `v.regex()`.
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+```
+
+If you already use `valibotResolver`, reuse your existing schema as-is. Define fields in the same order they appear in your form, because Formisch focuses the first field with an error on a failed submit. The <Link href="/react/guides/define-your-form/">define your form</Link> guide covers schema design in detail.
+
+### Replace the form setup
+
+Swap React Hook Form's `useForm` for the Formisch <Link href="/react/api/useForm/">`useForm`</Link> hook. The generic and the resolver disappear, and the schema takes their place. `defaultValues` becomes `initialInput` and is optional: required string fields start as an empty string automatically, so you no longer need to list every field just to avoid `undefined` values.
+
+```tsx
+// Before
+import { useForm } from 'react-hook-form';
+
+const { register, handleSubmit, formState } = useForm<LoginValues>({
+  resolver: valibotResolver(LoginSchema),
+  defaultValues: { email: '', password: '' },
+  mode: 'onTouched',
+});
+```
+
+```tsx
+// After
+import { useForm } from '@formisch/react';
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The `mode` and `reValidateMode` options map to `validate` and `revalidate`. See the <Link href="#validation-timing">validation timing</Link> section below for the exact mapping.
+
+### Replace field bindings
+
+Replace each `register` call with the <Link href="/react/api/Field/">`Field`</Link> component. Instead of spreading `register('email')`, you spread `field.props` onto the input and bind `field.input` as its value. Errors move from the central `formState.errors` object to the field store, so the error display lives right next to the input.
+
+```tsx
+// Before
+<>
+  <input
+    type="email"
+    {...register('email', { required: 'Please enter your email.' })}
+  />
+  {errors.email && <div>{errors.email.message}</div>}
+</>
+```
+
+```tsx
+// After
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <div>
+      <input {...field.props} value={field.input} type="email" />
+      {field.errors && <div>{field.errors[0]}</div>}
+    </div>
+  )}
+</Field>
+```
+
+String paths with dots become type-safe path arrays: `register('user.email')` turns into `path={['user', 'email']}` and `register('todos.0.label')` turns into `path={['todos', 0, 'label']}`. Where you used `Controller` or `useController` for individual field components, use the <Link href="/react/api/Field/">`Field`</Link> component or <Link href="/react/api/useField/">`useField`</Link> hook instead. The <Link href="/react/guides/add-form-fields/">add form fields</Link> guide explains both in detail.
+
+### Update submission handling
+
+Replace the `<form>` element wrapped with `handleSubmit(onSubmit)` by the <Link href="/react/api/Form/">`Form`</Link> component. Your handler keeps the same shape: it only runs after validation succeeds and receives the validated values, which are now typed as the schema's output.
+
+```tsx
+// Before
+<form onSubmit={handleSubmit(onSubmit)}>{/* fields */}</form>
+
+// After
+<Form of={loginForm} onSubmit={onSubmit}>{/* fields */}</Form>
+```
+
+Async handlers work the same way, and `loginForm.isSubmitting` replaces `formState.isSubmitting` for the loading state. See the <Link href="/react/guides/handle-submission/">handle submission</Link> guide for details.
+
+## API mapping
+
+| React Hook Form                       | Formisch                                                                                                                                                                                             |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useForm<T>(config)`                  | <Link href="/react/api/useForm/">`useForm`</Link> with `schema` (types are inferred)                                                                                                                 |
+| `resolver: valibotResolver(schema)`   | `schema` option                                                                                                                                                                                      |
+| `defaultValues`                       | `initialInput` option                                                                                                                                                                                |
+| `mode` / `reValidateMode`             | `validate` / `revalidate` options                                                                                                                                                                    |
+| `register('name')`                    | <Link href="/react/api/Field/">`Field`</Link> component with `path={['name']}`                                                                                                                       |
+| `Controller` / `useController`        | <Link href="/react/api/useField/">`useField`</Link> hook or `field.onChange`                                                                                                                         |
+| `handleSubmit(onValid)`               | `onSubmit` prop of <Link href="/react/api/Form/">`Form`</Link> or <Link href="/methods/api/handleSubmit/">`handleSubmit`</Link>                                                                      |
+| `formState.errors`                    | `field.errors` per field, <Link href="/methods/api/getErrors/">`getErrors`</Link>, <Link href="/methods/api/getDeepErrors/">`getDeepErrors`</Link>                                                   |
+| `formState.isDirty` / `dirtyFields`   | `form.isDirty`, `field.isDirty`, <Link href="/methods/api/getDirtyInput/">`getDirtyInput`</Link>                                                                                                     |
+| `formState.touchedFields`             | `field.isTouched`                                                                                                                                                                                    |
+| `formState.isSubmitting`              | `form.isSubmitting`                                                                                                                                                                                  |
+| `formState.isSubmitted`               | `form.isSubmitted`                                                                                                                                                                                   |
+| `formState.isValid`                   | `form.isValid`                                                                                                                                                                                       |
+| `formState.isValidating`              | `form.isValidating`                                                                                                                                                                                  |
+| `watch('name')` / `useWatch`          | `field.input`, <Link href="/methods/api/getInput/">`getInput`</Link>                                                                                                                                 |
+| `getValues()`                         | <Link href="/methods/api/getInput/">`getInput`</Link>                                                                                                                                                |
+| `setValue`                            | <Link href="/methods/api/setInput/">`setInput`</Link>                                                                                                                                                |
+| `setError` / `clearErrors`            | <Link href="/methods/api/setErrors/">`setErrors`</Link>                                                                                                                                              |
+| `trigger`                             | <Link href="/methods/api/validate/">`validate`</Link>                                                                                                                                                |
+| `setFocus`                            | <Link href="/methods/api/focus/">`focus`</Link>                                                                                                                                                      |
+| `reset` / `resetField`                | <Link href="/methods/api/reset/">`reset`</Link>                                                                                                                                                      |
+| `useFieldArray`                       | <Link href="/react/api/FieldArray/">`FieldArray`</Link> component or <Link href="/react/api/useFieldArray/">`useFieldArray`</Link> hook                                                              |
+| `append` / `prepend` / `insert`       | <Link href="/methods/api/insert/">`insert`</Link>                                                                                                                                                    |
+| `remove` / `move` / `swap` / `update` | <Link href="/methods/api/remove/">`remove`</Link>, <Link href="/methods/api/move/">`move`</Link>, <Link href="/methods/api/swap/">`swap`</Link>, <Link href="/methods/api/replace/">`replace`</Link> |
+| `FormProvider` / `useFormContext`     | Not needed (see notes)                                                                                                                                                                               |
+| `unregister` / `shouldUnregister`     | No equivalent (see notes)                                                                                                                                                                            |
+
+A few entries deserve extra context:
+
+- **`FormProvider` / `useFormContext`**: The Formisch form store is a plain object. Pass it down as a prop, as our <Link href="/react/guides/input-components/">input components</Link> do, or share it through your own React context if you prefer.
+- **`unregister` / `shouldUnregister`**: In Formisch, the schema defines which fields exist, independent of what is currently mounted. For conditional form shapes, model the variants in the schema, for example with `v.optional` or `v.variant`.
+- **`watch` callbacks and subscriptions**: There is no subscription API because none is needed. Reading `field.input` or any form state during render is automatically reactive.
+- **`trigger('name')`**: The <Link href="/methods/api/validate/">`validate`</Link> method always validates the entire form against the schema. The results are still distributed per field, so field-level triggering is not necessary.
+- **`shouldFocusError`**: Formisch focuses the first field with an error automatically when a submit fails, following the field order of your schema.
+- **`formState.isValid`**: In Formisch, `form.isValid` reflects the result of the last validation run. With the default `validate: 'submit'` timing it stays `true` until the first submit, unlike React Hook Form's `isValid`, which validates proactively. If you rely on it before the first submit, for example to disable the submit button, set `validate: 'initial'`.
+- **`formState.touchedFields`**: Formisch marks a field as touched when it receives focus, while React Hook Form marks it on blur. Logic that shows errors based on touched state therefore reacts one event earlier.
+
+## Common patterns
+
+### Form state
+
+React Hook Form exposes form state through the `formState` Proxy, which requires you to destructure the properties you use so the subscription is set up correctly. In Formisch, you read state directly from the form store. Reads are tracked through signals, so components re-render automatically and only when the state they read changes.
+
+```tsx
+// Before
+const {
+  formState: { isDirty, isSubmitting },
+} = useForm<ProfileValues>();
+<button type="submit" disabled={!isDirty || isSubmitting}>
+  Save
+</button>;
+
+// After
+const profileForm = useForm({ schema: ProfileSchema });
+<button
+  type="submit"
+  disabled={!profileForm.isDirty || profileForm.isSubmitting}
+>
+  Save
+</button>;
+```
+
+### Validation timing
+
+React Hook Form's `mode` and `reValidateMode` map to Formisch's `validate` and `revalidate`. The Formisch modes are named after DOM events: `'input'` fires on every keystroke and is what React Hook Form calls `onChange`. A separate `'change'` mode exists, but because React emits its change event on every keystroke for text inputs, both behave the same in React, so prefer `'input'`. There are also more options like `'touch'` and `'initial'`.
+
+```tsx
+// Before
+const form = useForm<Values>({
+  resolver: valibotResolver(Schema),
+  mode: 'onTouched',
+  reValidateMode: 'onChange',
+});
+
+// After: first validation on blur, revalidation on every keystroke
+const form = useForm({
+  schema: Schema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The defaults are already close: Formisch validates on submit first and revalidates on input, similar to React Hook Form's `onSubmit` mode with `onChange` revalidation. See the <Link href="/react/guides/validation/">validation</Link> guide for all modes and for showing errors at the right time.
+
+### Field arrays
+
+React Hook Form's `useFieldArray` returns `fields` with stable `id` keys plus mutation functions. Formisch provides the <Link href="/react/api/FieldArray/">`FieldArray`</Link> component, whose `items` array contains unique string identifiers to use as keys, and standalone methods like <Link href="/methods/api/insert/">`insert`</Link> and <Link href="/methods/api/remove/">`remove`</Link>.
+
+```tsx
+// Before
+const { fields, append, remove } = useFieldArray({ control, name: 'todos' });
+
+<>
+  {fields.map((item, index) => (
+    <div key={item.id}>
+      <input {...register(`todos.${index}.label`)} />
+      <button type="button" onClick={() => remove(index)}>
+        Delete
+      </button>
+    </div>
+  ))}
+  <button type="button" onClick={() => append({ label: '' })}>
+    Add
+  </button>
+</>;
+```
+
+```tsx
+// After
+import { Field, FieldArray, insert, remove } from '@formisch/react';
+
+<FieldArray of={todoForm} path={['todos']}>
+  {(fieldArray) => (
+    <div>
+      {fieldArray.items.map((item, index) => (
+        <div key={item}>
+          <Field of={todoForm} path={['todos', index, 'label']}>
+            {(field) => <input {...field.props} value={field.input} />}
+          </Field>
+          <button
+            type="button"
+            onClick={() => remove(todoForm, { path: ['todos'], at: index })}
+          >
+            Delete
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() =>
+          insert(todoForm, { path: ['todos'], initialInput: { label: '' } })
+        }
+      >
+        Add
+      </button>
+    </div>
+  )}
+</FieldArray>;
+```
+
+Unlike `append` and `prepend`, the single `insert` method covers all positions through its optional `at` option. See the <Link href="/react/guides/field-arrays/">field arrays</Link> guide for moving, swapping, and validating arrays.
+
+### Reset
+
+React Hook Form's `reset()` restores `defaultValues`, and `reset(values)` replaces them. The Formisch <Link href="/methods/api/reset/">`reset`</Link> method works the same way with its config object, and it also resets individual fields through the `path` option, replacing `resetField`.
+
+```tsx
+import { reset } from '@formisch/react';
+
+// Reset the entire form to its initial input
+reset(profileForm);
+
+// Reset with new initial input, e.g. after refetching server data
+reset(profileForm, { initialInput: { name: 'Jane' } });
+
+// Reset a single field
+reset(profileForm, { path: ['email'] });
+```
+
+As in React Hook Form, resetting updates the baseline for dirty tracking. Fields you plan to reset programmatically must be controlled, so bind `value`, `checked`, or `selected` as described in the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide.
+
+### Special inputs
+
+React Hook Form's `register` detects checkboxes, radio buttons, and selects through the input's ref. In Formisch, you spread `field.props` and bind the state attribute that matches the input type, for example `checked` for a checkbox:
+
+```tsx
+<Field of={form} path={['cookies']}>
+  {(field) => (
+    <label>
+      <input {...field.props} type="checkbox" checked={field.input} />
+      Yes, I want cookies
+    </label>
+  )}
+</Field>
+```
+
+Where you used `register('age', { valueAsNumber: true })`, note that Formisch reads DOM values as strings. Fields with a `v.number()` or `v.date()` schema convert the value in a controlled change handler instead, as shown in the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide. For component libraries where you previously reached for `Controller`, pass `field.input` and `field.onChange` directly to the component. The <Link href="/react/guides/special-inputs/">special inputs</Link> guide covers checkboxes, radio buttons, selects, and file inputs in detail.
+
+## Next steps
+
+You now have everything you need to migrate your forms. Start with the <Link href="/react/guides/define-your-form/">define your form</Link> and <Link href="/react/guides/create-your-form/">create your form</Link> guides to deepen the schema-first workflow, build reusable <Link href="/react/guides/input-components/">input components</Link> to keep your migrated forms tidy, and explore the <Link href="/react/guides/form-methods/">form methods</Link> guide for everything that replaces React Hook Form's imperative API.

--- a/website/src/routes/(docs)/react/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
@@ -1,0 +1,429 @@
+---
+title: Migrate from TanStack Form
+description: >-
+  Learn how to migrate your React forms from TanStack Form to Formisch, with a
+  side-by-side example, step-by-step instructions, and an API mapping table.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from TanStack Form
+
+This guide walks you through migrating your React forms from [TanStack Form](https://tanstack.com/form/latest) to Formisch. It explains the mental-model shift, shows the same form in both libraries side by side, breaks the migration into small steps, and maps common TanStack Form APIs to their Formisch equivalents.
+
+Migrating is a rewrite of the form layer, not a drop-in replacement. The component structure often stays similar, but the way you define types, validation, and state access changes. The good news: TanStack Form supports Standard Schema validators, so if you already validate with [Valibot](https://valibot.dev), your schemas carry over unchanged.
+
+Both libraries can coexist in the same application without conflicts. You can migrate one form at a time and remove `@tanstack/react-form` once the last form has been converted. Since both libraries export a hook named `useForm`, the import path determines which one a component uses.
+
+## Key differences
+
+TanStack Form starts from a state container: you declare `defaultValues`, TypeScript infers the form's types from them, and you attach validators to the form or to individual fields, each with its own trigger like `onChange`, `onBlur`, or `onSubmit`. Reactivity is subscription-based: you opt into re-renders with `form.Subscribe` or `useStore` selectors.
+
+Formisch starts from a schema: a single Valibot schema is the source of types, validation rules, and form structure at once. There is no `defaultValues` object to keep aligned with your types and no per-field validator configuration. Validation always parses the entire form against the schema, so cross-field rules work without extra wiring, and its timing is controlled form-wide with the `validate` and `revalidate` config. Reactivity is built on fine-grained signals wired into React's render cycle, so you read state directly from the form store and only the components that depend on it re-render.
+
+In practice, the migration boils down to these changes:
+
+- **Types**: Inferred from the schema instead of from `defaultValues`.
+- **Validation**: Defined once in the schema instead of spread across `validators` configs; timing moves from per-validator triggers to the form-wide `validate` and `revalidate` options.
+- **Field addressing**: Path arrays like `['todos', 0, 'label']` instead of interpolated string names like `` `todos[${index}].label` ``.
+- **Field binding**: Spreading `field.props` instead of manually wiring `value`, `onChange`, and `onBlur`.
+- **State access**: Reading the form store directly instead of subscribing with selectors.
+- **Errors**: Plain string arrays in `field.errors` instead of issue objects in `field.state.meta.errors`.
+
+## Side-by-side example
+
+The following login form validates an email and a password and logs the values on submission. Both versions use the exact same Valibot schema, which TanStack Form accepts as a Standard Schema validator.
+
+### TanStack Form
+
+```tsx
+import { useForm } from '@tanstack/react-form';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+export default function LoginPage() {
+  const form = useForm({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    validators: {
+      onChange: LoginSchema,
+    },
+    onSubmit: async ({ value }) => {
+      console.log(value);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        form.handleSubmit();
+      }}
+    >
+      <form.Field name="email">
+        {(field) => (
+          <div>
+            <input
+              name={field.name}
+              value={field.state.value}
+              onChange={(event) => field.handleChange(event.target.value)}
+              onBlur={field.handleBlur}
+              type="email"
+            />
+            {!field.state.meta.isValid && (
+              <div>{field.state.meta.errors[0]?.message}</div>
+            )}
+          </div>
+        )}
+      </form.Field>
+      <form.Field name="password">
+        {(field) => (
+          <div>
+            <input
+              name={field.name}
+              value={field.state.value}
+              onChange={(event) => field.handleChange(event.target.value)}
+              onBlur={field.handleBlur}
+              type="password"
+            />
+            {!field.state.meta.isValid && (
+              <div>{field.state.meta.errors[0]?.message}</div>
+            )}
+          </div>
+        )}
+      </form.Field>
+      <form.Subscribe selector={(state) => state.isSubmitting}>
+        {(isSubmitting) => (
+          <button type="submit" disabled={isSubmitting}>
+            Login
+          </button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}
+```
+
+### Formisch
+
+```tsx
+import { Field, Form, useForm } from '@formisch/react';
+import type { SubmitHandler } from '@formisch/react';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+  });
+
+  const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+    console.log(values);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={submitForm}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="email" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="password" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+Notice what disappeared: the `defaultValues` object (required string fields start as `''` automatically), the manual `value`, `onChange`, and `onBlur` wiring (replaced by spreading `field.props`), the `event.preventDefault()` boilerplate (the <Link href="/react/api/Form/">`Form`</Link> component handles it), and the `form.Subscribe` wrapper around the submit button (`loginForm.isSubmitting` is read directly). One timing difference: the TanStack Form version validates on every change from the start, while Formisch by default waits until the first submit and then revalidates on every input. Pass `validate: 'input'` to <Link href="/react/api/useForm/">`useForm`</Link> if you want to match the TanStack Form behavior.
+
+## Migration steps
+
+### Install Formisch
+
+Install Formisch and Valibot alongside your existing setup. Both form libraries can run in the same app during the migration.
+
+```bash
+npm install @formisch/react valibot
+```
+
+See the <Link href="/react/guides/installation/">installation</Link> guide for other package managers and TypeScript requirements.
+
+### Move validation into a Valibot schema
+
+If your form already passes a Valibot schema to `validators`, you can reuse it as is. If you use another Standard Schema library like Zod, or hand-written validator functions attached to fields, rewrite the rules as a single Valibot schema. Each field-level validator becomes a validation rule in the schema:
+
+```ts
+import * as v from 'valibot';
+
+// Before: onChange: ({ value }) => (!value ? 'Please enter your email.' : undefined)
+// After: defined once in the schema
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(v.string(), v.nonEmpty(), v.minLength(8)),
+});
+```
+
+Define the fields in the same order they appear in your form, because Formisch focuses the first field with an error after a failed submission. See the <Link href="/react/guides/define-your-form/">define your form</Link> guide for details.
+
+### Replace the form setup
+
+Swap the `useForm` import from `@tanstack/react-form` to `@formisch/react` and pass your schema instead of `defaultValues` and `validators`. The `onSubmit` option moves out of the hook (see below). If your `defaultValues` contained real data instead of empty placeholders, pass it as `initialInput`:
+
+```tsx
+import { useForm } from '@formisch/react';
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: {
+    email: 'user@example.com',
+  },
+});
+```
+
+Required string fields start as `''` automatically, so you no longer need to list every field just to initialize it. See the <Link href="/react/guides/create-your-form/">create your form</Link> guide for all configuration options.
+
+### Replace field bindings
+
+Replace each `form.Field` with the <Link href="/react/api/Field/">`Field`</Link> component. String names become path arrays, and the manual event wiring becomes a spread of `field.props`:
+
+```tsx
+import { Field } from '@formisch/react';
+
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <div>
+      <input {...field.props} value={field.input} type="email" />
+      {field.errors && <div>{field.errors[0]}</div>}
+    </div>
+  )}
+</Field>;
+```
+
+`field.state.value` becomes `field.input`, and `field.state.meta.errors` becomes `field.errors`, which is either `null` or a non-empty array of strings, so no `.message` access is needed. For nested fields, `name="user.email"` becomes `path={['user', 'email']}` with full autocompletion from your schema. If you extracted fields into their own components, use the <Link href="/react/api/useField/">`useField`</Link> hook instead, as shown in the <Link href="/react/guides/add-form-fields/">add form fields</Link> guide.
+
+### Update submission handling
+
+Replace the native `<form>` element and its `handleSubmit` boilerplate with the <Link href="/react/api/Form/">`Form`</Link> component. Your `onSubmit` option becomes a handler passed to `Form`, and it receives the validated output of your schema, fully typed by <Link href="/core/api/SubmitHandler/">`SubmitHandler`</Link>:
+
+```tsx
+import { Form } from '@formisch/react';
+import type { SubmitHandler } from '@formisch/react';
+
+const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+  await fetch('/api/login', {
+    method: 'POST',
+    body: JSON.stringify(values),
+  });
+};
+
+<Form of={loginForm} onSubmit={submitForm}>
+  {/* fields */}
+  <button type="submit" disabled={loginForm.isSubmitting}>
+    Login
+  </button>
+</Form>;
+```
+
+`event.preventDefault()` is called automatically, and the handler only runs when the form input passes your schema. See the <Link href="/react/guides/handle-submission/">handle submission</Link> guide for async patterns and submitting without a `<form>` element.
+
+## API mapping
+
+| TanStack Form                            | Formisch                                                                                                                 |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `useForm({ defaultValues, validators })` | <Link href="/react/api/useForm/">`useForm`</Link> with `schema`                                                          |
+| `defaultValues`                          | `initialInput` (optional, types come from the schema)                                                                    |
+| `onSubmit` option of `useForm`           | `onSubmit` prop of <Link href="/react/api/Form/">`Form`</Link>                                                           |
+| `<form>` element + `form.handleSubmit()` | <Link href="/react/api/Form/">`Form`</Link> component                                                                    |
+| `form.Field` with `name="user.email"`    | <Link href="/react/api/Field/">`Field`</Link> with `path={['user', 'email']}`                                            |
+| `field.state.value`                      | `field.input`                                                                                                            |
+| `field.handleChange`, `field.handleBlur` | Spread `field.props`, or `field.onChange` for custom inputs                                                              |
+| `field.state.meta.errors`                | `field.errors`                                                                                                           |
+| `field.state.meta.isTouched`             | `field.isTouched`                                                                                                        |
+| `field.state.meta.isDirty`               | `field.isEdited` (see below)                                                                                             |
+| `field.state.meta.isDefaultValue`        | `!field.isDirty` (see below)                                                                                             |
+| `form.Subscribe`, `useStore(form.store)` | Read the form store directly (e.g. `form.isSubmitting`, `form.isDirty`)                                                  |
+| `state.canSubmit`                        | No direct equivalent (see below)                                                                                         |
+| `form.state.values`                      | <Link href="/methods/api/getInput/">`getInput`</Link>                                                                    |
+| `form.setFieldValue(name, value)`        | <Link href="/methods/api/setInput/">`setInput`</Link>                                                                    |
+| `form.reset()`                           | <Link href="/methods/api/reset/">`reset`</Link>                                                                          |
+| `form.Field` with `mode="array"`         | <Link href="/react/api/FieldArray/">`FieldArray`</Link> or <Link href="/react/api/useFieldArray/">`useFieldArray`</Link> |
+| `pushValue`, `insertValue`               | <Link href="/methods/api/insert/">`insert`</Link>                                                                        |
+| `removeValue`, `moveValue`               | <Link href="/methods/api/remove/">`remove`</Link>, <Link href="/methods/api/move/">`move`</Link>                         |
+| `swapValues`, `replaceValue`             | <Link href="/methods/api/swap/">`swap`</Link>, <Link href="/methods/api/replace/">`replace`</Link>                       |
+| `createFormHook`, `useAppForm`           | No equivalent needed (see below)                                                                                         |
+| `asyncDebounceMs`                        | No direct equivalent (see below)                                                                                         |
+
+A few entries deserve a short note:
+
+- **`state.canSubmit`**: Formisch does not compute a combined "can submit" flag. The idiomatic pattern is to keep the submit button enabled and let submission trigger validation, which focuses the first invalid field. If you want a validity-based flag, `form.isValid` reflects the result of the last validation run. With the default `validate: 'submit'` timing it stays `true` until the first submit, so combine it with `validate: 'initial'` if you want TanStack-like behavior.
+- **Dirty state** is split differently. TanStack Form's `isDirty` stays `true` once a field was changed, even if the value is reverted. That matches Formisch's `isEdited`. Formisch's `isDirty` compares the current input against the initial input and turns back off when they match, like TanStack Form's `isDefaultValue` inverted.
+- **`createFormHook` and `useAppForm`**: These exist in TanStack Form to pre-bind typed field components and share form configuration. Formisch does not need them, since every hook and component is already fully typed by your schema. The role of pre-bound field components is filled by regular <Link href="/react/guides/input-components/">input components</Link>.
+- **`asyncDebounceMs`**: Formisch has no built-in debounce option. Async rules live in the schema via `v.pipeAsync` and `v.checkAsync`, and `form.isValidating` is `true` while they run. See the <Link href="/react/guides/validation/">validation</Link> guide.
+
+## Common patterns
+
+### Form state
+
+In TanStack Form you subscribe to state with a selector to control re-renders, either through `form.Subscribe` (as with the submit button in the side-by-side example above) or with the `useStore` hook in component logic. In Formisch you read the form store directly. The store is built on fine-grained signals wired into React's render cycle, so components re-render only when the properties they read change, without selectors:
+
+```tsx
+<button type="submit" disabled={loginForm.isSubmitting}>
+  {loginForm.isSubmitting ? 'Submitting...' : 'Login'}
+</button>
+```
+
+The form store exposes `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid`, and `errors`. To read field values in component logic, use the <Link href="/methods/api/getInput/">`getInput`</Link> method, which also stays reactive inside components.
+
+### Validation timing
+
+TanStack Form couples timing to each validator: the key you register a rule under (`onChange`, `onBlur`, `onSubmit`, `onMount`) decides when it runs. In Formisch, the rules live in the schema and timing is configured once for the whole form:
+
+```tsx
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+The `validate` option controls when a field is first validated (`'initial'`, `'touch'`, `'input'`, `'change'`, `'blur'`, or `'submit'`), and `revalidate` controls when it is checked again after it has an error or the form was submitted. As a rough mapping, `validators.onSubmit` corresponds to `validate: 'submit'` (the default), `validators.onBlur` to `validate: 'blur'`, `validators.onChange` to `validate: 'input'`, and `validators.onMount` to `validate: 'initial'`. Unlike TanStack Form, every validation pass parses the entire schema, so cross-field rules stay correct no matter which field triggered it. The <Link href="/react/guides/validation/">validation</Link> guide covers this in depth, including how to show errors only at the right time.
+
+### Field arrays
+
+In TanStack Form you set `mode="array"` on a field, map over `field.state.value`, and address items with interpolated string names:
+
+```tsx
+<form.Field name="todos" mode="array">
+  {(todosField) => (
+    <div>
+      {todosField.state.value.map((_, index) => (
+        <form.Field key={index} name={`todos[${index}].label`}>
+          {(field) => (
+            <input
+              value={field.state.value}
+              onChange={(event) => field.handleChange(event.target.value)}
+            />
+          )}
+        </form.Field>
+      ))}
+      <button type="button" onClick={() => todosField.pushValue({ label: '' })}>
+        Add todo
+      </button>
+    </div>
+  )}
+</form.Field>
+```
+
+In Formisch you use the <Link href="/react/api/FieldArray/">`FieldArray`</Link> component and standalone methods. The `items` array contains stable unique IDs to use as keys, so React correctly tracks items when they are added, moved, or removed:
+
+```tsx
+import { Field, FieldArray, insert } from '@formisch/react';
+
+<FieldArray of={todoForm} path={['todos']}>
+  {(fieldArray) => (
+    <div>
+      {fieldArray.items.map((item, index) => (
+        <Field key={item} of={todoForm} path={['todos', index, 'label']}>
+          {(field) => <input {...field.props} value={field.input} />}
+        </Field>
+      ))}
+      <button
+        type="button"
+        onClick={() =>
+          insert(todoForm, { path: ['todos'], initialInput: { label: '' } })
+        }
+      >
+        Add todo
+      </button>
+    </div>
+  )}
+</FieldArray>;
+```
+
+The <Link href="/methods/api/insert/">`insert`</Link>, <Link href="/methods/api/remove/">`remove`</Link>, <Link href="/methods/api/move/">`move`</Link>, <Link href="/methods/api/swap/">`swap`</Link>, and <Link href="/methods/api/replace/">`replace`</Link> methods cover the operations of `pushValue`, `removeValue`, `moveValue`, `swapValues`, and `replaceValue`. For example, `todosField.removeValue(index)` becomes `remove(todoForm, { path: ['todos'], at: index })`. Rules like a minimum or maximum number of items move into the schema, for example `v.pipe(v.array(…), v.maxLength(10))`. See the <Link href="/react/guides/field-arrays/">field arrays</Link> guide for the full picture.
+
+### Reset
+
+Where TanStack Form offers `form.reset()` to restore `defaultValues`, Formisch provides the <Link href="/methods/api/reset/">`reset`</Link> method, which can also target individual fields or update the baseline:
+
+```tsx
+import { reset } from '@formisch/react';
+
+// Reset the entire form to its initial input
+reset(loginForm);
+
+// Reset a single field
+reset(loginForm, { path: ['email'] });
+
+// Reset with a new initial input (e.g. refreshed server data)
+reset(loginForm, { initialInput: { email: 'jane@example.com' } });
+```
+
+Passing `initialInput` updates the dirty-tracking baseline, which is the right tool when server data changes. Use <Link href="/methods/api/setInput/">`setInput`</Link> instead when you only want to change the current value.
+
+### Special inputs
+
+In TanStack Form, checkboxes, selects, and files are wired manually, for example with `field.handleChange(event.target.checked)`. In Formisch, spreading `field.props` covers all native input types; you only set the state attribute that matches the input:
+
+```tsx
+<Field of={form} path={['cookies']}>
+  {(field) => (
+    <label>
+      <input {...field.props} type="checkbox" checked={field.input} />
+      Yes, I want cookies
+    </label>
+  )}
+</Field>
+```
+
+See the <Link href="/react/guides/special-inputs/">special inputs</Link> guide for radio groups, multi-selects, and file inputs. One caveat carried over from the DOM: event handlers read strings, so fields with a non-string schema like `v.number()` or `v.date()` need to be controlled, as explained in the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide. This replaces patterns like `field.handleChange(event.target.valueAsNumber)`.
+
+## Next steps
+
+You now have everything you need to convert your forms one by one. To deepen your understanding of the Formisch side, read the <Link href="/react/guides/define-your-form/">define your form</Link> and <Link href="/react/guides/add-form-fields/">add form fields</Link> guides, explore the <Link href="/react/guides/form-methods/">form methods</Link> for programmatic control, and check out the <Link href="/react/guides/typescript/">TypeScript</Link> guide to get the most out of schema-based type inference.

--- a/website/src/routes/(docs)/react/guides/menu.md
+++ b/website/src/routes/(docs)/react/guides/menu.md
@@ -26,3 +26,8 @@
 - [Field arrays](/react/guides/field-arrays/)
 - [TypeScript](/react/guides/typescript/)
 - [Architecture](/react/guides/architecture/)
+
+## Migration guides
+
+- [From React Hook Form](/react/guides/migrate-from-react-hook-form/)
+- [From TanStack Form](/react/guides/migrate-from-tanstack-form/)

--- a/website/src/routes/(docs)/solid/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(get-started)/comparison/index.mdx
@@ -47,9 +47,11 @@ Three reasons to pick Formisch over the alternatives above:
 
 **Formisch** makes the most sense for new projects in TypeScript-heavy codebases, especially when you expect forms to grow in complexity. The schema-first design means there is a single source of truth for types, runtime validation, and form structure, so there is less to keep aligned over time. The main consideration is that Formisch currently supports only [Valibot](https://valibot.dev) as the schema library.
 
-## Migrating from Felte
+## Migrating to Formisch
 
-Migrating from Felte to Formisch is not a drop-in replacement. The mental model is different: instead of attaching form behavior to an element through a directive, you start from a Valibot schema and build your fields around it. Formisch and Felte can coexist in the same application, so you can migrate one form at a time and use the most complex form first as a reference point.
+Migrating to Formisch is not a drop-in replacement. The mental model is different: instead of attaching form behavior to a component or element, you start from a Valibot schema and build your fields around it. The libraries can coexist in the same application, so you can migrate one form at a time.
+
+We provide a dedicated migration guide for each library, with a side-by-side example, step-by-step instructions, and an API mapping table: <Link href="/solid/guides/migrate-from-felte/">migrate from Felte</Link> and <Link href="/solid/guides/migrate-from-tanstack-form/">migrate from TanStack Form</Link>.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/solid/guides/(migration-guides)/migrate-from-felte/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(migration-guides)/migrate-from-felte/index.mdx
@@ -1,0 +1,415 @@
+---
+title: Migrate from Felte
+description: >-
+  Learn how to migrate your forms from Felte to Formisch. This guide maps
+  Felte's directive-based API and stores to Formisch's schema-first
+  primitives, components and methods.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from Felte
+
+This guide walks you through migrating a form from [Felte](https://felte.dev) (`@felte/solid`) to Formisch. It compares the mental models of both libraries, shows the same form implemented in each, and maps Felte's APIs, helpers and stores to their Formisch equivalents.
+
+Migrating is a rewrite of your form layer, not a drop-in replacement. Felte attaches its behavior to a native `<form>` element through a directive, while Formisch starts from a Valibot schema and builds the fields around it. The good news: your input elements, styling and business logic carry over unchanged, and the rewrite is mostly mechanical.
+
+Both libraries can coexist in the same application without conflicts. You can migrate one form at a time and remove Felte once the last form is converted.
+
+## Key differences
+
+Felte's core idea is to stay close to the platform. You call `createForm`, spread the returned `form` action onto a `<form>` element via `use:form`, and Felte picks up every input by its `name` attribute. Validation is added separately, either as a `validate` function or through a validator adapter package passed to `extend`, and form state is exposed as Solid accessors like `data`, `errors` and `isSubmitting` returned by `createForm`.
+
+Formisch is schema-first. A single Valibot schema provides everything at once: the TypeScript types, the runtime validation rules, and the structure of the form. There is no separate `validate` function, no validator adapter, and no generic type parameter to declare. When the schema changes, every field path, every validation message and every inferred type follows automatically.
+
+The main differences in practice:
+
+- **Field registration**: Felte discovers fields through their `name` attribute. Formisch connects fields explicitly with the <Link href="/solid/api/Field/">`Field`</Link> component and a type-safe `path` array.
+- **Validation location**: Felte configures validation on the form (`validate`, `warn`, `extend`). Formisch defines validation in the Valibot schema, next to the types it produces.
+- **Validation timing**: Felte validates fields it considers touched as you type and validates everything on submit. Formisch gives you explicit `validate` and `revalidate` config options that control when validation first runs and when it re-runs.
+- **State access**: Felte returns accessors from `createForm` that you call as functions, like `isSubmitting()`. Formisch exposes reactive properties on the form store, like `form.isSubmitting`, and per-field state on the field store, like `field.errors`.
+- **Methods**: Felte's helpers are destructured from `createForm`. Formisch's methods are standalone imports like `reset` and `setInput` that take the form store as their first argument, so unused methods are tree-shaken from your bundle.
+
+## Side-by-side example
+
+The following login form has two validated fields and an async submit handler, implemented once with Felte and once with Formisch.
+
+### Felte
+
+```tsx
+import { createForm } from '@felte/solid';
+
+interface LoginValues {
+  email: string;
+  password: string;
+}
+
+export default function LoginPage() {
+  const { form, errors, isSubmitting } = createForm<LoginValues>({
+    initialValues: { email: '', password: '' },
+    validate(values) {
+      const errors: Partial<LoginValues> = {};
+      if (!values.email) {
+        errors.email = 'Please enter your email.';
+      } else if (!/^\S+@\S+\.\S+$/.test(values.email)) {
+        errors.email = 'The email address is badly formatted.';
+      }
+      if (!values.password) {
+        errors.password = 'Please enter your password.';
+      } else if (values.password.length < 8) {
+        errors.password = 'Your password must have 8 characters or more.';
+      }
+      return errors;
+    },
+    async onSubmit(values) {
+      await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+    },
+  });
+
+  return (
+    <form use:form>
+      <input name="email" type="email" />
+      {errors('email') && <div>{errors('email')?.[0]}</div>}
+      <input name="password" type="password" />
+      {errors('password') && <div>{errors('password')?.[0]}</div>}
+      <button type="submit" disabled={isSubmitting()}>
+        Login
+      </button>
+    </form>
+  );
+}
+```
+
+In TypeScript, this snippet assumes the ambient `JSX.Directives` declaration for `use:form` that Felte projects already include.
+
+### Formisch
+
+```tsx
+import { createForm, Field, Form } from '@formisch/solid';
+import type { SubmitHandler } from '@formisch/solid';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+export default function LoginPage() {
+  const loginForm = createForm({
+    schema: LoginSchema,
+  });
+
+  const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+    await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={submitForm}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="email" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="password" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+Note that the manual `LoginValues` interface and the hand-written `validate` function are gone. The schema provides both, and the types flow from it into `path`, `field.input` and the values of your submit handler.
+
+## Migration steps
+
+### Install Formisch
+
+Formisch requires Valibot as a peer dependency. Install both packages alongside Felte, so you can migrate form by form:
+
+```bash
+npm install @formisch/solid valibot
+```
+
+See the <Link href="/solid/guides/installation/">installation</Link> guide for other package managers and TypeScript requirements.
+
+### Move validation into a Valibot schema
+
+Translate your Felte validation into a Valibot schema. If you used a validator adapter like `@felte/validator-zod`, this is a rule-by-rule translation. If you used a hand-written `validate` function, each `if` branch becomes a schema action with its error message:
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+```
+
+Custom checks that don't map to a built-in action can use `v.check`, and async rules (which you may have placed in Felte's `debounced.validate`) can use `v.checkAsync`. Define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/solid/guides/define-your-form/">define your form</Link> guide for details.
+
+### Replace the form setup
+
+Replace Felte's destructured `createForm` result with a single form store, and replace the `use:form` directive with the <Link href="/solid/api/Form/">`Form`</Link> component. Felte's `initialValues` option becomes `initialInput`, which is optional because required string fields start as an empty string by default:
+
+```tsx
+import { createForm, Form } from '@formisch/solid';
+
+const loginForm = createForm({
+  schema: LoginSchema,
+});
+
+<Form of={loginForm} onSubmit={(values) => console.log(values)}>
+  {/* Fields will go here */}
+  <button type="submit">Login</button>
+</Form>;
+```
+
+There is no generic type parameter to pass. The <Link href="/solid/api/createForm/">`createForm`</Link> primitive infers all types from the schema.
+
+### Replace field bindings
+
+Felte registers inputs through their `name` attribute. In Formisch, you wrap each input in a <Link href="/solid/api/Field/">`Field`</Link> component and spread `field.props` onto it, which wires up the name attribute, event handlers and ref. Felte's dotted names become path arrays, so `name="account.email"` turns into `path={['account', 'email']}`:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <div>
+      <input {...field.props} value={field.input} type="email" />
+      {field.errors && <div>{field.errors[0]}</div>}
+    </div>
+  )}
+</Field>
+```
+
+If you used `@felte/reporter-solid` and its `ValidationMessage` component, you no longer need a reporter package. The field's errors are available directly as `field.errors` inside the render function. See the <Link href="/solid/guides/add-form-fields/">add form fields</Link> guide for more on the field store, and the <Link href="/solid/guides/input-components/">input components</Link> guide for extracting this markup into reusable components.
+
+### Update submission handling
+
+Felte's `onSubmit`, `onSuccess` and `onError` config options collapse into a single submit handler passed to the `onSubmit` property of the <Link href="/solid/api/Form/">`Form`</Link> component. It only runs after successful validation and receives the fully typed output of your schema. What Felte split into `onSuccess` and `onError` becomes regular control flow inside your async handler:
+
+```tsx
+const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+  try {
+    const response = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+    if (!response.ok) {
+      // Felte: onError
+    }
+    // Felte: onSuccess
+  } catch {
+    // Felte: onError
+  }
+};
+```
+
+Note that Formisch does not replicate Felte's default submit handler, which posts to the form's `action` attribute when no `onSubmit` is given. In Formisch, you always write the request yourself. See the <Link href="/solid/guides/handle-submission/">handle submission</Link> guide for details.
+
+## API mapping
+
+| Felte (`@felte/solid`)               | Formisch (`@formisch/solid`)                                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `createForm({ onSubmit, … })`        | <Link href="/solid/api/createForm/">`createForm`</Link> + `onSubmit` on <Link href="/solid/api/Form/">`Form`</Link> |
+| `use:form` directive                 | <Link href="/solid/api/Form/">`Form`</Link> component                                                               |
+| `<input name="email" />`             | <Link href="/solid/api/Field/">`Field`</Link> component with `path={['email']}`                                     |
+| `initialValues`                      | `initialInput` config option                                                                                        |
+| `extend: validator({ schema })`      | `schema` config option (Valibot)                                                                                    |
+| `validate` config function           | Valibot schema actions, `v.check`                                                                                   |
+| `debounced.validate`                 | Async schema actions, `v.checkAsync`                                                                                |
+| `warn` config / `warnings`           | No equivalent                                                                                                       |
+| `data('email')`                      | `field.input` / <Link href="/methods/api/getInput/">`getInput`</Link>                                               |
+| `errors('email')`                    | `field.errors` / <Link href="/methods/api/getErrors/">`getErrors`</Link>                                            |
+| `<ValidationMessage>` (reporter)     | `field.errors` in the render function                                                                               |
+| `touched('email')`                   | `field.isTouched` / <Link href="/methods/api/isTouched/">`isTouched`</Link>                                         |
+| `interacted()`                       | No equivalent (`field.isEdited` covers most cases)                                                                  |
+| `isValid()`                          | `form.isValid`                                                                                                      |
+| `isSubmitting()`                     | `form.isSubmitting`                                                                                                 |
+| `isValidating()`                     | `form.isValidating`                                                                                                 |
+| `isDirty()`                          | `form.isDirty`                                                                                                      |
+| `setFields(path, value)` / `setData` | <Link href="/methods/api/setInput/">`setInput`</Link>                                                               |
+| `setErrors(path, errors)`            | <Link href="/methods/api/setErrors/">`setErrors`</Link>                                                             |
+| `setTouched(path, true)`             | Not needed (touched state is managed automatically)                                                                 |
+| `validate()` helper                  | <Link href="/methods/api/validate/">`validate`</Link>                                                               |
+| `reset()` / `resetField(path)`       | <Link href="/methods/api/reset/">`reset`</Link>                                                                     |
+| `setInitialValues(values)`           | <Link href="/methods/api/reset/">`reset`</Link> with `initialInput`                                                 |
+| `addField(path, value, index)`       | <Link href="/methods/api/insert/">`insert`</Link>                                                                   |
+| `unsetField(path)`                   | <Link href="/methods/api/remove/">`remove`</Link>                                                                   |
+| `moveField(path, from, to)`          | <Link href="/methods/api/move/">`move`</Link>                                                                       |
+| `swapFields(path, a, b)`             | <Link href="/methods/api/swap/">`swap`</Link>                                                                       |
+| `createSubmitHandler(config)`        | <Link href="/methods/api/handleSubmit/">`handleSubmit`</Link>                                                       |
+| `onSuccess` / `onError`              | Control flow inside your async submit handler                                                                       |
+
+A few entries have no direct equivalent. Felte's `warn` and `warnings` produce non-blocking messages next to errors; Formisch only tracks errors, so warnings need to be modeled outside the form state. The `debounced` config has no counterpart because Formisch controls validation frequency through the `validate` and `revalidate` config instead of debouncing individual functions. And `interacted`, which reports the name of the last field the user interacted with, has no equivalent, although the per-field `isEdited` flag covers the common use cases.
+
+## Common patterns
+
+### Form state
+
+Felte returns Solid accessors from `createForm` that you call as functions. In Formisch, form-level state consists of reactive properties on the form store, and values are read with the <Link href="/methods/api/getInput/">`getInput`</Link> method, which is reactive as well:
+
+```tsx
+import { createForm } from '@felte/solid';
+
+const { data, isValid, isSubmitting } = createForm<LoginValues>({
+  /* … */
+});
+data('email'); // string
+isValid(); // boolean
+```
+
+```tsx
+import { createForm, getInput } from '@formisch/solid';
+
+const loginForm = createForm({ schema: LoginSchema });
+getInput(loginForm, { path: ['email'] }); // string | undefined
+loginForm.isValid; // boolean
+```
+
+One difference to Felte's `data`, which is typed after your `initialValues`: Formisch input values are partial because not every field may have been set, so `getInput` returns `string | undefined` here.
+
+Field-level state like `field.input`, `field.errors` and `field.isTouched` is available on the field store inside <Link href="/solid/api/Field/">`Field`</Link> or via the <Link href="/solid/api/useField/">`useField`</Link> primitive.
+
+### Validation timing
+
+Felte validates the fields it considers touched as you fill the form and validates everything on submit, so errors for a field typically appear once you interact with it. Formisch makes this timing explicit: `validate` controls when a field is first validated (default `'submit'`) and `revalidate` controls when it is checked again (default `'input'`). To get behavior close to Felte's, validate on blur and revalidate on input:
+
+```tsx
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+Also note that Formisch populates `field.errors` for every invalid field as soon as validation runs, without filtering by touched state. You decide when to render them, for example only after the user edited the field or attempted to submit:
+
+```tsx
+{
+  (field.isEdited || loginForm.isSubmitted) && field.errors && (
+    <div>{field.errors[0]}</div>
+  );
+}
+```
+
+The <Link href="/solid/guides/validation/">validation</Link> guide covers these options and patterns in depth.
+
+### Field arrays
+
+In Felte, arrays are driven by indexed `name` attributes like `interests.0.value` together with the `addField` and `unsetField` helpers. In Formisch, the schema declares the array with `v.array`, and the <Link href="/solid/api/FieldArray/">`FieldArray`</Link> component provides stable `items` keys for SolidJS's `<For>` component. Items are added and removed with the <Link href="/methods/api/insert/">`insert`</Link> and <Link href="/methods/api/remove/">`remove`</Link> methods:
+
+```tsx
+import { Field, FieldArray, insert, remove } from '@formisch/solid';
+import { For } from 'solid-js';
+
+<FieldArray of={interestsForm} path={['interests']}>
+  {(fieldArray) => (
+    <For each={fieldArray.items}>
+      {(_, getIndex) => (
+        <div>
+          <Field of={interestsForm} path={['interests', getIndex(), 'value']}>
+            {(field) => (
+              <input {...field.props} value={field.input} type="text" />
+            )}
+          </Field>
+          <button
+            type="button"
+            onClick={() =>
+              remove(interestsForm, { path: ['interests'], at: getIndex() })
+            }
+          >
+            Remove
+          </button>
+        </div>
+      )}
+    </For>
+  )}
+</FieldArray>;
+
+<button
+  type="button"
+  onClick={() =>
+    insert(interestsForm, { path: ['interests'], initialInput: { value: '' } })
+  }
+>
+  Add interest
+</button>;
+```
+
+Felte's `moveField` and `swapFields` map to the <Link href="/methods/api/move/">`move`</Link> and <Link href="/methods/api/swap/">`swap`</Link> methods. See the <Link href="/solid/guides/field-arrays/">field arrays</Link> guide for a complete example including reordering, nesting and array-level validation.
+
+### Reset
+
+Felte's `reset` helper restores the initial values, and `setInitialValues` updates the baseline used by the next reset. Formisch combines both into the <Link href="/methods/api/reset/">`reset`</Link> method, which can also reset a single field via `path`:
+
+```tsx
+import { reset } from '@formisch/solid';
+
+// Reset the entire form to its initial input
+reset(loginForm);
+
+// Reset a single field (Felte: resetField('email'))
+reset(loginForm, { path: ['email'] });
+
+// Update the initial input and reset (Felte: setInitialValues + reset)
+reset(loginForm, { initialInput: { email: 'new@example.com' } });
+```
+
+### Special inputs
+
+Felte reads checkboxes, radio buttons, selects and file inputs automatically from the DOM based on their `name` attribute. Formisch supports all of these too, but since fields are connected through `field.props`, you set the appropriate controlled attribute yourself, like `checked` for checkboxes:
+
+```tsx
+<Field of={form} path={['cookies']}>
+  {(field) => (
+    <label>
+      <input {...field.props} type="checkbox" checked={!!field.input} />
+      Yes, I want cookies
+    </label>
+  )}
+</Field>
+```
+
+The <Link href="/solid/guides/special-inputs/">special inputs</Link> guide shows the equivalent patterns for radio groups, single and multiple selects, and file inputs.
+
+## Next steps
+
+With your first form migrated, work through the <Link href="/solid/guides/define-your-form/">define your form</Link>, <Link href="/solid/guides/add-form-fields/">add form fields</Link> and <Link href="/solid/guides/handle-submission/">handle submission</Link> guides to deepen the concepts this guide touched on. The <Link href="/solid/guides/controlled-fields/">controlled fields</Link> and <Link href="/solid/guides/form-methods/">form methods</Link> guides are useful next reads once your migrated forms grow more dynamic.

--- a/website/src/routes/(docs)/solid/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
@@ -1,0 +1,420 @@
+---
+title: Migrate from TanStack Form
+description: >-
+  Learn how to migrate your forms from TanStack Form to Formisch. This guide
+  maps the TanStack Form API to its Formisch equivalents and walks you through
+  the migration step by step.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from TanStack Form
+
+This guide walks you through migrating a SolidJS app from [TanStack Form](https://tanstack.com/form/latest) (`@tanstack/solid-form`) to Formisch. It covers the mental-model shift, a side-by-side example, concrete migration steps, and an API mapping table you can use as a reference while porting your forms.
+
+Migrating is a rewrite of the form layer, not a drop-in replacement. The two libraries structure forms differently, so you will replace form setup, field bindings, and validation config rather than swapping imports. The good news: both libraries are headless and use render-prop field components, so your markup and styling carry over largely unchanged.
+
+Formisch and TanStack Form can coexist in the same application. You can migrate one form at a time and remove `@tanstack/solid-form` once the last form is ported.
+
+## Key differences
+
+TanStack Form derives its types from the `defaultValues` object and attaches validation as per-validator config: each field (or the form) declares `onChange`, `onBlur`, or `onSubmit` validators, each with its own trigger and optional async variant. Form state is read through subscriptions, either the `form.Subscribe` component or the `form.useStore` hook with a selector.
+
+Formisch is schema-first. A single Valibot schema is the source of types, runtime validation, and form structure all at once. There is no `defaultValues` object to keep aligned with your validators and no per-field validation config. This changes three things in practice:
+
+- **Validation location**: Validation rules move out of your JSX and into the schema. Whenever validation runs, Formisch parses the entire form against the schema in one pass and distributes the issues to the individual fields, so cross-field rules work without extra wiring.
+- **Validation timing**: Instead of choosing a trigger per validator, you configure timing form-wide with the `validate` and `revalidate` options of <Link href="/solid/api/createForm/">`createForm`</Link>.
+- **Reactivity**: Form state like `isSubmitting` or a field's `errors` are fine-grained signals you read directly, for example `form.isSubmitting` in JSX. There is no subscription component or selector hook.
+
+Formisch is also several times smaller (from ~2.5 kB min+gzip) because methods like <Link href="/methods/api/reset/">`reset`</Link> and <Link href="/methods/api/insert/">`insert`</Link> are imported individually and tree-shaken. The main trade-off is that Formisch currently supports only [Valibot](https://valibot.dev) as the schema library, while TanStack Form accepts any Standard Schema validator. If your TanStack Form validators are already Valibot schemas, migration is mostly a matter of merging them into one object schema.
+
+## Side-by-side example
+
+The following login form has two validated fields, shows errors below each input, disables the submit button while submitting, and logs the values on submit.
+
+### TanStack Form
+
+```tsx
+import { createForm } from '@tanstack/solid-form';
+
+export default function LoginPage() {
+  const form = createForm(() => ({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    onSubmit: async ({ value }) => {
+      console.log(value);
+    },
+  }));
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        form.handleSubmit();
+      }}
+    >
+      <form.Field
+        name="email"
+        validators={{
+          onBlur: ({ value }) =>
+            !value.includes('@')
+              ? 'The email address is badly formatted.'
+              : undefined,
+        }}
+      >
+        {(field) => (
+          <div>
+            <input
+              type="email"
+              name={field().name}
+              value={field().state.value}
+              onBlur={field().handleBlur}
+              onInput={(event) =>
+                field().handleChange(event.currentTarget.value)
+              }
+            />
+            {!field().state.meta.isValid && (
+              <div>{field().state.meta.errors.join(', ')}</div>
+            )}
+          </div>
+        )}
+      </form.Field>
+      <form.Field
+        name="password"
+        validators={{
+          onBlur: ({ value }) =>
+            value.length < 8
+              ? 'Your password must have 8 characters or more.'
+              : undefined,
+        }}
+      >
+        {(field) => (
+          <div>
+            <input
+              type="password"
+              name={field().name}
+              value={field().state.value}
+              onBlur={field().handleBlur}
+              onInput={(event) =>
+                field().handleChange(event.currentTarget.value)
+              }
+            />
+            {!field().state.meta.isValid && (
+              <div>{field().state.meta.errors.join(', ')}</div>
+            )}
+          </div>
+        )}
+      </form.Field>
+      <form.Subscribe selector={(state) => state.isSubmitting}>
+        {(isSubmitting) => (
+          <button type="submit" disabled={isSubmitting()}>
+            Login
+          </button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}
+```
+
+### Formisch
+
+```tsx
+import { createForm, Field, Form } from '@formisch/solid';
+import type { SubmitHandler } from '@formisch/solid';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.email('The email address is badly formatted.')),
+  password: v.pipe(
+    v.string(),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+export default function LoginPage() {
+  const loginForm = createForm({
+    schema: LoginSchema,
+    validate: 'blur',
+  });
+
+  const handleLogin: SubmitHandler<typeof LoginSchema> = async (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleLogin}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="email" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <div>
+            <input {...field.props} value={field.input} type="password" />
+            {field.errors && <div>{field.errors[0]}</div>}
+          </div>
+        )}
+      </Field>
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+The validation rules moved from the `validators` props into the schema, the manual `<form>` element with `preventDefault` and `form.handleSubmit()` became the <Link href="/solid/api/Form/">`Form`</Link> component, and the input wiring collapsed into spreading `field.props`. Because the submit handler receives values that already passed the schema, `output` is fully typed as the schema's output type.
+
+## Migration steps
+
+### Install Formisch
+
+Formisch uses Valibot as a peer dependency, so install both packages. See the <Link href="/solid/guides/installation/">installation</Link> guide for details.
+
+```bash
+npm install valibot @formisch/solid
+```
+
+### Move validation into a Valibot schema
+
+Collect the `defaultValues` shape and all `validators` of a form and express them as a single Valibot schema, as shown in the side-by-side example above. Inline validator functions become Valibot pipes, and if you already passed Valibot schemas as Standard Schema validators, merge them into one object schema. Use `v.nonEmpty('…')` to require a value with its own error message, and define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/solid/guides/define-your-form/">define your form</Link> guide for more on schema design.
+
+### Replace the form setup
+
+TanStack Form's `createForm` takes a function returning an options object with `defaultValues` and `onSubmit`. Formisch's <Link href="/solid/api/createForm/">`createForm`</Link> primitive takes a plain config object with your schema. You no longer need `defaultValues` to define the form's shape: required string fields start as an empty string automatically. Only pass `initialInput` when fields should start with actual values.
+
+```tsx
+// Before
+const form = createForm(() => ({
+  defaultValues: { email: '', password: '' },
+  onSubmit: async ({ value }) => console.log(value),
+}));
+
+// After
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur',
+});
+```
+
+The `validate: 'blur'` option mirrors the `onBlur` validators from before. See the <Link href="/solid/guides/create-your-form/">create your form</Link> guide for all configuration options.
+
+### Replace field bindings
+
+Replace each `form.Field` with the <Link href="/solid/api/Field/">`Field`</Link> component. Two things change: the `name` string becomes a type-safe `path` array (`name="details.email"` becomes `path={['details', 'email']}`), and the manual wiring of `value`, `onBlur`, and `onInput` collapses into spreading `field.props`. Note that the Formisch field store is a plain object, not an accessor, so it is `field.input` instead of `field().state.value`.
+
+```tsx
+// Before
+<form.Field name="email">
+  {(field) => (
+    <input
+      type="email"
+      name={field().name}
+      value={field().state.value}
+      onBlur={field().handleBlur}
+      onInput={(event) => field().handleChange(event.currentTarget.value)}
+    />
+  )}
+</form.Field>
+
+// After
+<Field of={loginForm} path={['email']}>
+  {(field) => <input {...field.props} value={field.input} type="email" />}
+</Field>
+```
+
+Error display changes from `field().state.meta.errors` to `field.errors`, which is either `null` or a non-empty array of strings. If you built reusable field components with `createField` or wrapper components, rebuild them with the <Link href="/solid/api/useField/">`useField`</Link> primitive as shown in the <Link href="/solid/guides/add-form-fields/">add form fields</Link> and <Link href="/solid/guides/input-components/">input components</Link> guides.
+
+### Update submission handling
+
+The `onSubmit` option of the form config becomes the `onSubmit` prop of the <Link href="/solid/api/Form/">`Form`</Link> component, which also replaces the manual `<form>` element, `event.preventDefault()`, and `form.handleSubmit()` call. Your handler receives the validated output directly instead of a `{ value }` object, and it only runs when the schema passes. Also replace `form.Subscribe` and `form.useStore` reads with direct property access, for example `disabled={loginForm.isSubmitting}` on the submit button.
+
+```tsx
+const handleLogin: SubmitHandler<typeof LoginSchema> = async (output) => {
+  await loginUser(output);
+};
+
+<Form of={loginForm} onSubmit={handleLogin}>
+  {/* fields */}
+  <button type="submit" disabled={loginForm.isSubmitting}>
+    Login
+  </button>
+</Form>;
+```
+
+See the <Link href="/solid/guides/handle-submission/">handle submission</Link> guide for details, including how to trigger submission programmatically.
+
+## API mapping
+
+| TanStack Form                                     | Formisch                                                                                                                                            |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createForm(() => ({ … }))`                       | <Link href="/solid/api/createForm/">`createForm`</Link> with a plain config object                                                                  |
+| `defaultValues`                                   | `schema` defines the shape; `initialInput` sets values                                                                                              |
+| `validators` (form- or field-level)               | Valibot schema passed to `schema`                                                                                                                   |
+| `onChange` / `onBlur` / `onSubmit` validator keys | `validate` and `revalidate` config options                                                                                                          |
+| `onSubmit` config option                          | `onSubmit` prop of <Link href="/solid/api/Form/">`Form`</Link>                                                                                      |
+| `<form>` with `form.handleSubmit()`               | <Link href="/solid/api/Form/">`Form`</Link> component                                                                                               |
+| `<form.Field name="…">`                           | <Link href="/solid/api/Field/">`Field`</Link> with `path` array                                                                                     |
+| `field().state.value`                             | `field.input`                                                                                                                                       |
+| `field().handleChange` / `field().handleBlur`     | Spread `field.props`, or `field.onInput` for custom inputs                                                                                          |
+| `field().state.meta.errors`                       | `field.errors`                                                                                                                                      |
+| `field().state.meta.isTouched`                    | `field.isTouched`                                                                                                                                   |
+| `field().state.meta.isDirty`                      | `field.isEdited`                                                                                                                                    |
+| `!field().state.meta.isDefaultValue`              | `field.isDirty`                                                                                                                                     |
+| `form.Subscribe` / `form.useStore`                | Direct property access, e.g. `form.isSubmitting`                                                                                                    |
+| `form.state.values`                               | <Link href="/methods/api/getInput/">`getInput`</Link>                                                                                               |
+| `form.setFieldValue(name, value)`                 | <Link href="/methods/api/setInput/">`setInput`</Link>                                                                                               |
+| Setting errors manually                           | <Link href="/methods/api/setErrors/">`setErrors`</Link>                                                                                             |
+| Triggering validation manually                    | <Link href="/methods/api/validate/">`validate`</Link>                                                                                               |
+| `form.reset()`                                    | <Link href="/methods/api/reset/">`reset`</Link>                                                                                                     |
+| `<form.Field mode="array">`                       | <Link href="/solid/api/FieldArray/">`FieldArray`</Link>                                                                                             |
+| `pushValue` / `insertValue` / `removeValue`       | <Link href="/methods/api/insert/">`insert`</Link> / <Link href="/methods/api/remove/">`remove`</Link>                                               |
+| `moveValue` / `swapValues` / `replaceValue`       | <Link href="/methods/api/move/">`move`</Link> / <Link href="/methods/api/swap/">`swap`</Link> / <Link href="/methods/api/replace/">`replace`</Link> |
+
+A few entries deserve a note:
+
+- **`state.canSubmit`** has no direct equivalent. With the default `validate: 'submit'` timing, `form.isValid` stays `true` until the first submit, so a validity-based disabled state would not reflect the actual input before then. Use `form.isSubmitting` to disable during submission, or combine `form.isValid` with `validate: 'initial'` if you want TanStack-like behavior.
+- **Dirty state** is split differently. TanStack Form's `isDirty` stays `true` once a field was changed, even if the value is reverted. That matches Formisch's `isEdited`. Formisch's `isDirty` compares the current input against the initial input and turns back off when they match, like TanStack Form's `isDefaultValue` inverted.
+- **`onChangeAsyncDebounceMs`** has no equivalent. Async validation is expressed in the schema with Valibot's async API (`v.pipeAsync`, `v.checkAsync`), and the form exposes `isValidating` while it runs. Built-in debouncing is not provided.
+- **`form.Subscribe` and `form.useStore`** are unnecessary. Formisch state is exposed as fine-grained signals, so reading `form.isSubmitting` in JSX is already reactive and only updates what depends on it.
+
+## Common patterns
+
+### Form state
+
+In TanStack Form you subscribe to state with a selector to scope updates:
+
+```tsx
+<form.Subscribe selector={(state) => state.isSubmitting}>
+  {(isSubmitting) => <button disabled={isSubmitting()}>Login</button>}
+</form.Subscribe>
+```
+
+In Formisch you read the store directly. Properties like `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid`, and `errors` are backed by signals, so no subscription wrapper is needed:
+
+```tsx
+<button type="submit" disabled={loginForm.isSubmitting}>
+  {loginForm.isSubmitting ? 'Logging in...' : 'Login'}
+</button>
+```
+
+To read field values outside a field, replace `form.useStore((state) => state.values.email)` with `getInput(loginForm, { path: ['email'] })`. The <Link href="/methods/api/getInput/">`getInput`</Link> method is reactive as well, so any computation that calls it updates when the value changes.
+
+### Validation timing
+
+TanStack Form decides timing per validator: an `onChange` validator runs on every change, an `onBlur` validator on blur, and so on, per field. Formisch configures timing once for the whole form with `validate` (first validation, defaults to `'submit'`) and `revalidate` (after a field has an error or the form was submitted, defaults to `'input'`):
+
+```tsx
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur',
+  revalidate: 'input',
+});
+```
+
+This two-phase model replaces most per-field trigger combinations: fields stay quiet until first validated, then correct themselves live. To show errors only after a user actually changed a field, combine `field.isEdited` with `form.isSubmitted` as shown in the <Link href="/solid/guides/validation/">validation</Link> guide.
+
+### Field arrays
+
+TanStack Form uses `form.Field` with `mode="array"` and Solid's `<Index>` component, with helpers like `pushValue` and `removeValue` on the field:
+
+```tsx
+<form.Field name="todos" mode="array">
+  {(field) => (
+    <div>
+      <Index each={field().state.value}>
+        {(_, index) => (
+          <form.Field name={`todos[${index}].label`}>
+            {(subField) => (
+              <input
+                value={subField().state.value}
+                onInput={(event) =>
+                  subField().handleChange(event.currentTarget.value)
+                }
+              />
+            )}
+          </form.Field>
+        )}
+      </Index>
+      <button type="button" onClick={() => field().pushValue({ label: '' })}>
+        Add todo
+      </button>
+    </div>
+  )}
+</form.Field>
+```
+
+Formisch provides the <Link href="/solid/api/FieldArray/">`FieldArray`</Link> component. Its `items` array contains stable unique IDs designed for Solid's `<For>` component, and array operations are standalone methods:
+
+```tsx
+import { Field, FieldArray, insert } from '@formisch/solid';
+import { For } from 'solid-js';
+
+<FieldArray of={todoForm} path={['todos']}>
+  {(fieldArray) => (
+    <div>
+      <For each={fieldArray.items}>
+        {(_, getIndex) => (
+          <Field of={todoForm} path={['todos', getIndex(), 'label']}>
+            {(field) => (
+              <input {...field.props} value={field.input ?? ''} type="text" />
+            )}
+          </Field>
+        )}
+      </For>
+      <button
+        type="button"
+        onClick={() =>
+          insert(todoForm, { path: ['todos'], initialInput: { label: '' } })
+        }
+      >
+        Add todo
+      </button>
+    </div>
+  )}
+</FieldArray>;
+```
+
+Rules for the array itself, like a minimum or maximum length, live in the schema via `v.pipe(v.array(…), v.maxLength(10))`, and their errors appear on `fieldArray.errors`. See the <Link href="/solid/guides/field-arrays/">field arrays</Link> guide for the remaining methods and nested arrays.
+
+### Reset
+
+`form.reset()` becomes the standalone <Link href="/methods/api/reset/">`reset`</Link> method. It can also update the initial input at the same time, which is the right tool when server data is refreshed and the form's baseline should change:
+
+```tsx
+import { reset } from '@formisch/solid';
+
+// Reset to the initial values
+reset(loginForm);
+
+// Reset with new initial values
+reset(loginForm, { initialInput: { email: 'user@example.com' } });
+```
+
+### Special inputs
+
+In TanStack Form, non-text inputs are wired manually, for example a checkbox with `checked={field().state.value}` and `onChange={(event) => field().handleChange(event.currentTarget.checked)}`. In Formisch, `field.props` handles native checkboxes, radio buttons, selects, and file inputs automatically. You only set the visual state:
+
+```tsx
+<Field of={form} path={['terms']}>
+  {(field) => (
+    <input {...field.props} type="checkbox" checked={!!field.input} />
+  )}
+</Field>
+```
+
+See the <Link href="/solid/guides/special-inputs/">special inputs</Link> guide for selects, radio groups, and file inputs, and the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide for fields with non-string types like numbers and dates.
+
+## Next steps
+
+After migrating your first form, read the <Link href="/solid/guides/define-your-form/">define your form</Link> and <Link href="/solid/guides/validation/">validation</Link> guides to get the most out of the schema-first approach, and the <Link href="/solid/guides/form-methods/">form methods</Link> guide for the full set of methods to read and manipulate form state. If your forms use custom input components, the <Link href="/solid/guides/input-components/">input components</Link> guide shows how to port them cleanly.

--- a/website/src/routes/(docs)/solid/guides/menu.md
+++ b/website/src/routes/(docs)/solid/guides/menu.md
@@ -26,3 +26,8 @@
 - [Field arrays](/solid/guides/field-arrays/)
 - [TypeScript](/solid/guides/typescript/)
 - [Architecture](/solid/guides/architecture/)
+
+## Migration guides
+
+- [From Felte](/solid/guides/migrate-from-felte/)
+- [From TanStack Form](/solid/guides/migrate-from-tanstack-form/)

--- a/website/src/routes/(docs)/svelte/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(get-started)/comparison/index.mdx
@@ -48,9 +48,11 @@ Three reasons to pick Formisch over the alternatives above:
 
 **Formisch** makes the most sense for new projects in TypeScript-heavy codebases, especially when you expect forms to grow in complexity. The schema-first design means there is a single source of truth for types, runtime validation, and form structure, so there is less to keep aligned over time. Reactivity is fine-grained through Svelte 5 runes. The main considerations are that Formisch currently supports only [Valibot](https://valibot.dev) as the schema library, and is presently a client-side form layer — dedicated SvelteKit integration is planned for one of the next releases.
 
-## Migrating from Superforms
+## Migrating to Formisch
 
-Migrating from Superforms to Formisch is not a drop-in replacement. Superforms is built around SvelteKit's server form actions, while Formisch is a pure client-side form layer. Migration typically means moving validation and submission out of `+page.server.ts` actions into client-side handlers, or wiring server validation separately. The two libraries can coexist in the same application, so you can migrate one form at a time.
+Migrating to Formisch is not a drop-in replacement. Superforms in particular is built around SvelteKit's server form actions, while Formisch is a pure client-side form layer, so migration typically means moving validation and submission out of `+page.server.ts` actions into client-side handlers. The libraries can coexist in the same application, so you can migrate one form at a time.
+
+We provide a dedicated migration guide for each library, with a side-by-side example, step-by-step instructions, and an API mapping table: <Link href="/svelte/guides/migrate-from-superforms/">migrate from Superforms</Link> and <Link href="/svelte/guides/migrate-from-tanstack-form/">migrate from TanStack Form</Link>.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/svelte/guides/(migration-guides)/migrate-from-superforms/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(migration-guides)/migrate-from-superforms/index.mdx
@@ -1,0 +1,401 @@
+---
+title: Migrate from Superforms
+description: >-
+  Learn how to migrate your forms from Superforms to Formisch. This guide
+  compares both APIs side by side and walks you through the migration one
+  step at a time.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from Superforms
+
+This guide walks you through migrating a form from [Superforms](https://superforms.rocks) to Formisch. It covers the mental-model differences, shows the same form implemented in both libraries, and maps the Superforms API to its Formisch equivalents.
+
+Migrating is a rewrite of the form layer, not a drop-in replacement. Superforms is built around SvelteKit's server form actions, while Formisch is a pure client-side form layer. Migration typically means moving validation and submission out of `+page.server.ts` actions into client-side handlers, or wiring server validation separately. The good news: if you already validate with Valibot, your schemas carry over unchanged.
+
+Both libraries can coexist in the same application, so you can migrate one form at a time instead of rewriting everything at once.
+
+## Key differences
+
+The biggest shift is where the form lives. Superforms is server-first: you initialize the form with `superValidate` in a `load` function, post to a form action, and connect the client with `superForm` and `use:enhance`. Even in SPA mode, the API keeps this server-shaped structure with a `SuperValidated` object and an `onUpdate` event. Formisch is client-first: you call the <Link href="/svelte/api/createForm/">`createForm`</Link> rune directly in your component, and there is no `load` function, form action, or adapter involved. Dedicated SvelteKit integration is planned for one of the next releases; until then, server validation is something you wire up separately, for example by parsing the same Valibot schema in an API endpoint.
+
+Beyond that, three differences shape the migration:
+
+- **Schema handling**: Both libraries are schema-based, but Superforms supports many schema libraries through adapters like `valibot(schema)` and `valibotClient(schema)`. Formisch supports only Valibot and takes the schema directly, without an adapter. The schema is the single source of truth for types, validation, and form structure at once.
+- **Validation location and timing**: Superforms validates on the server by default, and client-side validation is opt-in via the `validators` option with timing controlled by `validationMethod`. Formisch always validates on the client against your schema, and timing is controlled by the `validate` and `revalidate` config.
+- **Reactivity**: Superforms exposes Svelte stores that hold the whole form, like `$form`, `$errors`, and `$tainted`, and you connect inputs with `bind:value={$form.email}`. Formisch is headless with fine-grained per-field reactivity: the <Link href="/svelte/api/Field/">`Field`</Link> component and <Link href="/svelte/api/useField/">`useField`</Link> rune expose a store for a single field, and you connect inputs by spreading `field.props`. Nested data works out of the box through path arrays, so there is no equivalent of the `dataType: 'json'` option.
+
+One trade-off to be aware of: because Formisch runs entirely on the client, your forms no longer submit without JavaScript. If progressive enhancement through form actions is a hard requirement, Superforms remains the better fit for that form.
+
+## Side-by-side example
+
+The following login form has two validated fields and a submit handler. Both versions use the same Valibot schema.
+
+### Superforms
+
+Superforms splits the form across three files: the shared schema, the server route with the `load` function and form action, and the page component.
+
+```ts
+// src/lib/schemas.ts
+import * as v from 'valibot';
+
+export const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+```
+
+```ts
+// src/routes/login/+page.server.ts
+import { LoginSchema } from '$lib/schemas';
+import { fail } from '@sveltejs/kit';
+import { superValidate } from 'sveltekit-superforms';
+import { valibot } from 'sveltekit-superforms/adapters';
+
+export const load = async () => {
+  const form = await superValidate(valibot(LoginSchema));
+  return { form };
+};
+
+export const actions = {
+  default: async ({ request }) => {
+    const form = await superValidate(request, valibot(LoginSchema));
+    if (!form.valid) {
+      return fail(400, { form });
+    }
+    // Log in the user with form.data
+    return { form };
+  },
+};
+```
+
+```svelte
+<!-- src/routes/login/+page.svelte -->
+<script lang="ts">
+  import { superForm } from 'sveltekit-superforms';
+  import { valibotClient } from 'sveltekit-superforms/adapters';
+  import { LoginSchema } from '$lib/schemas';
+
+  let { data } = $props();
+
+  const { form, errors, enhance, submitting } = superForm(data.form, {
+    validators: valibotClient(LoginSchema),
+  });
+</script>
+
+<form method="POST" use:enhance>
+  <input
+    type="email"
+    name="email"
+    aria-invalid={$errors.email ? 'true' : undefined}
+    bind:value={$form.email}
+  />
+  {#if $errors.email}<div>{$errors.email}</div>{/if}
+
+  <input
+    type="password"
+    name="password"
+    aria-invalid={$errors.password ? 'true' : undefined}
+    bind:value={$form.password}
+  />
+  {#if $errors.password}<div>{$errors.password}</div>{/if}
+
+  <button disabled={$submitting}>Login</button>
+</form>
+```
+
+### Formisch
+
+The same form in Formisch is a single component. The schema stays exactly the same.
+
+```svelte
+<!-- src/routes/login/+page.svelte -->
+<script lang="ts">
+  import { createForm, Field, Form } from '@formisch/svelte';
+  import type { SubmitHandler } from '@formisch/svelte';
+  import * as v from 'valibot';
+
+  const LoginSchema = v.object({
+    email: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your email.'),
+      v.email('The email address is badly formatted.')
+    ),
+    password: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your password.'),
+      v.minLength(8, 'Your password must have 8 characters or more.')
+    ),
+  });
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    validate: 'blur',
+    revalidate: 'input',
+  });
+
+  const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+    // Log in the user with the validated values
+    await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+  };
+</script>
+
+<Form of={loginForm} onsubmit={submitForm}>
+  <Field of={loginForm} path={['email']}>
+    {#snippet children(field)}
+      <input {...field.props} value={field.input} type="email" />
+      {#if field.errors}<div>{field.errors[0]}</div>{/if}
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['password']}>
+    {#snippet children(field)}
+      <input {...field.props} value={field.input} type="password" />
+      {#if field.errors}<div>{field.errors[0]}</div>{/if}
+    {/snippet}
+  </Field>
+
+  <button type="submit" disabled={loginForm.isSubmitting}>Login</button>
+</Form>
+```
+
+## Migration steps
+
+### Install Formisch
+
+Install the Svelte package of Formisch. If you used the Valibot adapter with Superforms, Valibot is already installed; otherwise add it as well, since it is a peer dependency.
+
+```bash
+npm install @formisch/svelte valibot
+```
+
+You can keep `sveltekit-superforms` installed while you migrate form by form and remove it at the end.
+
+### Move validation into a Valibot schema
+
+If your Superforms setup already uses Valibot, your schemas carry over unchanged. Just drop the adapter: instead of wrapping the schema in `valibot(...)` or `valibotClient(...)`, you pass it directly to <Link href="/svelte/api/createForm/">`createForm`</Link>. If you used Zod or another schema library, rewrite the schema in Valibot. Most validations translate one to one.
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(v.string(), v.nonEmpty(), v.email()),
+  password: v.pipe(v.string(), v.nonEmpty(), v.minLength(8)),
+});
+```
+
+Define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/svelte/guides/define-your-form/">define your form</Link> guide for details on how the schema shapes your form.
+
+### Replace the form setup
+
+Remove the `superValidate` call from your `load` function and the `data.form` plumbing, and replace `superForm` with the <Link href="/svelte/api/createForm/">`createForm`</Link> rune. Initial values that previously came from the `load` function move into the `initialInput` config.
+
+```svelte
+<script lang="ts">
+  import { createForm } from '@formisch/svelte';
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: 'user@example.com',
+    },
+  });
+</script>
+```
+
+If your Superforms form used client-side `validators`, carry the timing over with `validate: 'blur'` and `revalidate: 'input'`, as explained in the <Link href="#validation-timing">validation timing</Link> section below. Without these options, Formisch validates on submit first and then revalidates on every input.
+
+The form store returned by <Link href="/svelte/api/createForm/">`createForm`</Link> replaces the destructured stores of `superForm`: you access field state through the <Link href="/svelte/api/Field/">`Field`</Link> component and form state through properties like `loginForm.isSubmitting`.
+
+### Replace field bindings
+
+In Superforms, inputs bind to the central form store with `bind:value={$form.email}` and read errors from `$errors.email`. In Formisch, you wrap each input in a <Link href="/svelte/api/Field/">`Field`</Link> component, spread `field.props` onto the element, and set its `value` from `field.input`. The `name` attribute and all event handlers are included in `field.props`.
+
+```svelte
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <input {...field.props} value={field.input} type="email" />
+    {#if field.errors}<div>{field.errors[0]}</div>{/if}
+  {/snippet}
+</Field>
+```
+
+The `path` property is an array of keys, so nested fields like `$form.user.email` become `path={['user', 'email']}` without any `dataType: 'json'` configuration. For fields with a non-string schema like `v.number()` or `v.boolean()`, see the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> and <Link href="/svelte/guides/special-inputs/">special inputs</Link> guides.
+
+### Update submission handling
+
+Replace the form action and `use:enhance` with the <Link href="/svelte/api/Form/">`Form`</Link> component and its `onsubmit` property. Where Superforms posts to a form action and processes the result in `onUpdate` or `onUpdated`, Formisch validates on the client and calls your handler with the typed output of your schema. Logic from your form action moves into this handler, for example as a `fetch` call to an API endpoint.
+
+```svelte
+<script lang="ts">
+  import type { SubmitHandler } from '@formisch/svelte';
+
+  const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+    await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(values),
+    });
+  };
+</script>
+
+<Form of={loginForm} onsubmit={submitForm}>
+  <!-- fields -->
+  <button type="submit">Login</button>
+</Form>
+```
+
+If you still need server-side validation, parse the submitted data in your endpoint with the same Valibot schema. This keeps a single source of truth for both sides. See the <Link href="/svelte/guides/handle-submission/">handle submission</Link> guide for async submission and error handling patterns.
+
+## API mapping
+
+| Superforms                                 | Formisch                                                                                |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `superValidate(valibot(schema))` in `load` | Not needed, <Link href="/svelte/api/createForm/">`createForm`</Link> runs on the client |
+| `superForm(data.form, options)`            | <Link href="/svelte/api/createForm/">`createForm`</Link> rune                           |
+| `defaults(valibot(schema))`                | `initialInput` config of <Link href="/svelte/api/createForm/">`createForm`</Link>       |
+| `validators: valibotClient(schema)`        | `schema` config, validation always comes from the schema                                |
+| `validationMethod`                         | `validate` / `revalidate` config                                                        |
+| `dataType: 'json'`                         | Not needed, path arrays support nested data                                             |
+| `bind:value={$form.email}`                 | <Link href="/svelte/api/Field/">`Field`</Link> with `field.props` and `field.input`     |
+| `$errors.email`                            | `field.errors`                                                                          |
+| `$allErrors`                               | <Link href="/methods/api/getDeepErrorEntries/">`getDeepErrorEntries`</Link>             |
+| `$constraints`                             | No equivalent (see notes)                                                               |
+| `use:enhance` with form action             | <Link href="/svelte/api/Form/">`Form`</Link> with `onsubmit`                            |
+| `onUpdate` / `onUpdated` events            | <Link href="/core/api/SubmitHandler/">`SubmitHandler`</Link> passed to `onsubmit`       |
+| `$submitting`                              | `form.isSubmitting`                                                                     |
+| `$delayed` / `$timeout`                    | No equivalent (see notes)                                                               |
+| `$posted`                                  | `form.isSubmitted`                                                                      |
+| `$tainted` / `isTainted('email')`          | `field.isDirty` / <Link href="/methods/api/isDirty/">`isDirty`</Link>                   |
+| `reset({ data, newState })`                | <Link href="/methods/api/reset/">`reset`</Link> with `initialInput`                     |
+| `validateForm()` / `validate('email')`     | <Link href="/methods/api/validate/">`validate`</Link>                                   |
+| `submit()`                                 | <Link href="/methods/api/submit/">`submit`</Link>                                       |
+| `setError(form, 'email', message)`         | <Link href="/methods/api/setErrors/">`setErrors`</Link>                                 |
+| `$message` / `setMessage`                  | No equivalent (see notes)                                                               |
+| `taintedMessage`                           | No equivalent (see notes)                                                               |
+
+A few entries have no direct counterpart:
+
+- **`$constraints`**: Superforms derives HTML validation attributes like `required` and `minlength` from the schema. Formisch validates at runtime against the schema instead and does not generate constraint attributes. Set attributes like `required` on your inputs yourself where you want them for accessibility or styling.
+- **`$delayed` / `$timeout`**: Formisch exposes `isSubmitting` and `isValidating` but has no built-in loading timers. If you need a delayed spinner, wrap `form.isSubmitting` in your own timer logic.
+- **`$message` / `setMessage`**: Status messages are not form state in Formisch. Use regular Svelte state that you set in your submit handler.
+- **`taintedMessage`**: There is no built-in navigation guard. You can build one with SvelteKit's `beforeNavigate` and the <Link href="/methods/api/isDirty/">`isDirty`</Link> method.
+- **`validate('email')`**: Formisch has no partial validation. The <Link href="/methods/api/validate/">`validate`</Link> method always parses the whole form against the schema, which keeps cross-field rules correct, and then distributes the errors to the individual fields.
+
+## Common patterns
+
+### Form state
+
+Superforms spreads form state across several stores like `$submitting`, `$posted`, and `$tainted` with the `isTainted` helper. In Formisch, the form store exposes reactive properties directly: `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid`, and `errors`. Each field offers per-field `isTouched`, `isEdited`, `isDirty`, and `isValid` counterparts.
+
+```svelte
+<button type="submit" disabled={loginForm.isSubmitting || !loginForm.isDirty}>
+  {loginForm.isSubmitting ? 'Saving...' : 'Save'}
+</button>
+```
+
+To check the dirty state of a single field outside of a <Link href="/svelte/api/Field/">`Field`</Link> component, like `isTainted('email')` in Superforms, use the <Link href="/methods/api/isDirty/">`isDirty`</Link> method. Wrap the call in `$derived` so it stays reactive:
+
+```ts
+import { isDirty } from '@formisch/svelte';
+
+const emailIsDirty = $derived(isDirty(loginForm, { path: ['email'] }));
+```
+
+### Validation timing
+
+The `validationMethod` option of Superforms maps onto the `validate` and `revalidate` config of <Link href="/svelte/api/createForm/">`createForm`</Link>. The default `'auto'` behavior, where a field is first checked on blur and then re-checked on input once it has errors, corresponds to `validate: 'blur'` with `revalidate: 'input'`:
+
+```ts
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur', // 'onblur' part of Superforms 'auto'
+  revalidate: 'input', // 'oninput' part of Superforms 'auto'
+});
+```
+
+`'oninput'` maps to `validate: 'input'`, `'onblur'` to `validate: 'blur'`, and `'onsubmit'` to `validate: 'submit'`, which is the Formisch default. Note that `validate` and `revalidate` control when validation runs, not when errors are shown. The <Link href="/svelte/guides/validation/">validation</Link> guide shows how to reveal errors at the right time using flags like `field.isEdited` and `form.isSubmitted`.
+
+### Field arrays
+
+In Superforms, dynamic arrays require `dataType: 'json'`, an `{#each}` loop over `$form.tags`, and manual array mutations like `$form.tags = [...$form.tags, { name: '' }]`. Formisch provides the <Link href="/svelte/api/FieldArray/">`FieldArray`</Link> component, which exposes stable `items` keys for the `{#each}` block, together with methods like <Link href="/methods/api/insert/">`insert`</Link>, <Link href="/methods/api/remove/">`remove`</Link>, <Link href="/methods/api/move/">`move`</Link>, and <Link href="/methods/api/swap/">`swap`</Link>:
+
+```svelte
+<script lang="ts">
+  import { Field, FieldArray, insert } from '@formisch/svelte';
+</script>
+
+<FieldArray of={todoForm} path={['todos']}>
+  {#snippet children(fieldArray)}
+    {#each fieldArray.items as item, index (item)}
+      <Field of={todoForm} path={['todos', index, 'label']}>
+        {#snippet children(field)}
+          <input {...field.props} value={field.input} type="text" />
+        {/snippet}
+      </Field>
+    {/each}
+  {/snippet}
+</FieldArray>
+
+<button
+  type="button"
+  onclick={() =>
+    insert(todoForm, { path: ['todos'], initialInput: { label: '' } })}
+>
+  Add todo
+</button>
+```
+
+See the <Link href="/svelte/guides/field-arrays/">field arrays</Link> guide for the full API.
+
+### Reset
+
+The `reset()` method of Superforms maps to the <Link href="/methods/api/reset/">`reset`</Link> method of Formisch. Calling it without a config restores the initial values. Passing `initialInput` replaces the baseline, which covers both the `data` and `newState` options of Superforms at once, since future resets will use the new values:
+
+```ts
+import { reset } from '@formisch/svelte';
+
+// Reset to the initial values
+reset(loginForm);
+
+// Reset to new values that become the new baseline
+reset(loginForm, { initialInput: { email: 'new@example.com' } });
+```
+
+There is no `resetForm` option because Formisch does not reset the form after submission by default. If you want that behavior, call <Link href="/methods/api/reset/">`reset`</Link> at the end of your submit handler.
+
+### Special inputs
+
+Superforms binds special input types directly to the `$form` store, for example with `bind:checked={$form.cookies}` for a checkbox. In Formisch, you spread `field.props` and set the state attribute that matches the input type:
+
+```svelte
+<Field of={form} path={['cookies']}>
+  {#snippet children(field)}
+    <label>
+      <input {...field.props} type="checkbox" checked={field.input} />
+      Yes, I want cookies
+    </label>
+  {/snippet}
+</Field>
+```
+
+Checkboxes, radio buttons, selects and file inputs are covered in the <Link href="/svelte/guides/special-inputs/">special inputs</Link> guide. One thing to watch out for: Formisch's event handlers read values from the DOM as strings, so fields with a non-string schema like `v.number()` or `v.date()` must be controlled as described in the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide.
+
+## Next steps
+
+You now have everything you need to migrate your forms. To deepen your understanding of Formisch, work through the main concepts starting with <Link href="/svelte/guides/define-your-form/">define your form</Link> and <Link href="/svelte/guides/add-form-fields/">add form fields</Link>. The <Link href="/svelte/guides/validation/">validation</Link> guide covers error display in depth, the <Link href="/svelte/guides/form-methods/">form methods</Link> guide lists all available methods, and the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide explains how to handle non-string values.

--- a/website/src/routes/(docs)/svelte/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
@@ -1,0 +1,406 @@
+---
+title: Migrate from TanStack Form
+description: >-
+  Learn how to migrate your Svelte forms from TanStack Form to Formisch. This
+  guide compares both APIs side by side and walks you through the migration
+  step by step.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from TanStack Form
+
+This guide walks you through migrating a form from [TanStack Form](https://tanstack.com/form/latest) (`@tanstack/svelte-form`) to Formisch. It covers the mental-model differences, a complete side-by-side example, a step-by-step migration path, and a mapping of TanStack Form APIs to their Formisch equivalents.
+
+Migrating is a rewrite of the form layer, not a drop-in replacement. The two libraries structure forms differently: TanStack Form configures validation per field and reads state through subscriptions, while Formisch derives everything from a single Valibot schema. The form markup and your submission logic usually carry over with small changes. Both libraries can coexist in the same application, so you can migrate one form at a time and remove `@tanstack/svelte-form` once the last form is converted.
+
+## Key differences
+
+TanStack Form infers its types from the `defaultValues` object you pass to `createForm`. Validation is attached separately: each field (or the form itself) receives a `validators` object keyed by trigger, such as `onChange`, `onBlur`, `onSubmit` or `onMount`, with async variants like `onChangeAsync`. A validator can be a function or a Standard Schema, so a Valibot schema can already appear in a TanStack Form codebase, but it is one validator among many rather than the definition of the form.
+
+Formisch is schema-first. A single Valibot schema is the source of the form's TypeScript types, its runtime validation, and its structure, all at once. There is no `defaultValues` object to keep aligned with a separate type, and no per-field validator wiring. Validation always parses the entire form against the schema, so cross-field rules work without extra setup, and its timing is controlled form-wide by the `validate` and `revalidate` config.
+
+The remaining differences you will notice during migration:
+
+- **Field addressing**: TanStack Form uses string names like `"todos[0].label"`. Formisch uses type-safe path arrays like `['todos', 0, 'label']` that TypeScript checks against your schema.
+- **Input binding**: TanStack Form wires `value`, `oninput` and `onblur` by hand through `field.handleChange` and `field.handleBlur`. Formisch bundles the event handlers into `field.props`, which you spread onto the input element.
+- **Reactivity**: TanStack Form reads state through explicit subscriptions (`form.Subscribe`, `form.useStore`, now `form.useSelector`) with selector functions. Formisch state is fine-grained through Svelte 5 runes, so you read properties like `form.isSubmitting` directly and only the affected parts of the UI update.
+- **Submission**: TanStack Form calls the `onSubmit` option with the current values. Formisch validates against the schema first and calls your `onsubmit` handler only with typed, validated output.
+
+## Side-by-side example
+
+The same login form with two validated fields and a submit handler, first in TanStack Form, then in Formisch.
+
+### TanStack Form
+
+```svelte
+<script lang="ts">
+  import { createForm } from '@tanstack/svelte-form';
+
+  const form = createForm(() => ({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    onSubmit: async ({ value }) => {
+      console.log(value);
+    },
+  }));
+</script>
+
+<form
+  onsubmit={(event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    form.handleSubmit();
+  }}
+>
+  <form.Field
+    name="email"
+    validators={{
+      onBlur: ({ value }) =>
+        !value
+          ? 'Please enter your email.'
+          : !/^\S+@\S+\.\S+$/.test(value)
+            ? 'The email address is badly formatted.'
+            : undefined,
+    }}
+  >
+    {#snippet children(field)}
+      <input
+        type="email"
+        name={field.name}
+        value={field.state.value}
+        onblur={field.handleBlur}
+        oninput={(event) => field.handleChange(event.currentTarget.value)}
+      />
+      {#if field.state.meta.errors.length}
+        <div>{field.state.meta.errors[0]}</div>
+      {/if}
+    {/snippet}
+  </form.Field>
+
+  <form.Field
+    name="password"
+    validators={{
+      onBlur: ({ value }) =>
+        !value
+          ? 'Please enter your password.'
+          : value.length < 8
+            ? 'Your password must have 8 characters or more.'
+            : undefined,
+    }}
+  >
+    {#snippet children(field)}
+      <input
+        type="password"
+        name={field.name}
+        value={field.state.value}
+        onblur={field.handleBlur}
+        oninput={(event) => field.handleChange(event.currentTarget.value)}
+      />
+      {#if field.state.meta.errors.length}
+        <div>{field.state.meta.errors[0]}</div>
+      {/if}
+    {/snippet}
+  </form.Field>
+
+  <form.Subscribe selector={(state) => state.isSubmitting}>
+    {#snippet children(isSubmitting)}
+      <button type="submit" disabled={isSubmitting}>Login</button>
+    {/snippet}
+  </form.Subscribe>
+</form>
+```
+
+### Formisch
+
+```svelte
+<script lang="ts">
+  import { createForm, Field, Form } from '@formisch/svelte';
+  import type { SubmitHandler } from '@formisch/svelte';
+  import * as v from 'valibot';
+
+  const LoginSchema = v.object({
+    email: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your email.'),
+      v.email('The email address is badly formatted.')
+    ),
+    password: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your password.'),
+      v.minLength(8, 'Your password must have 8 characters or more.')
+    ),
+  });
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    validate: 'blur',
+  });
+
+  const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+    console.log(values);
+  };
+</script>
+
+<Form of={loginForm} onsubmit={submitForm}>
+  <Field of={loginForm} path={['email']}>
+    {#snippet children(field)}
+      <input {...field.props} value={field.input} type="email" />
+      {#if field.errors}
+        <div>{field.errors[0]}</div>
+      {/if}
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['password']}>
+    {#snippet children(field)}
+      <input {...field.props} value={field.input} type="password" />
+      {#if field.errors}
+        <div>{field.errors[0]}</div>
+      {/if}
+    {/snippet}
+  </Field>
+
+  <button type="submit" disabled={loginForm.isSubmitting}>Login</button>
+</Form>
+```
+
+The validation rules, error messages and types now live in one schema, the input wiring collapses into `{...field.props}`, and form state is read directly from the store without a subscription component.
+
+## Migration steps
+
+### Install Formisch
+
+Add Formisch and Valibot to your project. Valibot is a peer dependency:
+
+```bash
+npm install @formisch/svelte valibot
+```
+
+Keep `@tanstack/svelte-form` installed until all forms are migrated. See the <Link href="/svelte/guides/installation/">installation</Link> guide for other package managers.
+
+### Move validation into a Valibot schema
+
+Collect the rules from your `validators` objects and express them as one Valibot schema. Each per-field validator becomes a validation action in the schema, together with its error message. The `onBlur` validator of the email field above becomes:
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  // ...
+});
+```
+
+If your TanStack Form validators already use Valibot through Standard Schema, you can often merge the per-field schemas into a single object schema and reuse them as they are. Define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/svelte/guides/define-your-form/">define your form</Link> guide for details.
+
+### Replace the form setup
+
+TanStack Form's `createForm` takes a function returning options with `defaultValues` and `onSubmit`. The Formisch <Link href="/svelte/api/createForm/">`createForm`</Link> rune takes a plain config object with your schema:
+
+```ts
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur',
+});
+```
+
+You no longer need a `defaultValues` object just to establish types. Required string fields start as an empty string automatically. If you prefilled fields with `defaultValues`, pass those values as `initialInput`. The submission handler moves to the <Link href="/svelte/api/Form/">`Form`</Link> component in the next steps.
+
+### Replace field bindings
+
+Replace `form.Field` with the <Link href="/svelte/api/Field/">`Field`</Link> component. The string `name` becomes a type-safe `path` array, the manual event wiring becomes a spread of `field.props`, and errors move from `field.state.meta.errors` to `field.errors`:
+
+```svelte
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <input {...field.props} value={field.input} type="email" />
+    {#if field.errors}
+      <div>{field.errors[0]}</div>
+    {/if}
+  {/snippet}
+</Field>
+```
+
+For field components built with TanStack Form's form composition (`useFieldContext`), the Formisch counterpart is the <Link href="/svelte/api/useField/">`useField`</Link> rune, which gives you the same field store inside your own components. See the <Link href="/svelte/guides/add-form-fields/">add form fields</Link> and <Link href="/svelte/guides/input-components/">input components</Link> guides.
+
+### Update submission handling
+
+Replace the native `<form>` element and the manual `form.handleSubmit()` call with the <Link href="/svelte/api/Form/">`Form`</Link> component. It renders a `<form>` element, calls `event.preventDefault()` for you, and only invokes your handler after the schema validation passes:
+
+```svelte
+<script lang="ts">
+  const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+    // `values` is the validated, fully typed schema output
+    await loginUser(values);
+  };
+</script>
+
+<Form of={loginForm} onsubmit={submitForm}>
+  <!-- fields -->
+</Form>
+```
+
+Unlike TanStack Form's `onSubmit`, which receives the current form values, the Formisch handler receives the parsed schema output. See the <Link href="/svelte/guides/handle-submission/">handle submission</Link> guide to learn more.
+
+## API mapping
+
+| TanStack Form                                               | Formisch                                                                                |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `createForm(() => ({ … }))`                                 | <Link href="/svelte/api/createForm/">`createForm`</Link>`({ schema })`                  |
+| `defaultValues`                                             | `initialInput` config                                                                   |
+| `onSubmit` option                                           | `onsubmit` prop of <Link href="/svelte/api/Form/">`Form`</Link>                         |
+| `validators` config                                         | Valibot schema plus `validate` / `revalidate` config                                    |
+| `<form.Field name="…">`                                     | <Link href="/svelte/api/Field/">`Field`</Link> with `path` array                        |
+| `field.state.value`                                         | `field.input`                                                                           |
+| `field.handleChange` / `handleBlur`                         | Spread `field.props`, or `field.onInput` for custom inputs                              |
+| `field.state.meta.errors`                                   | `field.errors`                                                                          |
+| `field.state.meta.isTouched`                                | `field.isTouched`                                                                       |
+| `field.state.meta.isDirty`                                  | `field.isEdited`                                                                        |
+| `form.Subscribe` / `form.useStore` (now `form.useSelector`) | Direct property access, e.g. `form.isSubmitting`                                        |
+| `state.isSubmitting`                                        | `form.isSubmitting`                                                                     |
+| `state.canSubmit`                                           | No direct equivalent (see below)                                                        |
+| `form.handleSubmit()`                                       | <Link href="/methods/api/submit/">`submit`</Link>`(form)`                               |
+| `form.reset()`                                              | <Link href="/methods/api/reset/">`reset`</Link>`(form)`                                 |
+| `form.setFieldValue(name, value)`                           | <Link href="/methods/api/setInput/">`setInput`</Link>`(form, { path, input })`          |
+| `form.state.values`                                         | <Link href="/methods/api/getInput/">`getInput`</Link>`(form)`                           |
+| `form.validateAllFields`                                    | <Link href="/methods/api/validate/">`validate`</Link>`(form)`                           |
+| `<form.Field mode="array">`                                 | <Link href="/svelte/api/FieldArray/">`FieldArray`</Link>                                |
+| `field.pushValue` / `insertValue`                           | <Link href="/methods/api/insert/">`insert`</Link>`(form, { path })`                     |
+| `field.removeValue`                                         | <Link href="/methods/api/remove/">`remove`</Link>`(form, { path, at })`                 |
+| `field.moveValue`                                           | <Link href="/methods/api/move/">`move`</Link>`(form, { path, from, to })`               |
+| `field.swapValues`                                          | <Link href="/methods/api/swap/">`swap`</Link>`(form, { path, at, and })`                |
+| `field.replaceValue`                                        | <Link href="/methods/api/replace/">`replace`</Link>`(form, { path, at, initialInput })` |
+
+A few entries deserve a short note:
+
+- **`canSubmit`**: Formisch does not compute a "can submit" flag. The common pattern is to keep the submit button enabled: on submit, Formisch validates the whole form and automatically focuses the first field with an error. If you still want to reflect validity in the UI, `form.isValid` reflects the result of the last validation run, but with the default `validate: 'submit'` timing it stays `true` until the first submit, so combine it with `validate: 'initial'` for TanStack-like behavior.
+- **Dirty state**: TanStack Form's `isDirty` is persistent (it stays `true` after a change is reverted), which matches Formisch's `isEdited`. Formisch's `isDirty` compares the current input against the initial input, which matches TanStack Form's `!isDefaultValue`.
+- **`onMount` validator**: use `validate: 'initial'` in the Formisch config to validate as soon as the form is created.
+- **Async validators**: there is no counterpart to `onChangeAsyncDebounceMs`. Async checks live in the schema via `v.pipeAsync` and `v.checkAsync`, and the form-level `form.isValidating` reflects the in-flight state (Formisch does not track validating state per field, because validation always parses the whole schema).
+
+## Common patterns
+
+### Form state
+
+TanStack Form reads reactive state through the `form.Subscribe` component or the `form.useStore` hook (now `form.useSelector`) with a selector, as shown in the side-by-side example above. In Formisch, the form store returned by the <Link href="/svelte/api/createForm/">`createForm`</Link> rune is reactive through Svelte 5 runes, so you access properties directly and only the affected parts of the DOM update:
+
+```svelte
+<button type="submit" disabled={loginForm.isSubmitting}>
+  {loginForm.isSubmitting ? 'Submitting...' : 'Login'}
+</button>
+```
+
+The form store exposes `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid` and `errors`.
+
+### Validation timing
+
+In TanStack Form, timing is part of each validator: the same rule behaves differently depending on whether you register it as `onChange`, `onBlur` or `onSubmit`. In Formisch, the rules live in the schema and the timing is configured once for the whole form:
+
+```ts
+const loginForm = createForm({
+  schema: LoginSchema,
+  validate: 'blur', // first validation on blur
+  revalidate: 'input', // revalidate on every keystroke afterwards
+});
+```
+
+`validate` controls when a field is first validated (`'initial'`, `'touch'`, `'input'`, `'change'`, `'blur'` or `'submit'`, defaulting to `'submit'`), and `revalidate` controls subsequent runs once a field has an error or the form was submitted (defaulting to `'input'`). To reveal errors only at the right moment, combine `field.isEdited` with `form.isSubmitted` as shown in the <Link href="/svelte/guides/validation/">validation</Link> guide.
+
+### Field arrays
+
+TanStack Form handles arrays with `mode="array"` and helper methods on the field:
+
+```svelte
+<form.Field name="todos" mode="array">
+  {#snippet children(todosField)}
+    {#each todosField.state.value as _, index}
+      <form.Field name={`todos[${index}].label`}>
+        {#snippet children(field)}
+          <input
+            value={field.state.value}
+            oninput={(event) => field.handleChange(event.currentTarget.value)}
+          />
+        {/snippet}
+      </form.Field>
+    {/each}
+    <button type="button" onclick={() => todosField.pushValue({ label: '' })}>
+      Add todo
+    </button>
+  {/snippet}
+</form.Field>
+```
+
+Formisch provides the <Link href="/svelte/api/FieldArray/">`FieldArray`</Link> component, whose `items` array contains stable IDs for keying the `{#each}` block, together with standalone methods like <Link href="/methods/api/insert/">`insert`</Link> and <Link href="/methods/api/remove/">`remove`</Link>:
+
+```svelte
+<script lang="ts">
+  import { Field, FieldArray, insert } from '@formisch/svelte';
+</script>
+
+<FieldArray of={todoForm} path={['todos']}>
+  {#snippet children(fieldArray)}
+    {#each fieldArray.items as item, index (item)}
+      <Field of={todoForm} path={['todos', index, 'label']}>
+        {#snippet children(field)}
+          <input {...field.props} value={field.input} type="text" />
+        {/snippet}
+      </Field>
+    {/each}
+    <button
+      type="button"
+      onclick={() =>
+        insert(todoForm, { path: ['todos'], initialInput: { label: '' } })}
+    >
+      Add todo
+    </button>
+  {/snippet}
+</FieldArray>
+```
+
+Constraints such as a minimum or maximum number of items move into the schema, for example with `v.nonEmpty()` and `v.maxLength(10)` on the array. See the <Link href="/svelte/guides/field-arrays/">field arrays</Link> guide for the full picture.
+
+### Reset
+
+TanStack Form resets with `form.reset()`, or `form.reset(values)` to also update the default values. Formisch uses the <Link href="/methods/api/reset/">`reset`</Link> method:
+
+```ts
+import { reset } from '@formisch/svelte';
+
+// Reset the form to its initial input
+reset(loginForm);
+
+// Reset and replace the initial input (the new dirty baseline)
+reset(loginForm, { initialInput: { email: 'user@example.com' } });
+```
+
+Passing `initialInput` also updates the baseline for dirty tracking, just like passing values to TanStack Form's `reset` updates its default values.
+
+### Special inputs
+
+In TanStack Form, every input type is wired manually by passing the parsed value to `field.handleChange`, for example toggling a boolean for a checkbox. In Formisch, you spread `field.props` and set the state attribute that matches the input type:
+
+```svelte
+<Field of={form} path={['cookies']}>
+  {#snippet children(field)}
+    <label>
+      <input {...field.props} type="checkbox" checked={field.input} />
+      Yes, I want cookies
+    </label>
+  {/snippet}
+</Field>
+```
+
+Checkboxes, radio buttons, selects and file inputs are covered in the <Link href="/svelte/guides/special-inputs/">special inputs</Link> guide. One thing to watch out for: Formisch's event handlers read values from the DOM as strings, so fields with a non-string schema like `v.number()` or `v.date()` must be controlled as described in the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide. Custom components that don't expose a native element use `field.onInput` instead of `field.props`.
+
+## Next steps
+
+With your first form migrated, work through the main concepts to solidify the Formisch mental model: <Link href="/svelte/guides/define-your-form/">define your form</Link>, <Link href="/svelte/guides/create-your-form/">create your form</Link>, <Link href="/svelte/guides/add-form-fields/">add form fields</Link> and <Link href="/svelte/guides/handle-submission/">handle submission</Link>. The <Link href="/svelte/guides/form-methods/">form methods</Link> guide lists everything that replaces TanStack Form's imperative API, and the <Link href="/svelte/guides/validation/">validation</Link> guide covers error timing and async checks in depth.

--- a/website/src/routes/(docs)/svelte/guides/menu.md
+++ b/website/src/routes/(docs)/svelte/guides/menu.md
@@ -26,3 +26,8 @@
 - [Field arrays](/svelte/guides/field-arrays/)
 - [TypeScript](/svelte/guides/typescript/)
 - [Architecture](/svelte/guides/architecture/)
+
+## Migration guides
+
+- [From Superforms](/svelte/guides/migrate-from-superforms/)
+- [From TanStack Form](/svelte/guides/migrate-from-tanstack-form/)

--- a/website/src/routes/(docs)/vue/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(get-started)/comparison/index.mdx
@@ -50,9 +50,11 @@ Three reasons to pick Formisch over the alternatives above:
 
 **Formisch** makes the most sense for new projects in TypeScript-heavy codebases, especially when you expect forms to grow in complexity. The schema-first design means there is a single source of truth for types, runtime validation, and form structure, so there is less to keep aligned over time. Reactivity is fine-grained through Vue 3's composition API. The main consideration is that Formisch currently supports only [Valibot](https://valibot.dev) as the schema library.
 
-## Migrating from VeeValidate
+## Migrating to Formisch
 
-Migrating from VeeValidate to Formisch is not a drop-in replacement, but the conceptual gap is smaller than with a component-driven library. Both are headless and schema-friendly, so the main work is consolidating per-field validator rules into a single root Valibot schema and replacing VeeValidate's `useForm` / `useField` composables with Formisch's equivalents. The two libraries can coexist in the same application, so you can migrate one form at a time.
+Migrating to Formisch is not a drop-in replacement, but the libraries can coexist in the same application, so you can migrate one form at a time. The main work is consolidating validation rules into a single root Valibot schema and replacing the previous library's form and field APIs with Formisch's composables.
+
+We provide a dedicated migration guide for each library, with a side-by-side example, step-by-step instructions, and an API mapping table: <Link href="/vue/guides/migrate-from-vee-validate/">migrate from VeeValidate</Link>, <Link href="/vue/guides/migrate-from-formkit/">migrate from FormKit</Link>, and <Link href="/vue/guides/migrate-from-tanstack-form/">migrate from TanStack Form</Link>.
 
 ## Next steps
 

--- a/website/src/routes/(docs)/vue/guides/(migration-guides)/migrate-from-formkit/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(migration-guides)/migrate-from-formkit/index.mdx
@@ -1,0 +1,434 @@
+---
+title: Migrate from FormKit
+description: >-
+  Learn how to migrate your Vue forms from FormKit to Formisch. This guide
+  covers the key differences, a side-by-side example, step-by-step migration
+  instructions, and an API mapping.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from FormKit
+
+This guide walks you through migrating your Vue forms from [FormKit](https://formkit.com) (`@formkit/vue`) to Formisch. It covers the differences in mental model, shows the same form in both libraries side by side, and maps FormKit's APIs to their Formisch equivalents.
+
+Migrating is a rewrite of your form layer, not a drop-in replacement. FormKit is component-driven and renders your inputs for you, while Formisch is headless and only provides the data layer. The migration therefore replaces both the form logic and the input markup that FormKit generated for you.
+
+The good news: both libraries can coexist in the same application. Formisch does not require an app-level plugin, so you can leave FormKit's plugin registered in `main.ts` and migrate one form at a time. Once the last FormKit form is gone, remove the plugin and the dependency.
+
+## Key differences
+
+FormKit is a batteries-included form framework. A single globally registered `<FormKit>` component renders the entire input scaffolding, including the label, help text, validation messages, and styling. The form's structure emerges at runtime from the `name` props of the inputs nested inside `<FormKit type="form">`, validation rules are co-located with each input as string props like `validation="required|email"`, and TypeScript types for the submitted data are declared manually (or derived via the optional Zod plugin).
+
+Formisch flips this around with a schema-first approach. A single Valibot schema is the form: it defines the structure, the TypeScript types, and all validation rules at once. The `useForm` composable turns the schema into a reactive form store, and headless components like `Field` connect your own markup to it via type-safe path arrays. When the schema changes, every path and every inferred type follows at compile time.
+
+The main differences at a glance:
+
+- **UI ownership**: FormKit renders inputs, labels, and messages for you. Formisch renders nothing; you write the markup (or your own reusable <Link href="/vue/guides/input-components/">input components</Link>) and get full control over it.
+- **Source of truth**: In FormKit, structure lives in the template, validation lives on each input, and types live in your TypeScript code. In Formisch, all three live in one Valibot schema.
+- **Validation location and timing**: FormKit validates each input against its `validation` prop and controls message display per input via `validation-visibility`. Formisch validates the whole form against the schema and controls timing form-wide via the `validate` and `revalidate` config. When errors are shown is up to your markup.
+- **Reactivity**: FormKit keeps state in its own framework-agnostic core node tree that you access through `getNode`, node contexts, or slot props. Formisch stores state directly in Vue's reactivity system, so you read `form.isSubmitting` or `field.errors` like any other reactive value.
+- **Bundle size**: FormKit starts at roughly 25 kB (min+gzip). Formisch starts at about 2.5 kB and only grows with the methods you import, since it is fully tree-shakable.
+
+## Side-by-side example
+
+The following login form has two required fields with validation messages and an async submit handler, implemented once with each library.
+
+### FormKit
+
+```vue
+<script setup lang="ts">
+// The <FormKit> component is registered globally via
+// app.use(plugin, defaultConfig) in main.ts
+const handleSubmit = async (data: { email: string; password: string }) => {
+  console.log(data);
+};
+</script>
+
+<template>
+  <FormKit type="form" submit-label="Login" @submit="handleSubmit">
+    <FormKit
+      type="email"
+      name="email"
+      label="Email"
+      validation="required|email"
+      :validation-messages="{
+        required: 'Please enter your email.',
+        email: 'The email address is badly formatted.',
+      }"
+    />
+    <FormKit
+      type="password"
+      name="password"
+      label="Password"
+      validation="required|length:8"
+      :validation-messages="{
+        required: 'Please enter your password.',
+        length: 'Your password must have 8 characters or more.',
+      }"
+    />
+  </FormKit>
+</template>
+```
+
+### Formisch
+
+```vue
+<script setup lang="ts">
+import { Field, Form, useForm } from '@formisch/vue';
+import type { SubmitHandler } from '@formisch/vue';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+});
+
+const handleSubmit: SubmitHandler<typeof LoginSchema> = async (values) => {
+  console.log(values); // { email: string, password: string }
+};
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="handleSubmit">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <input v-bind="field.props" v-model="field.input" type="email" />
+      <div v-if="field.errors">{{ field.errors[0] }}</div>
+    </Field>
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <input v-bind="field.props" v-model="field.input" type="password" />
+      <div v-if="field.errors">{{ field.errors[0] }}</div>
+    </Field>
+    <button type="submit" :disabled="loginForm.isSubmitting">Login</button>
+  </Form>
+</template>
+```
+
+The Formisch version renders plain HTML instead of FormKit's prebuilt scaffolding, so the label, help text, and error markup that FormKit generated is now yours to write. In a real app you would move it into a reusable `TextInput` component, as shown in the <Link href="/vue/guides/input-components/">input components</Link> guide. In return, the submit handler receives values that are validated and fully typed by the schema, without a manually declared type.
+
+## Migration steps
+
+### Install Formisch
+
+Install Formisch and Valibot alongside FormKit. See the <Link href="/vue/guides/installation/">installation</Link> guide for details.
+
+```bash
+npm install @formisch/vue valibot
+```
+
+Since Formisch requires no `app.use(...)` call, nothing changes in `main.ts` yet. Keep FormKit's plugin registered until the last FormKit form is migrated.
+
+### Move validation into a Valibot schema
+
+Collect the `validation` and `:validation-messages` props of each input in the form and translate them into one Valibot schema. The nesting of `name` props (including `type="group"` wrappers) becomes the nesting of the object schema, and each validation rule becomes a Valibot action with its message as the first argument.
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  // FormKit: validation="required|email"
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+});
+```
+
+Common rule mappings: `required` becomes `v.nonEmpty(...)` for strings, `email` becomes `v.email(...)`, `length:8` becomes `v.minLength(8, ...)`, `between:1,10` becomes `v.minValue(1, ...)` and `v.maxValue(10, ...)`, and custom rules become `v.check(...)` or `v.checkAsync(...)`. Define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/vue/guides/define-your-form/">define your form</Link> guide for more details.
+
+### Replace the form setup
+
+Replace `<FormKit type="form">` with the <Link href="/vue/api/useForm/">`useForm`</Link> composable and the <Link href="/vue/api/Form/">`Form`</Link> component. If your FormKit form was prefilled via the `:value` prop or `v-model`, pass that data as `initialInput` instead.
+
+```vue
+<script setup lang="ts">
+import { Form, useForm } from '@formisch/vue';
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: { email: 'jane@example.com' },
+});
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="handleSubmit">
+    <!-- Fields will go here -->
+    <button type="submit">Login</button>
+  </Form>
+</template>
+```
+
+Note that FormKit automatically renders a submit button at the bottom of every form. Formisch does not, so add your own `<button type="submit">`.
+
+### Replace field bindings
+
+Each `<FormKit>` input becomes a <Link href="/vue/api/Field/">`Field`</Link> component wrapping your own markup. The `name` prop becomes a type-safe `path` array, and nested `type="group"` structures become longer paths like `['address', 'street']`. The `v-slot` directive exposes the field store with `props` to spread onto the element, `input` for `v-model`, and `errors` for display.
+
+```vue
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <label :for="field.props.name">Email</label>
+    <input
+      v-bind="field.props"
+      :id="field.props.name"
+      v-model="field.input"
+      type="email"
+    />
+    <div v-if="field.errors">{{ field.errors[0] }}</div>
+  </Field>
+</template>
+```
+
+For field components that encapsulate a single field, the <Link href="/vue/api/useField/">`useField`</Link> composable provides the same field store in the script block. See the <Link href="/vue/guides/add-form-fields/">add form fields</Link> guide for both approaches.
+
+### Update submission handling
+
+FormKit's `@submit` handler receives the collected form data and the form's core node, which is also used to set backend errors via `node.setErrors(...)`. In Formisch, the `@submit` handler on the `Form` component receives the schema-validated output, typed by <Link href="/core/api/SubmitHandler/">`SubmitHandler`</Link>, and backend errors are set with the <Link href="/methods/api/setErrors/">`setErrors`</Link> method.
+
+```ts
+import { setErrors } from '@formisch/vue';
+import type { SubmitHandler } from '@formisch/vue';
+
+const handleSubmit: SubmitHandler<typeof LoginSchema> = async (values) => {
+  const response = await login(values);
+  if (!response.ok) {
+    setErrors(loginForm, {
+      path: ['email'],
+      errors: ['This email is not registered.'],
+    });
+  }
+};
+```
+
+Leaving out the `path` sets form-level errors, which you can display via `loginForm.errors`.
+
+## API mapping
+
+| FormKit                              | Formisch                                                                                                                                                        |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `plugin` + `defaultConfig`           | Not needed, just import from `@formisch/vue`                                                                                                                    |
+| `<FormKit type="form">`              | <Link href="/vue/api/useForm/">`useForm`</Link> + <Link href="/vue/api/Form/">`Form`</Link>                                                                     |
+| `<FormKit name="…" />`               | <Link href="/vue/api/Field/">`Field`</Link> component or <Link href="/vue/api/useField/">`useField`</Link> composable                                           |
+| `<FormKit type="group">`             | Nested object schema + path arrays                                                                                                                              |
+| `validation` prop                    | Valibot schema passed to `useForm`                                                                                                                              |
+| `:validation-messages` prop          | Messages in the schema actions                                                                                                                                  |
+| `validation-visibility` prop         | `validate` / `revalidate` config + your markup                                                                                                                  |
+| `:value` / `v-model` on the form     | `initialInput` config                                                                                                                                           |
+| `@submit`                            | `@submit` on <Link href="/vue/api/Form/">`Form`</Link>                                                                                                          |
+| `state.valid`                        | `form.isValid` / `field.isValid`                                                                                                                                |
+| `state.dirty`                        | `form.isDirty` / `field.isDirty`                                                                                                                                |
+| `state.loading`                      | `form.isSubmitting`                                                                                                                                             |
+| `state.submitted`                    | `form.isSubmitted`                                                                                                                                              |
+| `node.setErrors()`                   | <Link href="/methods/api/setErrors/">`setErrors`</Link>                                                                                                         |
+| `reset()`                            | <Link href="/methods/api/reset/">`reset`</Link>                                                                                                                 |
+| `submitForm()`                       | <Link href="/methods/api/submit/">`submit`</Link>                                                                                                               |
+| `getNode()` + `node.value`           | <Link href="/methods/api/getInput/">`getInput`</Link>                                                                                                           |
+| `<FormKit type="repeater">` / `list` | <Link href="/vue/api/FieldArray/">`FieldArray`</Link> + <Link href="/methods/api/insert/">`insert`</Link>, <Link href="/methods/api/remove/">`remove`</Link>, … |
+| `<FormKitSchema>`                    | No equivalent                                                                                                                                                   |
+| `@formkit/zod` plugin                | Built in, the Valibot schema is the form definition                                                                                                             |
+
+A few entries have no direct equivalent. `<FormKitSchema>` generates entire forms from JSON, which has no counterpart in a headless library; with Formisch you write the template yourself. The same applies to FormKit's rendered UI scaffolding, themes, and icons: in Formisch you own the markup, so labels, help text, and message rendering move into your own <Link href="/vue/guides/input-components/">input components</Link>. And where FormKit configures validation display per input, Formisch configures validation timing once per form and leaves error display to your template.
+
+## Common patterns
+
+### Form state
+
+In FormKit, form state lives on the core node and is accessed through the form's slot props or via `getNode('id').context.state`:
+
+```vue
+<template>
+  <FormKit
+    type="form"
+    :actions="false"
+    @submit="handleSubmit"
+    v-slot="{ state }"
+  >
+    <!-- Fields -->
+    <FormKit type="submit" label="Login" :disabled="!state.valid" />
+  </FormKit>
+</template>
+```
+
+In Formisch, the form store returned by `useForm` is reactive, so you read state directly in script or template. The form store exposes `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid`, and `errors`, and each field store offers per-field `isTouched`, `isEdited`, `isDirty`, and `isValid` counterparts.
+
+```vue
+<template>
+  <Form :of="loginForm" @submit="handleSubmit">
+    <!-- Fields -->
+    <button type="submit" :disabled="loginForm.isSubmitting">
+      {{ loginForm.isSubmitting ? 'Submitting...' : 'Login' }}
+    </button>
+  </Form>
+</template>
+```
+
+### Validation timing
+
+FormKit validates continuously and uses `validation-visibility` (with values like `blur`, `live`, `dirty`, and `submit`) to decide per input when messages appear. Formisch splits this into two parts. The `validate` and `revalidate` config control when validation runs for the whole form:
+
+```ts
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur', // First validation on blur (default: 'submit')
+  revalidate: 'input', // Revalidation on every keystroke (default: 'input')
+});
+```
+
+When errors are displayed is decided in your markup. To approximate FormKit's default behavior of revealing messages once a field was interacted with, guard the error output with field state:
+
+```vue
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <input v-bind="field.props" v-model="field.input" type="email" />
+  <div v-if="(field.isEdited || loginForm.isSubmitted) && field.errors">
+    {{ field.errors[0] }}
+  </div>
+</Field>
+```
+
+See the <Link href="/vue/guides/validation/">validation</Link> guide for the full picture, including async validation with `isValidating`.
+
+### Field arrays
+
+FormKit handles repeating groups with the `repeater` input (a free Pro input from `@formkit/pro` that must be registered separately) or a dynamic `list`, and the repeater brings its own UI for adding, removing, and shifting items:
+
+```vue
+<template>
+  <FormKit type="form" @submit="saveTeam">
+    <FormKit type="repeater" name="members" label="Team members">
+      <FormKit type="text" name="name" label="Name" validation="required" />
+    </FormKit>
+  </FormKit>
+</template>
+```
+
+In Formisch, the array is part of the schema, the <Link href="/vue/api/FieldArray/">`FieldArray`</Link> component provides stable `items` keys for `v-for`, and methods like <Link href="/methods/api/insert/">`insert`</Link> and <Link href="/methods/api/remove/">`remove`</Link> mutate the array:
+
+```vue
+<script setup lang="ts">
+import {
+  Field,
+  FieldArray,
+  Form,
+  insert,
+  remove,
+  useForm,
+} from '@formisch/vue';
+import * as v from 'valibot';
+
+const TeamSchema = v.object({
+  members: v.array(
+    v.object({
+      name: v.pipe(v.string(), v.nonEmpty('Please enter a name.')),
+    })
+  ),
+});
+
+const teamForm = useForm({
+  schema: TeamSchema,
+  initialInput: { members: [{ name: '' }] },
+});
+</script>
+
+<template>
+  <Form :of="teamForm" @submit="(output) => console.log(output)">
+    <FieldArray :of="teamForm" :path="['members']" v-slot="fieldArray">
+      <div v-for="(item, index) in fieldArray.items" :key="item">
+        <Field :of="teamForm" :path="['members', index, 'name']" v-slot="field">
+          <input v-bind="field.props" v-model="field.input" type="text" />
+          <div v-if="field.errors">{{ field.errors[0] }}</div>
+        </Field>
+        <button
+          type="button"
+          @click="remove(teamForm, { path: ['members'], at: index })"
+        >
+          Remove
+        </button>
+      </div>
+    </FieldArray>
+    <button
+      type="button"
+      @click="
+        insert(teamForm, { path: ['members'], initialInput: { name: '' } })
+      "
+    >
+      Add member
+    </button>
+    <button type="submit">Save</button>
+  </Form>
+</template>
+```
+
+The <Link href="/methods/api/move/">`move`</Link>, <Link href="/methods/api/swap/">`swap`</Link>, and <Link href="/methods/api/replace/">`replace`</Link> methods cover reordering. See the <Link href="/vue/guides/field-arrays/">field arrays</Link> guide for nested arrays and array-level validation.
+
+### Reset
+
+FormKit resets a form through its `id` with the `reset` helper, for example `reset('login-form')` imported from `@formkit/core`. In Formisch, the <Link href="/methods/api/reset/">`reset`</Link> method takes the form store directly:
+
+```vue
+<script setup lang="ts">
+import { reset } from '@formisch/vue';
+</script>
+
+<template>
+  <button type="button" @click="reset(loginForm)">Reset</button>
+</template>
+```
+
+Like FormKit's optional second argument to `reset`, Formisch accepts new initial values. Calling `reset(loginForm, { initialInput: ... })` updates the baseline that dirty tracking compares against, which is the right tool when refreshed server data should become the new initial state.
+
+### Special inputs
+
+FormKit ships dedicated input types like `select`, `checkbox`, and `radio` that render their options from a prop:
+
+```vue
+<template>
+  <FormKit
+    type="select"
+    name="framework"
+    label="Framework"
+    :options="{ vue: 'Vue', react: 'React' }"
+  />
+</template>
+```
+
+Formisch works with the native HTML elements instead. You render the options yourself and bind the field with `v-bind` and `v-model`:
+
+```vue
+<template>
+  <Field :of="form" :path="['framework']" v-slot="field">
+    <select v-bind="field.props" v-model="field.input">
+      <option
+        v-for="option in [
+          { label: 'Vue', value: 'vue' },
+          { label: 'React', value: 'react' },
+        ]"
+        :key="option.value"
+        :value="option.value"
+      >
+        {{ option.label }}
+      </option>
+    </select>
+  </Field>
+</template>
+```
+
+Checkboxes, radio groups, and multi-selects follow the same pattern. File inputs are the exception: Vue does not allow `v-model` on them, so instead add an `input` handler that writes the selected file to `field.input` yourself. The <Link href="/vue/guides/special-inputs/">special inputs</Link> guide covers each of them, including checkbox groups that represent an array of strings.
+
+## Next steps
+
+With your first form migrated, work through the main concepts to deepen your understanding: <Link href="/vue/guides/define-your-form/">define your form</Link>, <Link href="/vue/guides/add-form-fields/">add form fields</Link>, and <Link href="/vue/guides/handle-submission/">handle submission</Link>. To rebuild the input scaffolding that FormKit provided, follow the <Link href="/vue/guides/input-components/">input components</Link> guide, and for programmatic control over your forms, explore the <Link href="/vue/guides/form-methods/">form methods</Link> guide.

--- a/website/src/routes/(docs)/vue/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(migration-guides)/migrate-from-tanstack-form/index.mdx
@@ -1,0 +1,475 @@
+---
+title: Migrate from TanStack Form
+description: >-
+  Learn how to migrate your Vue forms from TanStack Form to Formisch. This
+  guide compares both APIs side by side and walks through the migration step
+  by step.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from TanStack Form
+
+If your Vue forms are built with [TanStack Form](https://tanstack.com/form/latest) and you are considering a switch, this guide is for you. It explains how the two libraries differ, shows the same form implemented in both, and maps each TanStack Form API to its Formisch equivalent.
+
+Migration is a rewrite of the form layer, not a drop-in replacement. Both libraries are headless and type-safe, but they build on different foundations, so the form setup, field bindings, and validation configuration change, while the components and markup around your forms usually stay the same.
+
+The good news is that both libraries can coexist in the same application without conflict. You can install Formisch next to `@tanstack/vue-form` and migrate one form at a time instead of all at once. Since both libraries export a composable named `useForm`, the import path determines which one a component uses.
+
+## Key differences
+
+TanStack Form infers your form's types from a `defaultValues` object and attaches validation separately through `validators` objects, either on the form or on individual fields. Each validator is bound to its own trigger such as `onChange`, `onBlur`, or `onSubmit`, with async variants and debouncing available per validator. Reactivity comes from TanStack Store: you subscribe to state explicitly with `form.useStore` selectors or the `form.Subscribe` component.
+
+Formisch is schema-first. A single Valibot schema passed to the <Link href="/vue/api/useForm/">`useForm`</Link> composable is the source of types, validation rules, and form structure all at once. There is no `defaultValues` object to keep aligned with your types and no validator configuration scattered across fields. Validation always parses the entire form against the schema in one pass, and its timing is controlled form-wide with the `validate` and `revalidate` config.
+
+In practice, the migration comes down to these shifts:
+
+- **Source of truth**: `defaultValues` plus per-field validators become one Valibot schema.
+- **Validation timing**: per-validator triggers become the form-wide `validate` and `revalidate` config.
+- **Field addressing**: string names like `` `people[${i}].name` `` become path arrays like `['people', i, 'name']`.
+- **Field binding**: manual `:value`, `@input`, and `@blur` wiring becomes `v-bind="field.props"` with `v-model`.
+- **Reactivity**: explicit `form.useStore` and `form.Subscribe` subscriptions become direct property access on the reactive form store, powered by Vue's reactivity system.
+
+If you already use TanStack Form's Standard Schema support with a Valibot schema, the mental gap is smaller than it looks. The difference is that in TanStack Form the schema is one of several possible validation sources, while in Formisch the schema is the form definition itself.
+
+## Side-by-side example
+
+The following login form has two validated fields, displays error messages, and disables the submit button while the form is submitting. Both versions implement the same behavior.
+
+### TanStack Form
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@tanstack/vue-form';
+
+const form = useForm({
+  defaultValues: {
+    email: '',
+    password: '',
+  },
+  onSubmit: async ({ value }) => {
+    console.log(value);
+  },
+});
+</script>
+
+<template>
+  <form @submit.prevent.stop="form.handleSubmit">
+    <form.Field
+      name="email"
+      :validators="{
+        onBlur: ({ value }) =>
+          !value
+            ? 'Please enter your email.'
+            : !value.includes('@')
+              ? 'The email address is badly formatted.'
+              : undefined,
+      }"
+    >
+      <template v-slot="{ field }">
+        <input
+          type="email"
+          :name="field.name"
+          :value="field.state.value"
+          @blur="field.handleBlur"
+          @input="
+            (e) => field.handleChange((e.target as HTMLInputElement).value)
+          "
+        />
+        <div v-if="field.state.meta.errors.length">
+          {{ field.state.meta.errors[0] }}
+        </div>
+      </template>
+    </form.Field>
+    <form.Field
+      name="password"
+      :validators="{
+        onBlur: ({ value }) =>
+          !value
+            ? 'Please enter your password.'
+            : value.length < 8
+              ? 'Your password must have 8 characters or more.'
+              : undefined,
+      }"
+    >
+      <template v-slot="{ field }">
+        <input
+          type="password"
+          :name="field.name"
+          :value="field.state.value"
+          @blur="field.handleBlur"
+          @input="
+            (e) => field.handleChange((e.target as HTMLInputElement).value)
+          "
+        />
+        <div v-if="field.state.meta.errors.length">
+          {{ field.state.meta.errors[0] }}
+        </div>
+      </template>
+    </form.Field>
+    <form.Subscribe>
+      <template v-slot="{ canSubmit, isSubmitting }">
+        <button type="submit" :disabled="!canSubmit">
+          {{ isSubmitting ? 'Logging in...' : 'Login' }}
+        </button>
+      </template>
+    </form.Subscribe>
+  </form>
+</template>
+```
+
+### Formisch
+
+```vue
+<script setup lang="ts">
+import { Field, Form, useForm } from '@formisch/vue';
+import type { SubmitHandler } from '@formisch/vue';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur',
+});
+
+const submitForm: SubmitHandler<typeof LoginSchema> = async (output) => {
+  console.log(output);
+};
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="submitForm">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <input v-bind="field.props" v-model="field.input" type="email" />
+      <div v-if="field.errors">{{ field.errors[0] }}</div>
+    </Field>
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <input v-bind="field.props" v-model="field.input" type="password" />
+      <div v-if="field.errors">{{ field.errors[0] }}</div>
+    </Field>
+    <button type="submit" :disabled="loginForm.isSubmitting">
+      {{ loginForm.isSubmitting ? 'Logging in...' : 'Login' }}
+    </button>
+  </Form>
+</template>
+```
+
+Note how the validation rules moved from the individual `form.Field` components into the schema, and how the manual event wiring collapsed into `v-bind="field.props"` with `v-model`. The `validate: 'blur'` config replaces the per-field `onBlur` triggers, so errors still first appear when a field loses focus.
+
+## Migration steps
+
+### Install Formisch
+
+Add Formisch and Valibot alongside your existing setup. Both libraries can run in the same app during the migration.
+
+```bash
+npm install @formisch/vue valibot
+```
+
+See the <Link href="/vue/guides/installation/">installation</Link> guide for other package managers and TypeScript requirements.
+
+### Move validation into a Valibot schema
+
+Collect the validation rules from your `validators` objects and express them as a single Valibot schema. Each field-level validator function typically becomes one or two pipe actions with the same error messages.
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+```
+
+If you already pass a Valibot schema to TanStack Form's `validators` option via Standard Schema, you can reuse it as is. Define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/vue/guides/define-your-form/">define your form</Link> guide for details on schema design.
+
+### Replace the form setup
+
+Replace `useForm` from `@tanstack/vue-form` with the <Link href="/vue/api/useForm/">`useForm`</Link> composable from `@formisch/vue`. The schema replaces `defaultValues` entirely: types are inferred from it, and required string fields automatically start as empty strings. If you need prefilled values, pass a partial `initialInput`.
+
+```ts
+import { useForm } from '@formisch/vue';
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: {
+    email: 'user@example.com',
+  },
+});
+```
+
+Without further config, Formisch validates on submit. If your TanStack Form validators ran on blur or change, add the matching `validate` config, such as `validate: 'blur'` for the login form above, to preserve the timing (see the <Link href="#validation-timing">validation timing</Link> section below).
+
+The `onSubmit` option has no counterpart here. Submission moves to the template, as shown below. See the <Link href="/vue/guides/create-your-form/">create your form</Link> guide for all configuration options.
+
+### Replace field bindings
+
+Replace each `form.Field` component with the <Link href="/vue/api/Field/">`Field`</Link> component. Instead of a string `name`, it takes the form store via `of` and a `path` array that is type-checked against your schema. The manual `:value`, `@input`, and `@blur` wiring is replaced by spreading `field.props` and binding `v-model` to `field.input`.
+
+```vue
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <input v-bind="field.props" v-model="field.input" type="email" />
+    <div v-if="field.errors">{{ field.errors[0] }}</div>
+  </Field>
+</template>
+```
+
+Error output changes from `field.state.meta.errors` to `field.errors`, which is either `null` or a non-empty array of strings. For single-field components, the <Link href="/vue/api/useField/">`useField`</Link> composable is the counterpart to TanStack Form's `useField`. See the <Link href="/vue/guides/add-form-fields/">add form fields</Link> guide for both approaches.
+
+### Update submission handling
+
+Replace the native `<form>` element and its `@submit.prevent.stop="form.handleSubmit"` wiring with the <Link href="/vue/api/Form/">`Form`</Link> component, and move the logic from the `onSubmit` option into a handler passed to its `@submit` event. The handler only runs after successful validation and receives the fully typed, validated output. Calling `event.preventDefault()` is taken care of for you.
+
+```vue
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue';
+
+const submitForm: SubmitHandler<typeof LoginSchema> = async (output) => {
+  await login(output);
+};
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="submitForm">
+    <!-- Fields and submit button -->
+  </Form>
+</template>
+```
+
+Also remove the `form.Subscribe` wrapper around the submit button. The form store is reactive, so the button reads `loginForm.isSubmitting` directly, as shown in the side-by-side example and covered in the <Link href="#form-state">form state</Link> section below.
+
+See the <Link href="/vue/guides/handle-submission/">handle submission</Link> guide for async submission and programmatic submits.
+
+## API mapping
+
+| TanStack Form                              | Formisch                                                                                                           |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `useForm({ defaultValues, onSubmit })`     | <Link href="/vue/api/useForm/">`useForm`</Link>`({ schema })`                                                      |
+| `defaultValues`                            | `initialInput` (optional and partial)                                                                              |
+| `onSubmit` option                          | `@submit` on the <Link href="/vue/api/Form/">`Form`</Link> component                                               |
+| `form.handleSubmit`                        | <Link href="/methods/api/submit/">`submit`</Link> or <Link href="/methods/api/handleSubmit/">`handleSubmit`</Link> |
+| `form.Field` with `name` string            | <Link href="/vue/api/Field/">`Field`</Link> with `path` array                                                      |
+| `form.Field` with `mode="array"`           | <Link href="/vue/api/FieldArray/">`FieldArray`</Link>                                                              |
+| `useField`                                 | <Link href="/vue/api/useField/">`useField`</Link>                                                                  |
+| `field.state.value` + `field.handleChange` | `v-model="field.input"`                                                                                            |
+| `field.handleBlur`                         | Included in `v-bind="field.props"`                                                                                 |
+| `field.state.meta.errors`                  | `field.errors`                                                                                                     |
+| `field.state.meta.isTouched`               | `field.isTouched`                                                                                                  |
+| `field.state.meta.isDirty`                 | `field.isEdited`                                                                                                   |
+| `field.state.meta.isDefaultValue`          | `!field.isDirty`                                                                                                   |
+| `validators` with `onChange`, `onBlur`, …  | Valibot schema plus `validate` and `revalidate` config                                                             |
+| `validators` with `onChangeAsync`          | Async schema with `v.pipeAsync` and `v.checkAsync`                                                                 |
+| `form.useStore` and `form.Subscribe`       | Direct reactive property access, e.g. `loginForm.isValid`                                                          |
+| `form.state.isSubmitting`                  | `form.isSubmitting`                                                                                                |
+| `form.state.canSubmit`                     | No direct equivalent (see below)                                                                                   |
+| `form.reset(values)`                       | <Link href="/methods/api/reset/">`reset`</Link>`(form, { initialInput })`                                          |
+| `form.resetField(name)`                    | <Link href="/methods/api/reset/">`reset`</Link>`(form, { path })`                                                  |
+| `form.setFieldValue(name, value)`          | <Link href="/methods/api/setInput/">`setInput`</Link>`(form, { path, input })`                                     |
+| `form.getFieldValue(name)`                 | <Link href="/methods/api/getInput/">`getInput`</Link>`(form, { path })`                                            |
+| `form.validateAllFields(cause)`            | <Link href="/methods/api/validate/">`validate`</Link>`(form)`                                                      |
+| `field.pushValue(value)`                   | <Link href="/methods/api/insert/">`insert`</Link>`(form, { path, initialInput })`                                  |
+| `field.removeValue(index)`                 | <Link href="/methods/api/remove/">`remove`</Link>`(form, { path, at })`                                            |
+| `form.moveFieldValues(name, from, to)`     | <Link href="/methods/api/move/">`move`</Link>`(form, { path, from, to })`                                          |
+| `form.swapFieldValues(name, i1, i2)`       | <Link href="/methods/api/swap/">`swap`</Link>`(form, { path, at, and })`                                           |
+| `form.replaceFieldValue(name, i, value)`   | <Link href="/methods/api/replace/">`replace`</Link>`(form, { path, at, initialInput })`                            |
+
+A few entries deserve extra context:
+
+- **`canSubmit`**: Formisch has no combined flag. Forms stay submittable, validation runs on submit, blocks the handler when invalid, and automatically focuses the first field with an error. To prevent double submits, disable the button with `form.isSubmitting`. If you want a validity-based flag instead, `form.isValid` reflects the result of the last validation run, but with the default `validate: 'submit'` timing it stays `true` until the first submit, so combine it with `validate: 'initial'` for TanStack-like behavior.
+- **`form.useStore` and `form.Subscribe`**: Formisch needs neither. The form store is reactive through Vue's reactivity system, so reading `form.isDirty` in a template or computed property subscribes automatically, and only what you read triggers updates.
+- **`field.state.meta.errorMap`**: There is no per-trigger error map. Since validation always parses the whole schema, each field holds a single `errors` array.
+- **Dirty semantics**: TanStack Form's `isDirty` stays `true` once a field was changed, even if the value is reverted. That matches Formisch's `isEdited`. Formisch's `isDirty` compares the current input against the initial input, matching the inverse of TanStack Form's `isDefaultValue`.
+- **`listeners`**: For side effects on field changes, use Vue's `watch` with a reactive read, for example `watch(() => getInput(form, { path: ['country'] }), callback)`. Reading values with Formisch methods is reactive.
+
+## Common patterns
+
+### Form state
+
+In TanStack Form, you subscribe to form state through selectors or the `form.Subscribe` component to keep re-renders scoped:
+
+```vue
+<template>
+  <form.Subscribe>
+    <template v-slot="{ isSubmitting }">
+      <button type="submit" :disabled="isSubmitting">Submit</button>
+    </template>
+  </form.Subscribe>
+</template>
+```
+
+In Formisch, the form store itself is reactive. Read `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid`, and `errors` directly wherever you need them:
+
+```vue
+<template>
+  <p v-if="loginForm.isDirty">You have unsaved changes.</p>
+  <button type="submit" :disabled="loginForm.isSubmitting">Submit</button>
+</template>
+```
+
+Note that `form.errors` only contains errors at the root level of the form. To collect the errors of all fields, use the <Link href="/methods/api/getDeepErrors/">`getDeepErrors`</Link> method.
+
+### Validation timing
+
+TanStack Form binds timing to each validator: an `onBlur` validator runs on blur, an `onChange` validator on every change, and so on. Formisch configures timing once for the whole form:
+
+```ts
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur', // first validation of a field on blur
+  revalidate: 'input', // revalidate on every keystroke afterwards
+});
+```
+
+`validate` controls when a field is first validated (`'initial'`, `'touch'`, `'input'`, `'change'`, `'blur'`, or `'submit'`), and `revalidate` controls when it is validated again once it has an error or the form has been submitted. The defaults are `'submit'` and `'input'`.
+
+Async validators like `onChangeAsync` move into the schema itself. Use `v.pipeAsync` with `v.checkAsync` for checks like username availability, and use the form's `isValidating` state, the counterpart to TanStack Form's `isValidating`, to indicate progress. The <Link href="/vue/guides/validation/">validation</Link> guide covers this in depth, including how to reveal errors only at the right moment.
+
+### Field arrays
+
+In TanStack Form, you mark a field as an array with `mode="array"`, address items with interpolated name strings, and mutate the array through methods on the field:
+
+```vue
+<template>
+  <form.Field name="people" mode="array">
+    <template v-slot="{ field }">
+      <div v-for="(_, i) of field.state.value" :key="i">
+        <form.Field :name="`people[${i}].name`">
+          <template v-slot="{ field: subField }">
+            <input
+              :value="subField.state.value"
+              @input="
+                (e) =>
+                  subField.handleChange((e.target as HTMLInputElement).value)
+              "
+            />
+          </template>
+        </form.Field>
+        <button type="button" @click="field.removeValue(i)">Remove</button>
+      </div>
+      <button type="button" @click="field.pushValue({ name: '' })">Add</button>
+    </template>
+  </form.Field>
+</template>
+```
+
+In Formisch, the <Link href="/vue/api/FieldArray/">`FieldArray`</Link> component provides an `items` array of unique string identifiers to use as `v-for` keys, which keeps Vue's rendering correct when items are added, moved, or removed. Array mutations go through standalone methods:
+
+```vue
+<script setup lang="ts">
+import { Field, FieldArray, insert, remove, useForm } from '@formisch/vue';
+import * as v from 'valibot';
+
+const PeopleSchema = v.object({
+  people: v.array(v.object({ name: v.pipe(v.string(), v.nonEmpty()) })),
+});
+
+const peopleForm = useForm({ schema: PeopleSchema });
+</script>
+
+<template>
+  <FieldArray :of="peopleForm" :path="['people']" v-slot="fieldArray">
+    <div v-for="(item, index) in fieldArray.items" :key="item">
+      <Field :of="peopleForm" :path="['people', index, 'name']" v-slot="field">
+        <input v-bind="field.props" v-model="field.input" type="text" />
+      </Field>
+      <button
+        type="button"
+        @click="remove(peopleForm, { path: ['people'], at: index })"
+      >
+        Remove
+      </button>
+    </div>
+    <button
+      type="button"
+      @click="
+        insert(peopleForm, { path: ['people'], initialInput: { name: '' } })
+      "
+    >
+      Add
+    </button>
+  </FieldArray>
+</template>
+```
+
+The <Link href="/methods/api/move/">`move`</Link>, <Link href="/methods/api/swap/">`swap`</Link>, and <Link href="/methods/api/replace/">`replace`</Link> methods cover the remaining array operations. See the <Link href="/vue/guides/field-arrays/">field arrays</Link> guide for validation of the array itself and nested arrays.
+
+### Reset
+
+TanStack Form resets through methods on the form instance:
+
+```ts
+form.reset(); // back to defaultValues
+form.resetField('email'); // reset a single field
+```
+
+Formisch provides a standalone <Link href="/methods/api/reset/">`reset`</Link> method that can also establish a new baseline, which is useful when refreshed server data should become the new initial state:
+
+```ts
+import { reset } from '@formisch/vue';
+
+// Reset the entire form to its initial input
+reset(loginForm);
+
+// Reset a single field
+reset(loginForm, { path: ['email'] });
+
+// Reset with a new baseline, e.g. after refreshing server data
+reset(loginForm, { initialInput: { email: 'new@example.com' } });
+```
+
+Because resetting changes values programmatically, your inputs must be controlled with `v-model` as shown throughout this guide. See the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide for details.
+
+### Special inputs
+
+In TanStack Form, checkboxes, selects, and number inputs require manual wiring because `field.handleChange` receives whatever you extract from the event:
+
+```vue
+<input
+  type="checkbox"
+  :checked="field.state.value"
+  @change="(e) => field.handleChange((e.target as HTMLInputElement).checked)"
+  @blur="field.handleBlur"
+/>
+```
+
+In Formisch, the combination of `v-bind="field.props"` and `v-model="field.input"` covers native input types without extra code:
+
+```vue
+<template>
+  <Field :of="form" :path="['cookies']" v-slot="field">
+    <label>
+      <input type="checkbox" v-bind="field.props" v-model="field.input" />
+      Yes, I want cookies
+    </label>
+  </Field>
+</template>
+```
+
+The <Link href="/vue/guides/special-inputs/">special inputs</Link> guide covers checkboxes, checkbox groups, radio buttons, selects, and file inputs.
+
+## Next steps
+
+With your first form migrated, work through the <Link href="/vue/guides/define-your-form/">define your form</Link> and <Link href="/vue/guides/add-form-fields/">add form fields</Link> guides to deepen your understanding of the schema-first approach. The <Link href="/vue/guides/validation/">validation</Link> guide explains how to fine-tune validation timing and error display, the <Link href="/vue/guides/form-methods/">form methods</Link> guide gives an overview of all available methods, and the <Link href="/vue/guides/input-components/">input components</Link> guide shows how to wrap the field bindings from this guide into reusable components.

--- a/website/src/routes/(docs)/vue/guides/(migration-guides)/migrate-from-vee-validate/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(migration-guides)/migrate-from-vee-validate/index.mdx
@@ -1,0 +1,381 @@
+---
+title: Migrate from VeeValidate
+description: >-
+  Learn how to migrate your Vue forms from VeeValidate to Formisch. This guide
+  compares both APIs side by side, walks you through the migration step by
+  step, and maps VeeValidate APIs to their Formisch equivalents.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from VeeValidate
+
+This guide walks you through migrating a form from [VeeValidate](https://vee-validate.logaretm.com) to Formisch. It explains the mental-model differences, shows the same form implemented in both libraries, and maps VeeValidate's APIs, options, and state fields to their Formisch counterparts.
+
+Migrating is a rewrite of your form layer, not a drop-in replacement. That said, the conceptual gap is small: both libraries are headless, composables-based, and schema-friendly. The main work is consolidating your validation into a single root Valibot schema and replacing VeeValidate's `useForm` and `defineField` with Formisch's composables and components.
+
+Both libraries can coexist in the same application, so you can migrate one form at a time instead of doing everything in a single step. Since both libraries export a composable named `useForm`, the import path determines which one a component uses.
+
+## Key differences
+
+The biggest shift is that Formisch is strictly schema-first. In VeeValidate, validation can come from several places: validator functions, globally registered rules, or a schema from Yup, Zod, or Valibot passed as `validationSchema` (usually wrapped in `toTypedSchema` for type inference). The form's shape is implied by whatever fields you register. In Formisch, a single Valibot schema is the one source of truth for the form's structure, its TypeScript types, and its validation rules. There is no resolver or wrapper to configure: you pass the schema to <Link href="/vue/api/useForm/">`useForm`</Link> and every path, input value, and submit handler is typed from it.
+
+Validation also runs differently:
+
+- **Location**: VeeValidate attaches rules per field (or resolves them from a schema per field). Formisch always parses the entire form against the schema in a single pass and distributes the resulting issues to the individual fields, so cross-field rules work without extra wiring.
+- **Timing**: VeeValidate configures triggers per field or globally via `configure()` with flags like `validateOnBlur`, `validateOnChange`, and `validateOnModelUpdate`. Formisch controls timing form-wide with two options on `useForm`: `validate` (first validation, defaults to `'submit'`) and `revalidate` (subsequent validations, defaults to `'input'`).
+- **Field addressing**: VeeValidate identifies fields by string paths like `'members[0].email'`. Formisch uses path arrays like `['members', 0, 'email']` that are fully type-checked against your schema.
+- **Form state**: VeeValidate spreads state across the values returned by `useForm` (`values`, `errors`, `meta`, `isSubmitting`, …) plus helper composables like `useIsFormDirty`. Formisch returns one form store with flat reactive properties such as `isDirty`, `isValid`, and `isSubmitting`.
+
+Reactivity is comparable: both libraries build on Vue's reactivity system, so components only re-render when the state they read changes. The trade-offs to be aware of are that Formisch currently supports only Valibot as the schema library, while its bundle size starts at about 2.5 kB compared to VeeValidate's roughly 12 kB. See the <Link href="/vue/guides/comparison/">comparison</Link> guide for a broader overview.
+
+## Side-by-side example
+
+The following login form has two validated fields and an async submit handler. The VeeValidate version uses the composition API with a Zod schema, which is one of the most common setups. The Formisch version implements the exact same behavior.
+
+### VeeValidate
+
+```vue
+<script setup lang="ts">
+import { toTypedSchema } from '@vee-validate/zod';
+import { useForm } from 'vee-validate';
+import { z } from 'zod';
+
+const validationSchema = toTypedSchema(
+  z.object({
+    email: z
+      .string()
+      .min(1, 'Please enter your email.')
+      .email('The email address is badly formatted.'),
+    password: z
+      .string()
+      .min(1, 'Please enter your password.')
+      .min(8, 'Your password must have 8 characters or more.'),
+  })
+);
+
+const { defineField, errors, handleSubmit, isSubmitting } = useForm({
+  validationSchema,
+});
+
+const [email, emailProps] = defineField('email');
+const [password, passwordProps] = defineField('password');
+
+const onSubmit = handleSubmit(async (values) => {
+  await fetch('/api/login', {
+    method: 'POST',
+    body: JSON.stringify(values),
+  });
+});
+</script>
+
+<template>
+  <form @submit="onSubmit">
+    <div>
+      <input v-model="email" v-bind="emailProps" type="email" />
+      <div v-if="errors.email">{{ errors.email }}</div>
+    </div>
+    <div>
+      <input v-model="password" v-bind="passwordProps" type="password" />
+      <div v-if="errors.password">{{ errors.password }}</div>
+    </div>
+    <button type="submit" :disabled="isSubmitting">Login</button>
+  </form>
+</template>
+```
+
+### Formisch
+
+```vue
+<script setup lang="ts">
+import { Field, Form, useForm } from '@formisch/vue';
+import type { SubmitHandler } from '@formisch/vue';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+});
+
+const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+  await fetch('/api/login', {
+    method: 'POST',
+    body: JSON.stringify(values),
+  });
+};
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="submitForm">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <div>
+        <input v-model="field.input" v-bind="field.props" type="email" />
+        <div v-if="field.errors">{{ field.errors[0] }}</div>
+      </div>
+    </Field>
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <div>
+        <input v-model="field.input" v-bind="field.props" type="password" />
+        <div v-if="field.errors">{{ field.errors[0] }}</div>
+      </div>
+    </Field>
+    <button type="submit" :disabled="loginForm.isSubmitting">Login</button>
+  </Form>
+</template>
+```
+
+Instead of destructuring `useForm` and defining a model tuple per field, you keep the single `loginForm` store and connect each input through the <Link href="/vue/api/Field/">`Field`</Link> component. Errors live on the field store as an array, and the submit handler receives values that are already validated and typed by the schema.
+
+## Migration steps
+
+### Install Formisch
+
+Add Formisch and Valibot to your project. Keep `vee-validate` installed until the last form is migrated, then remove it together with its schema adapter packages like `@vee-validate/zod`.
+
+```bash
+npm install @formisch/vue valibot
+```
+
+### Move validation into a Valibot schema
+
+Formisch validates exclusively against a Valibot schema. If you used Zod or Yup with VeeValidate, translate the schema; the structure usually maps one to one. If you already used Valibot through `@vee-validate/valibot`, you can reuse your schema unchanged and simply drop the `toTypedSchema` wrapper.
+
+```ts
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+});
+```
+
+If some of your validation lives in validator functions or globally registered rules instead of a schema, consolidate it into the schema now. Custom logic translates to `v.check()`, and async rules (for example a server-side uniqueness check) translate to `v.checkAsync()` with `v.objectAsync()` and `v.pipeAsync()`. Define the fields in the same order they appear in your form, since Formisch focuses the first invalid field on submit based on the schema order. See the <Link href="/vue/guides/define-your-form/">define your form</Link> guide for details.
+
+### Replace the form setup
+
+Replace VeeValidate's `useForm` with Formisch's <Link href="/vue/api/useForm/">`useForm`</Link> composable. Instead of destructuring individual helpers, you keep the returned form store and pass it to Formisch's components and methods. The `initialValues` option becomes `initialInput`.
+
+```ts
+// VeeValidate
+const { defineField, errors, handleSubmit } = useForm({
+  validationSchema,
+  initialValues: { email: 'jane@example.com' },
+});
+
+// Formisch
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: { email: 'jane@example.com' },
+});
+```
+
+### Replace field bindings
+
+Each `defineField` tuple (or `useField` call, or `<Field name="…">` component) becomes a <Link href="/vue/api/Field/">`Field`</Link> component with a type-safe path array. The `v-slot` directive exposes the field store with `input`, `props`, `errors`, and state flags.
+
+```vue
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <input v-model="field.input" v-bind="field.props" type="email" />
+    <div v-if="field.errors">{{ field.errors[0] }}</div>
+  </Field>
+</template>
+```
+
+Note that errors move with the field: instead of looking up `errors.email` on the form, you read `field.errors` inside the field's slot. This also replaces VeeValidate's `<ErrorMessage />` component. For dedicated field components, use the <Link href="/vue/api/useField/">`useField`</Link> composable as described in the <Link href="/vue/guides/add-form-fields/">add form fields</Link> guide.
+
+### Update submission handling
+
+VeeValidate wraps your handler with `handleSubmit` and binds the result to a native `<form>` element. In Formisch, you wrap your fields in the <Link href="/vue/api/Form/">`Form`</Link> component and pass your handler to its `@submit` event. The handler only runs when the schema parses successfully and receives the fully typed output.
+
+```vue
+<script setup lang="ts">
+import type { SubmitHandler } from '@formisch/vue';
+
+const submitForm: SubmitHandler<typeof LoginSchema> = async (values) => {
+  console.log(values); // { email: string, password: string }
+};
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="submitForm">
+    <!-- fields -->
+  </Form>
+</template>
+```
+
+If you cannot render a `<form>` element, for example inside another form, use the <Link href="/methods/api/handleSubmit/">`handleSubmit`</Link> method instead, as shown in the <Link href="/vue/guides/handle-submission/">handle submission</Link> guide.
+
+## API mapping
+
+| VeeValidate                        | Formisch                                                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `useForm({ validationSchema })`    | <Link href="/vue/api/useForm/">`useForm`</Link> with `schema`                                                                  |
+| `initialValues`                    | `initialInput`                                                                                                                 |
+| `configure({ validateOnBlur, … })` | `validate` / `revalidate` config of <Link href="/vue/api/useForm/">`useForm`</Link>                                            |
+| `defineField('email')`             | <Link href="/vue/api/Field/">`Field`</Link> component with `:path="['email']"`                                                 |
+| `useField('email')`                | <Link href="/vue/api/useField/">`useField`</Link> composable                                                                   |
+| `<Field name="email" />`           | <Link href="/vue/api/Field/">`Field`</Link> component                                                                          |
+| `<ErrorMessage name="email" />`    | `field.errors` inside the <Link href="/vue/api/Field/">`Field`</Link> slot                                                     |
+| `handleSubmit(onSuccess)`          | `@submit` of <Link href="/vue/api/Form/">`Form`</Link> or <Link href="/methods/api/handleSubmit/">`handleSubmit`</Link>        |
+| `values`                           | `field.input` or <Link href="/methods/api/getInput/">`getInput`</Link>                                                         |
+| `errors.email`                     | `field.errors` or <Link href="/methods/api/getErrors/">`getErrors`</Link>                                                      |
+| `meta.dirty` / `meta.touched`      | `form.isDirty` / `form.isTouched`                                                                                              |
+| `meta.valid`                       | `form.isValid`                                                                                                                 |
+| `meta.pending`                     | `form.isValidating`                                                                                                            |
+| `isSubmitting`                     | `form.isSubmitting`                                                                                                            |
+| `submitCount`                      | `form.isSubmitted`                                                                                                             |
+| `setFieldValue` / `setValues`      | <Link href="/methods/api/setInput/">`setInput`</Link>                                                                          |
+| `setFieldError` / `setErrors`      | <Link href="/methods/api/setErrors/">`setErrors`</Link>                                                                        |
+| `resetForm` / `resetField`         | <Link href="/methods/api/reset/">`reset`</Link>                                                                                |
+| `validate` / `validateField`       | <Link href="/methods/api/validate/">`validate`</Link>                                                                          |
+| `useFieldArray('list')`            | <Link href="/vue/api/FieldArray/">`FieldArray`</Link> component or <Link href="/vue/api/useFieldArray/">`useFieldArray`</Link> |
+| `push` / `prepend` / `insert`      | <Link href="/methods/api/insert/">`insert`</Link>                                                                              |
+| `remove`                           | <Link href="/methods/api/remove/">`remove`</Link>                                                                              |
+| `swap`                             | <Link href="/methods/api/swap/">`swap`</Link>                                                                                  |
+| `move`                             | <Link href="/methods/api/move/">`move`</Link>                                                                                  |
+| `update`                           | <Link href="/methods/api/replace/">`replace`</Link>                                                                            |
+
+A few entries deserve a note. `submitCount` has no direct equivalent: Formisch tracks the boolean `isSubmitted`, which is `true` after the first submit attempt. The touched flag behaves slightly differently: Formisch marks a field as touched when it receives focus, while VeeValidate marks it on blur, so touched-based logic reacts one event earlier. Similarly, `validateField` has no per-field counterpart, because Formisch's <Link href="/methods/api/validate/">`validate`</Link> always parses the whole form and distributes the resulting issues to the fields. VeeValidate's `replace(items)`, which swaps out the entire array, maps to calling <Link href="/methods/api/setInput/">`setInput`</Link> with the array's path. Globally registered rules via `defineRule` and the `@vee-validate/rules` package have no equivalent, since all validation lives in the Valibot schema. The same applies to `toTypedSchema`: it is simply no longer needed, because types are inferred from the schema directly. Helper composables like `useIsFormDirty` or `useFormValues` are also unnecessary, as the form store itself is reactive and can be passed around freely.
+
+## Common patterns
+
+### Form state
+
+In VeeValidate, aggregated form state lives on the `meta` computed ref and separate refs like `isSubmitting`, or is accessed through helper composables. In Formisch, everything is a flat reactive property on the form store, so you read it directly in your template or component logic.
+
+```vue
+<template>
+  <button
+    type="submit"
+    :disabled="!loginForm.isDirty || loginForm.isSubmitting"
+  >
+    {{ loginForm.isSubmitting ? 'Submitting...' : 'Login' }}
+  </button>
+</template>
+```
+
+The available properties are `isSubmitting`, `isSubmitted`, `isValidating`, `isTouched`, `isEdited`, `isDirty`, `isValid`, and `errors`. The same flags exist per field on the field store.
+
+### Validation timing
+
+VeeValidate validates each field aggressively by default (on model updates, change, and blur) and lets you tune this per field, for example with `validateOnModelUpdate: false` on `defineField`, or globally via `configure()`. Formisch replaces this per-field event configuration with two form-wide options:
+
+```ts
+const loginForm = useForm({
+  schema: LoginSchema,
+  validate: 'blur', // first validation per field, defaults to 'submit'
+  revalidate: 'input', // subsequent validations, defaults to 'input'
+});
+```
+
+With the defaults, a field stays quiet until the form is submitted and then corrects itself on every keystroke. Unlike VeeValidate, Formisch also decouples running validation from showing errors: after a validation pass you decide which errors to render, typically guarded by `field.isEdited || form.isSubmitted`. The <Link href="/vue/guides/validation/">validation</Link> guide covers this pattern in depth.
+
+### Field arrays
+
+VeeValidate's `useFieldArray` returns a `fields` ref whose entries carry a `key` for the `v-for` directive, plus bound methods like `push` and `remove`. Formisch provides the <Link href="/vue/api/FieldArray/">`FieldArray`</Link> component, whose store exposes an `items` array of unique string identifiers to use as keys, and standalone array methods that take the form store and a path.
+
+```vue
+<script setup lang="ts">
+import { Field, FieldArray, insert, remove } from '@formisch/vue';
+</script>
+
+<template>
+  <FieldArray :of="todoForm" :path="['todos']" v-slot="fieldArray">
+    <div v-for="(item, index) in fieldArray.items" :key="item">
+      <Field :of="todoForm" :path="['todos', index, 'label']" v-slot="field">
+        <input v-model="field.input" v-bind="field.props" type="text" />
+      </Field>
+      <button
+        type="button"
+        @click="remove(todoForm, { path: ['todos'], at: index })"
+      >
+        Delete
+      </button>
+    </div>
+    <button
+      type="button"
+      @click="
+        insert(todoForm, { path: ['todos'], initialInput: { label: '' } })
+      "
+    >
+      Add todo
+    </button>
+  </FieldArray>
+</template>
+```
+
+Rules on the array itself, like VeeValidate's `.min(1)` on a Yup array, move into the schema with `v.nonEmpty()` or `v.minLength()` on `v.array()`, and their errors appear on `fieldArray.errors`. See the <Link href="/vue/guides/field-arrays/">field arrays</Link> guide for the complete picture, including `move`, `swap`, and `replace`.
+
+### Reset
+
+VeeValidate's `resetForm()` restores initial values, and `resetForm({ values })` establishes new ones. The Formisch equivalent is the <Link href="/methods/api/reset/">`reset`</Link> method, which also accepts a new `initialInput` as the new baseline for dirty tracking, for example after refreshed server data.
+
+```ts
+import { reset } from '@formisch/vue';
+
+// Reset the form to its initial state
+reset(loginForm);
+
+// Reset with new initial values
+reset(loginForm, { initialInput: { email: 'jane@example.com', password: '' } });
+```
+
+Note that resetting to programmatically set values requires controlled fields, so make sure your inputs use `v-model` as shown in the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide.
+
+### Special inputs
+
+In VeeValidate, checkboxes and radio buttons need extra configuration such as `type: 'checkbox'` and `checkedValue` on `useField`. With Formisch, you spread `field.props` onto the native element and add `v-model`, and Vue's `v-model` semantics handle single checkboxes, checkbox groups, radio buttons, and selects without further setup:
+
+```vue
+<template>
+  <Field :of="form" :path="['cookies']" v-slot="field">
+    <label>
+      <input type="checkbox" v-bind="field.props" v-model="field.input" />
+      Yes, I want cookies
+    </label>
+  </Field>
+</template>
+```
+
+File inputs are the exception: Vue does not allow `v-model` on them, and spreading `field.props` alone does not capture the selected file. Add an `input` handler that writes the file to `field.input` yourself:
+
+```vue
+<template>
+  <Field :of="form" :path="['document']" v-slot="field">
+    <input
+      v-bind="field.props"
+      type="file"
+      @input="field.input = ($event.target as HTMLInputElement).files?.[0]"
+    />
+  </Field>
+</template>
+```
+
+The <Link href="/vue/guides/special-inputs/">special inputs</Link> guide shows the full set of supported input types.
+
+## Next steps
+
+You now have everything you need to migrate your forms one at a time. To deepen your understanding of the Formisch APIs used in this guide, work through the <Link href="/vue/guides/add-form-fields/">add form fields</Link> and <Link href="/vue/guides/handle-submission/">handle submission</Link> guides, build reusable <Link href="/vue/guides/input-components/">input components</Link>, and explore the <Link href="/vue/guides/form-methods/">form methods</Link> guide for programmatic control of your forms.

--- a/website/src/routes/(docs)/vue/guides/menu.md
+++ b/website/src/routes/(docs)/vue/guides/menu.md
@@ -26,3 +26,9 @@
 - [Field arrays](/vue/guides/field-arrays/)
 - [TypeScript](/vue/guides/typescript/)
 - [Architecture](/vue/guides/architecture/)
+
+## Migration guides
+
+- [From VeeValidate](/vue/guides/migrate-from-vee-validate/)
+- [From FormKit](/vue/guides/migrate-from-formkit/)
+- [From TanStack Form](/vue/guides/migrate-from-tanstack-form/)


### PR DESCRIPTION
This PR adds a new "Migration guides" section to the docs of every framework that has a comparison guide. Each library listed in a framework's comparison guide gets its own guide explaining how to migrate to Formisch:

- **React**: React Hook Form, TanStack Form
- **Vue**: VeeValidate, FormKit, TanStack Form
- **Svelte**: Superforms, TanStack Form
- **Solid**: Felte, TanStack Form

All nine guides follow the same structure, modeled on Valibot's "Migrate from Zod" guide: intro, key differences, a complete side-by-side example, step-by-step migration instructions, an API mapping table, common patterns (form state, validation timing, field arrays, reset, special inputs), and next steps.

Every guide was validated in a test project with the source library and `@formisch/*@1.0.0-rc.0` installed from npm: the "before" examples compile against the current stable release of each library, following the migration steps literally produces the "after" examples, all snippets and API mapping rows typecheck against the installed packages, and all internal links resolve to existing routes.

Additional changes:

- Added a "Migration guides" section after "Advanced guides" to the `menu.md` of the four frameworks
- Updated the comparison guides to link to the new migration guides
- Registered the `(migration-guides)` route group in the `repo-website-guide-create` skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guides for React, Solid, Svelte, and Vue.
  * Included step-by-step instructions for moving from popular form libraries to Formisch.
  * Added side-by-side examples, API comparisons, validation guidance, field arrays, reset behavior, and special input handling.
  * Updated comparison pages to link to dedicated migration resources.
  * Added migration guide sections to each framework’s documentation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->