### PR TITLE
Fix duplicate element registration in useField after array reorders

### DIFF
--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix duplicate element registration in `useField` after array reorders
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/preact/src/hooks/useField/useField.test.tsx
+++ b/frameworks/preact/src/hooks/useField/useField.test.tsx
@@ -1,3 +1,5 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/preact';
+import { swap } from '@formisch/methods/preact';
 import {
   act,
   fireEvent,
@@ -10,6 +12,8 @@ import type { JSX } from 'preact';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { Form } from '../../components/Form/index.ts';
+import type { FormStore } from '../../types/index.ts';
+import { useFieldArray } from '../useFieldArray/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -419,6 +423,73 @@ describe('useField', () => {
       unmount();
 
       expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should not register an element that is already present', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = useForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
+        'name',
+      ]);
+      const element = document.createElement('input');
+      // Simulate an array reorder having already transferred the element
+      internalFieldStore.elements.push(element);
+      result.current.field.props.ref(element);
+      expect(internalFieldStore.elements).toEqual([element]);
+    });
+
+    test('should not duplicate element registration after an array reorder', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      function Row(props: {
+        form: FormStore<typeof schema>;
+        index: number;
+      }): JSX.Element {
+        const field = useField(props.form, {
+          path: ['todos', props.index, 'label'],
+        });
+        return <input {...field.props} />;
+      }
+
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema,
+          initialInput: { todos: [{ label: 'a' }, { label: 'b' }] },
+        });
+        formStore = form;
+        const fieldArray = useFieldArray(form, { path: ['todos'] });
+        return (
+          <>
+            {fieldArray.items.value.map((id, index) => (
+              <Row key={id} form={form} index={index} />
+            ))}
+          </>
+        );
+      }
+
+      render(<Test />);
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+      ).toHaveLength(1);
+
+      act(() => {
+        swap(formStore!, { path: ['todos'], at: 0, and: 1 });
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        ).toHaveLength(1);
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+        ).toHaveLength(1);
+      });
     });
   });
 });

--- a/frameworks/preact/src/hooks/useField/useField.ts
+++ b/frameworks/preact/src/hooks/useField/useField.ts
@@ -103,7 +103,10 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
         },
         autofocus: !!internalFieldStore.value.errors.value,
         ref(element) {
-          if (element) {
+          // An array reorder transfers registered elements between the field
+          // stores, so the element may already be present when the framework
+          // re-registers it against the destination store
+          if (element && !internalFieldStore.value.elements.includes(element)) {
             internalFieldStore.value.elements.push(element);
           }
         },

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix duplicate element registration in `useField` after array reorders
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/qwik/src/hooks/useField/useField.ts
+++ b/frameworks/qwik/src/hooks/useField/useField.ts
@@ -104,7 +104,12 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
       },
       autofocus: !!internalFieldStore.value.errors.value,
       ref: $((element) => {
-        internalFieldStore.value.elements.push(element);
+        // An array reorder transfers registered elements between the field
+        // stores, so the element may already be present when the framework
+        // re-registers it against the destination store
+        if (!internalFieldStore.value.elements.includes(element)) {
+          internalFieldStore.value.elements.push(element);
+        }
       }),
       onFocus$: $(() => {
         setFieldBool(internalFieldStore.value, 'isTouched', true);

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix duplicate element registration in `useField` after array reorders
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/react/src/hooks/useField/useField.test.tsx
+++ b/frameworks/react/src/hooks/useField/useField.test.tsx
@@ -1,4 +1,5 @@
-import { reset } from '@formisch/methods/react';
+import { getFieldStore, INTERNAL } from '@formisch/core/react';
+import { reset, swap } from '@formisch/methods/react';
 import {
   act,
   fireEvent,
@@ -12,6 +13,7 @@ import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { Form } from '../../components/Form/index.ts';
 import type { FormStore } from '../../types/index.ts';
+import { useFieldArray } from '../useFieldArray/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -445,6 +447,73 @@ describe('useField', () => {
       unmount();
 
       expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should not register an element that is already present', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = useForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
+        'name',
+      ]);
+      const element = document.createElement('input');
+      // Simulate an array reorder having already transferred the element
+      internalFieldStore.elements.push(element);
+      result.current.field.props.ref(element);
+      expect(internalFieldStore.elements).toEqual([element]);
+    });
+
+    test('should not duplicate element registration after an array reorder', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      function Row(props: {
+        form: FormStore<typeof schema>;
+        index: number;
+      }): ReactElement {
+        const field = useField(props.form, {
+          path: ['todos', props.index, 'label'],
+        });
+        return <input {...field.props} />;
+      }
+
+      function Test(): ReactElement {
+        const form = useForm({
+          schema,
+          initialInput: { todos: [{ label: 'a' }, { label: 'b' }] },
+        });
+        formStore = form;
+        const fieldArray = useFieldArray(form, { path: ['todos'] });
+        return (
+          <>
+            {fieldArray.items.map((id, index) => (
+              <Row key={id} form={form} index={index} />
+            ))}
+          </>
+        );
+      }
+
+      render(<Test />);
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+      ).toHaveLength(1);
+
+      act(() => {
+        swap(formStore!, { path: ['todos'], at: 0, and: 1 });
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        ).toHaveLength(1);
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+        ).toHaveLength(1);
+      });
     });
   });
 });

--- a/frameworks/react/src/hooks/useField/useField.ts
+++ b/frameworks/react/src/hooks/useField/useField.ts
@@ -96,7 +96,10 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
         name: internalFieldStore.name,
         autoFocus: !!internalFieldStore.errors.value,
         ref(element) {
-          if (element) {
+          // An array reorder transfers registered elements between the field
+          // stores, so the element may already be present when the framework
+          // re-registers it against the destination store
+          if (element && !internalFieldStore.elements.includes(element)) {
             internalFieldStore.elements.push(element);
           }
         },

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix duplicate element registration in `useField` after array reorders
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/solid/src/primitives/useField/useField.test.tsx
+++ b/frameworks/solid/src/primitives/useField/useField.test.tsx
@@ -1,3 +1,5 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/solid';
+import { swap } from '@formisch/methods/solid';
 import {
   fireEvent,
   render,
@@ -5,11 +7,13 @@ import {
   screen,
   waitFor,
 } from '@solidjs/testing-library';
-import type { JSX } from 'solid-js';
+import { For, type JSX } from 'solid-js';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { Form } from '../../components/Form/index.ts';
+import type { FormStore } from '../../types/index.ts';
 import { createForm } from '../createForm/index.ts';
+import { useFieldArray } from '../useFieldArray/index.ts';
 import { useField } from './useField.ts';
 
 describe('useField', () => {
@@ -404,6 +408,68 @@ describe('useField', () => {
       unmount();
 
       expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should not register an element that is already present', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = createForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.form[INTERNAL], ['name']);
+      const element = document.createElement('input');
+      // Simulate an array reorder having already transferred the element
+      internalFieldStore.elements.push(element);
+      result.field.props.ref(element);
+      expect(internalFieldStore.elements).toEqual([element]);
+    });
+
+    test('should not duplicate element registration after an array reorder', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      function Row(props: {
+        form: FormStore<typeof schema>;
+        index: number;
+      }): JSX.Element {
+        const field = useField(props.form, {
+          // eslint-disable-next-line solid/reactivity
+          path: ['todos', props.index, 'label'],
+        });
+        return <input {...field.props} />;
+      }
+
+      function Test(): JSX.Element {
+        const form = createForm({
+          schema,
+          initialInput: { todos: [{ label: 'a' }, { label: 'b' }] },
+        });
+        formStore = form;
+        const fieldArray = useFieldArray(form, { path: ['todos'] });
+        return (
+          <For each={fieldArray.items}>
+            {(id, index) => <Row form={form} index={index()} />}
+          </For>
+        );
+      }
+
+      render(() => <Test />);
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+      ).toHaveLength(1);
+
+      swap(formStore!, { path: ['todos'], at: 0, and: 1 });
+
+      await vi.waitFor(() => {
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        ).toHaveLength(1);
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+        ).toHaveLength(1);
+      });
     });
   });
 });

--- a/frameworks/solid/src/primitives/useField/useField.ts
+++ b/frameworks/solid/src/primitives/useField/useField.ts
@@ -108,7 +108,12 @@ export function useField(
       autofocus: !!getInternalFieldStore().errors.value,
       ref: (element) => {
         const internalFieldStore = getInternalFieldStore();
-        internalFieldStore.elements.push(element);
+        // An array reorder transfers registered elements between the field
+        // stores, so the element may already be present when the framework
+        // re-registers it against the destination store
+        if (!internalFieldStore.elements.includes(element)) {
+          internalFieldStore.elements.push(element);
+        }
         onCleanup(() => {
           const elements = internalFieldStore.elements.filter(
             (el) => el !== element

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix duplicate element registration in `useField` after array reorders
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/svelte/src/runes/useField/useField.svelte.ts
+++ b/frameworks/svelte/src/runes/useField/useField.svelte.ts
@@ -92,7 +92,12 @@ export function useField(
       },
       autofocus: !!internalFieldStore.errors.value,
       [createAttachmentKey()](element) {
-        internalFieldStore.elements.push(element);
+        // An array reorder transfers registered elements between the field
+        // stores, so the element may already be present when the framework
+        // re-registers it against the destination store
+        if (!internalFieldStore.elements.includes(element)) {
+          internalFieldStore.elements.push(element);
+        }
         return () => {
           const elements = internalFieldStore.elements.filter(
             (el) => el !== element

--- a/frameworks/svelte/src/runes/useField/useField.test.ts
+++ b/frameworks/svelte/src/runes/useField/useField.test.ts
@@ -1,9 +1,13 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/svelte';
+import { swap } from '@formisch/methods/svelte';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { flushSync, tick } from 'svelte';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
+import type { FormStore } from '../../types/index.ts';
 import FieldHost from '../../vitest/FieldHost.svelte';
 import { renderHook } from '../../vitest/renderHook.ts';
+import ReorderHost from '../../vitest/ReorderHost.svelte';
 import UnmountHost from '../../vitest/UnmountHost.svelte';
 import { createForm } from '../createForm/createForm.svelte.ts';
 import { useField } from './useField.svelte.ts';
@@ -319,6 +323,65 @@ describe('useField', () => {
       unmount();
 
       expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should not register an element that is already present', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = createForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
+        'name',
+      ]);
+      const element = document.createElement('input');
+      // Simulate an array reorder having already transferred the element
+      internalFieldStore.elements.push(element);
+      // The element attachment is keyed by a private symbol
+      const [attachmentKey] = Object.getOwnPropertySymbols(
+        result.current.field.props
+      );
+      (
+        (result.current.field.props as unknown as Record<symbol, unknown>)[
+          attachmentKey
+        ] as (element: HTMLElement) => void
+      )(element);
+      expect(internalFieldStore.elements).toEqual([element]);
+    });
+
+    test('should not duplicate element registration after an array reorder', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      render(ReorderHost, {
+        props: {
+          config: {
+            schema,
+            initialInput: { todos: [{ label: 'a' }, { label: 'b' }] },
+          },
+          onMounted: (form: FormStore<typeof schema>) => {
+            formStore = form;
+          },
+        },
+      });
+
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+      ).toHaveLength(1);
+
+      swap(formStore!, { path: ['todos'], at: 0, and: 1 });
+      flushSync();
+
+      await vi.waitFor(() => {
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        ).toHaveLength(1);
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+        ).toHaveLength(1);
+      });
     });
   });
 });

--- a/frameworks/svelte/src/vitest/ReorderHost.svelte
+++ b/frameworks/svelte/src/vitest/ReorderHost.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { FormConfig, FormSchema } from '@formisch/core/svelte';
+  import { createForm } from '../runes/createForm/createForm.svelte.ts';
+  import { useFieldArray } from '../runes/useFieldArray/useFieldArray.svelte.ts';
+  import ReorderRowHost from './ReorderRowHost.svelte';
+  // Test fixture: generic parameters are deliberately untyped because Svelte
+  // component generics don't survive @testing-library/svelte's `render()`
+  // signature. We accept permissive types and cast internally.
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let {
+    config,
+    onMounted,
+  }: {
+    config: FormConfig<FormSchema>;
+    onMounted: (form: any) => void;
+  } = $props();
+
+  const form = createForm(config as any);
+  const fieldArray = useFieldArray(form, { path: ['todos'] as any });
+  onMounted(form);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+</script>
+
+{#each fieldArray.items as id, index (id)}
+  <ReorderRowHost {form} {index} />
+{/each}

--- a/frameworks/svelte/src/vitest/ReorderRowHost.svelte
+++ b/frameworks/svelte/src/vitest/ReorderRowHost.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { useField } from '../runes/useField/useField.svelte.ts';
+  // Test fixture: generic parameters are deliberately untyped because Svelte
+  // component generics don't survive @testing-library/svelte's `render()`
+  // signature. We accept permissive types and cast internally.
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let { form, index }: { form: any; index: number } = $props();
+
+  const field = useField(form, () => ({
+    path: ['todos', index, 'label'] as any,
+  }));
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+</script>
+
+<input {...field.props} />

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix duplicate element registration in `useField` after array reorders
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/vue/src/composables/useField/useField.test.ts
+++ b/frameworks/vue/src/composables/useField/useField.test.ts
@@ -1,9 +1,13 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/vue';
+import { swap } from '@formisch/methods/vue';
 import { mount } from '@vue/test-utils';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { defineComponent, h } from 'vue';
 import Form from '../../components/Form/Form.vue';
+import type { FormStore } from '../../types/index.ts';
 import { renderHook } from '../../vitest/renderHook.ts';
+import { useFieldArray } from '../useFieldArray/index.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -377,6 +381,74 @@ describe('useField', () => {
       wrapper.unmount();
 
       expect(document.querySelector('[data-testid="input"]')).toBeNull();
+    });
+
+    test('should not register an element that is already present', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = useForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
+        'name',
+      ]);
+      const element = document.createElement('input');
+      // Simulate an array reorder having already transferred the element
+      internalFieldStore.elements.push(element);
+      (result.current.field.props.ref as (element: unknown) => void)(element);
+      expect(internalFieldStore.elements).toEqual([element]);
+    });
+
+    test('should not duplicate element registration after an array reorder', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      const Row = defineComponent({
+        props: {
+          form: { type: Object, required: true },
+          index: { type: Number, required: true },
+        },
+        setup(props) {
+          const field = useField(
+            props.form as FormStore<typeof schema>,
+            () => ({ path: ['todos', props.index, 'label'] as const })
+          );
+          return () => h('input', { ...field.props });
+        },
+      });
+
+      const Test = defineComponent({
+        setup() {
+          const form = useForm({
+            schema,
+            initialInput: { todos: [{ label: 'a' }, { label: 'b' }] },
+          });
+          formStore = form;
+          const fieldArray = useFieldArray(form, { path: ['todos'] });
+          return () =>
+            fieldArray.items.map((id, index) =>
+              h(Row, { key: id, form, index })
+            );
+        },
+      });
+
+      mount(Test, { attachTo: document.body });
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+      ).toHaveLength(1);
+
+      swap(formStore!, { path: ['todos'], at: 0, and: 1 });
+
+      await vi.waitFor(() => {
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        ).toHaveLength(1);
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+        ).toHaveLength(1);
+      });
     });
   });
 });

--- a/frameworks/vue/src/composables/useField/useField.ts
+++ b/frameworks/vue/src/composables/useField/useField.ts
@@ -122,7 +122,13 @@ export function useField(
       },
       autofocus: !!internalFieldStore.value.errors.value,
       ref(element) {
-        if (element) {
+        // An array reorder transfers registered elements between the field
+        // stores, so the element may already be present when the framework
+        // re-registers it against the destination store
+        if (
+          element &&
+          !internalFieldStore.value.elements.includes(element as FieldElement)
+        ) {
           internalFieldStore.value.elements.push(element as FieldElement);
         }
       },


### PR DESCRIPTION
## Problem

Core's `swapItemState`/`copyItemState` transfer the registered `elements` arrays between field stores when an array is reordered via `move` or `swap`, so DOM registrations follow the data. When the framework layer then re-registers the element against the destination store, it pushed unconditionally — appending a duplicate on every reorder.

Originally reported by a review bot on #124 for the Angular package (fixed there); this PR verifies and fixes the same defect in all other framework packages.

## Verification

Each framework got two tests: a handler-level test (simulating the transfer, then invoking `ref`) and a rendered keyed-reorder test (two-row form, `swap`, assert element counts). Run against the unfixed sources:

| Framework | Handler unguarded | Actively triggered by reorders |
|---|---|---|
| React | yes | **yes** — refs re-invoked when a keyed row's path changes |
| Svelte | yes | **yes** — attachment re-runs on reorder |
| Preact | yes | no — refs not re-invoked on keyed moves |
| Solid | yes | no — refs fire once per element |
| Vue | yes | no — vnode ref stable across keyed moves |
| Qwik | yes (same handler shape) | not verifiable (no test infrastructure) |

In React and Svelte the elements array grew by one duplicate per reorder. In the others the defect was latent.

## Fix

Each `ref`/attachment handler now skips elements that are already present, with a comment explaining the reorder-transfer interplay. One-line guard per framework, mirroring the fix already applied to the Angular package on #124.

## Tests

- `should not register an element that is already present` — covers the guard branch deterministically (all five frameworks with test infrastructure)
- `should not duplicate element registration after an array reorder` — end-to-end keyed reorder (all five; new Svelte host fixtures verified absent from `pnpm pack` output)

All framework test suites, ESLint, and Prettier pass. Changelogs updated with unreleased entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate form element registrations when array items are reordered or remounted.
  * Improved field handling consistency across React, Preact, Qwik, Solid, Svelte, and Vue integrations.

* **Tests**
  * Added regression coverage for repeated element registration and reordered field arrays.

* **Documentation**
  * Updated framework changelogs with the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->