### PR TITLE
Fix critical seroval vulnerability by bumping override to 1.5.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   '@qwik.dev/core>rollup': 4.59.0
   semver@7: 7.5.2
   serialize-javascript@6: 7.0.5
-  seroval@1: 1.4.1
+  seroval@1: 1.5.3
   shell-quote@1: 1.8.4
   svgo@3: 3.3.3
   tar@4: 7.5.19
@@ -8565,10 +8565,10 @@ packages:
     resolution: {integrity: sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: 1.4.1
+      seroval: 1.5.3
 
-  seroval@1.4.1:
-    resolution: {integrity: sha512-9GOc+8T6LN4aByLN75uRvMbrwY5RDBW6lSlknsY4LEa9ZmWcxKcRe1G/Q3HZXjltxMHTrStnvrwAICxZrhldtg==}
+  seroval@1.5.3:
+    resolution: {integrity: sha512-BXe0x4buEeYiIKaRUnth1WqCILQ3k4O67KP/B4pC3pVz0Mv2c96ngA9QDREUYxWY1sb2RZVRqwI9RcpVMyHCVw==}
     engines: {node: '>=10'}
 
   serve-placeholder@2.0.2:
@@ -12510,8 +12510,8 @@ snapshots:
       error-stack-parser: 2.1.4
       html-to-image: 1.11.13
       radix3: 1.1.2
-      seroval: 1.4.1
-      seroval-plugins: 1.3.3(seroval@1.4.1)
+      seroval: 1.5.3
+      seroval-plugins: 1.3.3(seroval@1.5.3)
       shiki: 1.29.2
       source-map-js: 1.2.1
       terracotta: 1.0.6(solid-js@1.9.9)
@@ -18585,11 +18585,11 @@ snapshots:
 
   serialize-javascript@7.0.5: {}
 
-  seroval-plugins@1.3.3(seroval@1.4.1):
+  seroval-plugins@1.3.3(seroval@1.5.3):
     dependencies:
-      seroval: 1.4.1
+      seroval: 1.5.3
 
-  seroval@1.4.1: {}
+  seroval@1.5.3: {}
 
   serve-placeholder@2.0.2:
     dependencies:
@@ -18826,8 +18826,8 @@ snapshots:
   solid-js@1.9.9:
     dependencies:
       csstype: 3.1.3
-      seroval: 1.4.1
-      seroval-plugins: 1.3.3(seroval@1.4.1)
+      seroval: 1.5.3
+      seroval-plugins: 1.3.3(seroval@1.5.3)
 
   solid-refresh@0.6.3(solid-js@1.9.9):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ overrides:
   '@qwik.dev/core>rollup': '4.59.0'
   'semver@7': '7.5.2'
   'serialize-javascript@6': '7.0.5'
-  'seroval@1': '1.4.1'
+  'seroval@1': '1.5.3'
   'shell-quote@1': '1.8.4'
   'svgo@3': '3.3.3'
   'tar@4': '7.5.19'


### PR DESCRIPTION
The security workflow fails on `fail-on: critical`, and the current critical finding is `seroval@1.4.1`.

## The vulnerability

`seroval` versions before 1.5.3 are affected by [GHSA-mv8w-475r-vwqw](https://github.com/advisories/GHSA-mv8w-475r-vwqw) (critical, CVSS 9.8 `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`). A type confusion in `fromJSON()` lets attacker-controlled JSON make Promise control nodes operate on values from the general deserialization reference table without verifying they are genuine internal promise resolver records. With plugins enabled this is a deserialization side-effect primitive that can escalate to server-side invocation in downstream frameworks that register callable wrappers.

## The fix

`seroval` is already pinned through a major-keyed override, so this bumps that entry from `1.4.1` to `1.5.3`, the patched version. The package reaches us through two paths — `solid-js` and `@solidjs/start` — and the single override covers both, which the lockfile diff confirms.

Note that `seroval-plugins` stays at `1.3.3`: it only imports `createPlugin` and `createStream` from `seroval`, both unchanged in 1.5.3, and its peer range is `^1.0`.

## Verification

- `pnpm scan` — the critical finding is gone (45 → 44 packages, 0 critical). The remaining high/medium findings are pre-existing and do not gate the workflow.
- `pnpm -C frameworks/solid test` — 46 tests pass, no type errors
- `pnpm -C packages/core test` — 445 tests pass, no type errors
- `pnpm -C frameworks/solid build` and `lint` pass
- `pnpm -C playgrounds/solid build` succeeds, and the built SolidStart server renders the login route with intact hydration markers — the actual runtime path where seroval serializes — with no errors in the server log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency version to improve compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->