### PR TITLE
chore: reschedule and add npm target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,29 @@
 version: 2
 updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: "saturday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "dependabot"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+      day: "saturday"
+      time: "09:00"
     cooldown:
       default-days: 7
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       prefix: "dependabot"
     groups:
       npm-deps:
+        update-types:
+          - "patch"
+          - "minor"
         patterns:
           - "*"
     ignore:
@@ -38,10 +41,12 @@ updates:
       prefix: "dependabot"
     groups:
       github-actions:
+        update-types:
+          - "patch"
+          - "minor"
         patterns:
           - '*'
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: /
+    directories:
+      - /
+      - /frameworks/*
+      - /packages/*
+      - /playgrounds/*
+      - /scripts
+      - /website
+      - /examples/svelte-invoice-form
     schedule:
       interval: weekly
       day: "saturday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       - /examples/svelte-invoice-form
     schedule:
       interval: weekly
+      day: "saturday"
+      time: "09:00"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
       npm-deps:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -36,3 +40,8 @@ updates:
       github-actions:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,20 +11,15 @@ updates:
       - /examples/svelte-invoice-form
     schedule:
       interval: weekly
-      day: "saturday"
-      time: "09:00"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
     commit-message:
       prefix: "dependabot"
     groups:
-      patch-updates:
-        update-types:
-          - "patch"
-      minor-updates:
-        update-types:
-          - "minor"
+      npm-deps:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
rescheduled depenadbot interval monthly to weekly.
It is best to update library versions frequently.
I’ll be reviewing them on my own initiative every week.

I have also included npm packages in the scope for Dependabot.
I will be checking these on a weekly basis as well.

Regarding major version updates, automatic updates are too risky, so we have decided to verify them ourselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added weekly automated update checks for npm dependencies across multiple project areas (Saturdays at 09:00).
  * Updated automated GitHub Actions dependency checks to run weekly (Saturdays at 09:00).
  * Grouped dependency updates to reduce noise, capped concurrent open update pull requests, and set a cooldown window.
  * Prefixed automated update commit messages and skipped major version bumps for matching dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->