### PR TITLE
Drop detached elements from the reset baseline in useField cleanups

### DIFF
--- a/frameworks/angular/CHANGELOG.md
+++ b/frameworks/angular/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `injectField` destroy cleanup to drop detached elements from the reset baseline
+
 ## v0.1.0 (July 26, 2026)
 
 - Initial release

--- a/frameworks/angular/src/functions/injectField/injectField.test.ts
+++ b/frameworks/angular/src/functions/injectField/injectField.test.ts
@@ -177,4 +177,27 @@ describe('injectField', () => {
     expect(internalFieldStore.initialElements).toBe(initialElements);
     expect(internalFieldStore.initialElements).toContain(element);
   });
+
+  it('drops a detached element from the reset baseline on destroy', () => {
+    const injector = createEnvironmentInjector(
+      [],
+      TestBed.inject(EnvironmentInjector)
+    );
+    const { form, field } = runInInjectionContext(injector, () => {
+      const form = injectForm({ schema: Schema });
+      return { form, field: injectField(form, { path: ['email'] }) };
+    });
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+
+    const element = document.createElement('input');
+    field[CONTROL].ref(element);
+    expect(internalFieldStore.initialElements).toContain(element);
+
+    // Simulate an array operation moving the elements to another store
+    internalFieldStore.elements = [];
+
+    // The detached element must not survive in the reset baseline
+    injector.destroy();
+    expect(internalFieldStore.initialElements).not.toContain(element);
+  });
 });

--- a/frameworks/angular/src/functions/injectField/injectField.ts
+++ b/frameworks/angular/src/functions/injectField/injectField.ts
@@ -79,10 +79,15 @@ export function injectField(
     const elements = fieldStore.elements.filter(
       (element) => element.isConnected
     );
-    // Keep `initialElements` in sync unless a reorder has moved the elements,
-    // so resetting a remounted field restores its live element, not a stale one
+    // Keep `initialElements` in sync while the store still owns it (same
+    // reference) and filter it separately otherwise, so the detached element
+    // of a removed array item does not survive in the reset baseline
     if (fieldStore.elements === fieldStore.initialElements) {
       fieldStore.initialElements = elements;
+    } else {
+      fieldStore.initialElements = fieldStore.initialElements.filter(
+        (element) => element.isConnected
+      );
     }
     fieldStore.elements = elements;
   });

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` cleanup to drop detached elements from the reset baseline
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/qwik/src/hooks/useField/useField.ts
+++ b/frameworks/qwik/src/hooks/useField/useField.ts
@@ -66,13 +66,19 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
       const elements = internalFieldStoreValue.elements.filter(
         (element) => element.isConnected
       );
-      // Keep `initialElements` in sync unless a reorder has moved the elements,
-      // so resetting a remounted field restores its live element, not a stale one
+      // Keep `initialElements` in sync while the store still owns it (same
+      // reference) and filter it separately otherwise, so the detached element
+      // of a removed array item does not survive in the reset baseline
       if (
         internalFieldStoreValue.elements ===
         internalFieldStoreValue.initialElements
       ) {
         internalFieldStoreValue.initialElements = elements;
+      } else {
+        internalFieldStoreValue.initialElements =
+          internalFieldStoreValue.initialElements.filter(
+            (element) => element.isConnected
+          );
       }
       internalFieldStoreValue.elements = elements;
     });

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` cleanup to drop detached elements from the reset baseline
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/react/src/hooks/useField/useField.test.tsx
+++ b/frameworks/react/src/hooks/useField/useField.test.tsx
@@ -1,3 +1,4 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/react';
 import { reset } from '@formisch/methods/react';
 import {
   act,
@@ -7,7 +8,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { Form } from '../../components/Form/index.ts';
@@ -445,6 +446,35 @@ describe('useField', () => {
       unmount();
 
       expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should drop a detached element from the reset baseline after the elements moved', () => {
+      const schema = v.object({ name: v.string() });
+
+      let capturedForm: FormStore<typeof schema> | undefined;
+
+      function Test(): ReactElement {
+        const form = useForm({ schema, initialInput: { name: '' } });
+        useEffect(() => {
+          capturedForm = form;
+        }, [form]);
+        const field = useField(form, { path: ['name'] });
+        return <input data-testid="input" {...field.props} />;
+      }
+
+      const { unmount } = render(<Test />);
+      const element = screen.getByTestId('input');
+      const internalFieldStore = getFieldStore(capturedForm![INTERNAL], [
+        'name',
+      ]);
+      expect(internalFieldStore.initialElements).toContain(element);
+
+      // Simulate an array operation moving the elements to another store
+      internalFieldStore.elements = [];
+
+      // The detached element must not survive in the reset baseline
+      unmount();
+      expect(internalFieldStore.initialElements).not.toContain(element);
     });
   });
 });

--- a/frameworks/react/src/hooks/useField/useField.ts
+++ b/frameworks/react/src/hooks/useField/useField.ts
@@ -57,10 +57,16 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
       const elements = internalFieldStore.elements.filter(
         (element) => element.isConnected
       );
-      // Keep `initialElements` in sync unless a reorder has moved the elements,
-      // so resetting a remounted field restores its live element, not a stale one
+      // Keep `initialElements` in sync while the store still owns it (same
+      // reference) and filter it separately otherwise, so the detached element
+      // of a removed array item does not survive in the reset baseline
       if (internalFieldStore.elements === internalFieldStore.initialElements) {
         internalFieldStore.initialElements = elements;
+      } else {
+        internalFieldStore.initialElements =
+          internalFieldStore.initialElements.filter(
+            (element) => element.isConnected
+          );
       }
       internalFieldStore.elements = elements;
     };

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` cleanup to drop detached elements from the reset baseline
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/solid/src/primitives/useField/useField.test.tsx
+++ b/frameworks/solid/src/primitives/useField/useField.test.tsx
@@ -1,3 +1,4 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/solid';
 import {
   fireEvent,
   render,
@@ -9,6 +10,7 @@ import type { JSX } from 'solid-js';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { Form } from '../../components/Form/index.ts';
+import type { FormStore } from '../../types/index.ts';
 import { createForm } from '../createForm/index.ts';
 import { useField } from './useField.ts';
 
@@ -404,6 +406,33 @@ describe('useField', () => {
       unmount();
 
       expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should drop a detached element from the reset baseline after the elements moved', () => {
+      const schema = v.object({ name: v.string() });
+
+      let capturedForm: FormStore<typeof schema> | undefined;
+
+      function Test(): JSX.Element {
+        const form = createForm({ schema, initialInput: { name: '' } });
+        capturedForm = form;
+        const field = useField(form, { path: ['name'] });
+        return <input data-testid="input" {...field.props} />;
+      }
+
+      const { unmount } = render(() => <Test />);
+      const element = screen.getByTestId('input');
+      const internalFieldStore = getFieldStore(capturedForm![INTERNAL], [
+        'name',
+      ]);
+      expect(internalFieldStore.initialElements).toContain(element);
+
+      // Simulate an array operation moving the elements to another store
+      internalFieldStore.elements = [];
+
+      // The detached element must not survive in the reset baseline
+      unmount();
+      expect(internalFieldStore.initialElements).not.toContain(element);
     });
   });
 });

--- a/frameworks/solid/src/primitives/useField/useField.ts
+++ b/frameworks/solid/src/primitives/useField/useField.ts
@@ -113,12 +113,17 @@ export function useField(
           const elements = internalFieldStore.elements.filter(
             (el) => el !== element
           );
-          // Keep `initialElements` in sync unless a reorder has moved the
-          // elements, so resetting a remounted field restores its live element
+          // Keep `initialElements` in sync while the store still owns it
+          // (same reference) and filter it separately otherwise, so the
+          // detached element of a removed array item does not survive in the
+          // reset baseline
           if (
             internalFieldStore.elements === internalFieldStore.initialElements
           ) {
             internalFieldStore.initialElements = elements;
+          } else {
+            internalFieldStore.initialElements =
+              internalFieldStore.initialElements.filter((el) => el !== element);
           }
           internalFieldStore.elements = elements;
         });

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `useField` cleanup to drop detached elements from the reset baseline
+
 ## v1.0.0-rc.0 (June 23, 2026)
 
 - Release candidate for v1.0.0

--- a/frameworks/vue/src/composables/useField/useField.test.ts
+++ b/frameworks/vue/src/composables/useField/useField.test.ts
@@ -1,8 +1,10 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/vue';
 import { mount } from '@vue/test-utils';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
 import { defineComponent, h } from 'vue';
 import Form from '../../components/Form/Form.vue';
+import type { FormStore } from '../../types/index.ts';
 import { renderHook } from '../../vitest/renderHook.ts';
 import { useForm } from '../useForm/index.ts';
 import { useField } from './useField.ts';
@@ -377,6 +379,35 @@ describe('useField', () => {
       wrapper.unmount();
 
       expect(document.querySelector('[data-testid="input"]')).toBeNull();
+    });
+
+    test('should drop a detached element from the reset baseline after the elements moved', () => {
+      const schema = v.object({ name: v.string() });
+
+      let capturedForm: FormStore<typeof schema> | undefined;
+
+      const Test = defineComponent({
+        setup() {
+          const form = useForm({ schema, initialInput: { name: '' } });
+          capturedForm = form;
+          const field = useField(form, { path: ['name'] });
+          return () => h('input', { 'data-testid': 'input', ...field.props });
+        },
+      });
+
+      const wrapper = mount(Test, { attachTo: document.body });
+      const element = document.querySelector('[data-testid="input"]');
+      const internalFieldStore = getFieldStore(capturedForm![INTERNAL], [
+        'name',
+      ]);
+      expect(internalFieldStore.initialElements).toContain(element);
+
+      // Simulate an array operation moving the elements to another store
+      internalFieldStore.elements = [];
+
+      // The detached element must not survive in the reset baseline
+      wrapper.unmount();
+      expect(internalFieldStore.initialElements).not.toContain(element);
     });
   });
 });

--- a/frameworks/vue/src/composables/useField/useField.ts
+++ b/frameworks/vue/src/composables/useField/useField.ts
@@ -61,13 +61,19 @@ export function useField(
     const elements = internalFieldStoreValue.elements.filter(
       (element) => element.isConnected
     );
-    // Keep `initialElements` in sync unless a reorder has moved the elements,
-    // so resetting a remounted field restores its live element, not a stale one
+    // Keep `initialElements` in sync while the store still owns it (same
+    // reference) and filter it separately otherwise, so the detached element
+    // of a removed array item does not survive in the reset baseline
     if (
       internalFieldStoreValue.elements ===
       internalFieldStoreValue.initialElements
     ) {
       internalFieldStoreValue.initialElements = elements;
+    } else {
+      internalFieldStoreValue.initialElements =
+        internalFieldStoreValue.initialElements.filter(
+          (element) => element.isConnected
+        );
     }
     internalFieldStoreValue.elements = elements;
   });


### PR DESCRIPTION
## Problem

When a field-array item is removed, core's `copyItemState` moves the following item's `elements` array into the preceding store before the removed item's cleanup runs. The cleanup's `elements === initialElements` guard is then false, so the detached element survives in `initialElements` — and a later `reset` restores that stale baseline via `elements = initialElements`, so validation focus can target an unmounted element instead of a live one.

Found while addressing review feedback on the React Native adapter (#137, which ships the same fix). #163 fixes the sibling duplicate-registration defect in the registration path; this PR fixes the cleanup path it does not cover.

## Fix

When the store no longer owns the elements array (references diverged), the cleanup now filters `initialElements` separately:

- **React, Qwik, Vue**: same `isConnected` predicate as the existing `elements` pruning — it can never remove a live element, so keyed reorders are unaffected.
- **Solid**: filters by element identity in the per-element `onCleanup` — safe because Solid's refs are not re-invoked on keyed reorders (per the verification table in #163).
- **Angular**: `isConnected` filter in the destroy cleanup.

## Intentionally not changed

- **Svelte** and **Angular's per-element ref cleanup**: these cleanups also run during keyed reorders (attachments/refs re-run, see #163's table), where a baseline filter would erode live bindings — Angular's `does not touch initialElements when a reorder moved the elements` test encodes exactly this. Their stale-baseline window remains, bounded by focus skipping detached elements and by re-registration on the next render.
- **Preact**: its hook cleanup runs before the DOM node detaches, so an `isConnected` filter is provably a no-op there (verified by test during development — which also revealed that the existing `elements` pruning in Preact is latently ineffective for the same reason). A proper fix needs per-element registration tracking and is left as a follow-up.

## Verification

- New regression test per framework with test infrastructure (React, Solid, Vue, Angular): register an element, simulate the array transfer (`elements` reassigned), unmount/destroy, and assert the baseline no longer contains the detached element.
- Each test was run against the unfixed sources and failed exactly as expected (React 1/55, Solid 1/47, Vue 1/44, Angular 1/117), then passed with the fix.
- Qwik has no test infrastructure (same situation as #163); its fix is shape-identical to React's.
- All framework test suites, ESLint, Prettier, and builds pass. Changelogs updated with unreleased entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved field cleanup across Angular, Qwik, React, Solid, and Vue so detached form elements are dropped from the reset baseline.
  - Prevents stale elements from being retained after unmounting or when fields are relocated.

- **Tests**
  - Added regression coverage across the affected frameworks to verify detached elements are removed from the reset baseline during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->