### PR TITLE
Add Angular and React Native to framework lists in blog posts

### DIFF
--- a/website/src/routes/blog/(posts)/formisch-v1-release-candidate/index.mdx
+++ b/website/src/routes/blog/(posts)/formisch-v1-release-candidate/index.mdx
@@ -73,7 +73,7 @@ You can run this exact example on the <Link href="/playground/login/">playground
 
 The `path` is fully typed against your schema, so if you rename a field, TypeScript flags every place that no longer matches. Because state lives in fine-grained signals, only the fields that actually change re-render. And thanks to the modular design, the bundle size starts at around 2.5 kB.
 
-Formisch runs on React, Vue, Solid, Qwik, Svelte, and Preact from a single core, but there is no adapter tax. At build time it swaps in your framework's own reactivity, so you get real React updates, real Solid signals, and native performance with no extra layer in your bundle.
+Formisch runs on Angular, Preact, Qwik, React, React Native, SolidJS, Svelte, and Vue from a single core, but there is no adapter tax. At build time it swaps in your framework's own reactivity, so you get real React updates, real Solid signals, and native performance with no extra layer in your bundle.
 
 For a deeper look at the design decisions behind Formisch, read our <Link href="/blog/one-core-six-frameworks/">architecture post</Link>. We explain how the runtime works and why there is no abstraction layer.
 
@@ -107,7 +107,7 @@ If something behaves unexpectedly in your forms, that feedback is the most valua
 
 ## Give it a try
 
-Install it for your framework. Here is the React package as an example. Every other framework works the same way, just swap in `@formisch/solid`, `@formisch/vue`, `@formisch/svelte`, `@formisch/preact`, or `@formisch/qwik`:
+Install it for your framework. Here is the React package as an example. Every other framework works the same way, just swap in `@formisch/angular`, `@formisch/preact`, `@formisch/qwik`, `@formisch/react-native`, `@formisch/solid`, `@formisch/svelte`, or `@formisch/vue`:
 
 ```bash
 npm install @formisch/react valibot

--- a/website/src/routes/blog/(posts)/react-form-library-comparison/index.mdx
+++ b/website/src/routes/blog/(posts)/react-form-library-comparison/index.mdx
@@ -341,7 +341,7 @@ A signal represents a single value and tracks exactly which components depend on
 The dependency graph is more direct than a store-based model. In a large field array where many rows update frequently, only the component reading that specific value re-renders. This difference is small in most web forms
 and more noticeable in React Native or in very large dynamic forms.
 
-Formisch is also framework-agnostic. The same mental model works across React, SolidJS, Vue, Svelte, Preact, and Qwik. That is relevant if your team works across multiple framework environments, or expects that to change.
+Formisch is also framework-agnostic. The same mental model works across Angular, Preact, Qwik, React, React Native, SolidJS, Svelte, and Vue. That is relevant if your team works across multiple framework environments, or expects that to change.
 
 For most applications, the difference between TanStack Form and Formisch comes down to this: both scope re-renders automatically without requiring deliberate component structure. Formisch does it at the signal level, which can reduce overhead as form size and update frequency increase.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework support information to include Angular and React Native.
  * Expanded installation examples with the corresponding framework packages.
  * Added Angular and React Native to the framework comparison guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->