### PR TITLE
feat(core): add honox framework target

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/index.angular.d.ts",
       "default": "./dist/index.angular.js"
     },
+    "./honox": {
+      "types": "./dist/index.honox.d.ts",
+      "default": "./dist/index.honox.js"
+    },
     "./preact": {
       "types": "./dist/index.preact.d.ts",
       "default": "./dist/index.preact.js"

--- a/packages/core/src/framework/index.honox.ts
+++ b/packages/core/src/framework/index.honox.ts
@@ -1,0 +1,140 @@
+import type { Signal } from '../types/signal/index.ts';
+import type { Framework } from './index.ts';
+
+/**
+ * The current framework being used.
+ */
+export const framework: Framework = 'honox';
+
+/**
+ * Creates a unique identifier string.
+ *
+ * @returns The unique identifier.
+ */
+// @__NO_SIDE_EFFECTS__
+export function createId(): string {
+  return Math.random().toString(36).slice(2);
+}
+
+/**
+ * Listener tuple.
+ *
+ * Hint: The first element is the execute function, which notifies the listener
+ * about updates. The second element is the subscription set, which keeps track
+ * of where the listener is subscribed and is used to clean up subscriptions if
+ * they are no longer needed.
+ */
+export type Listener = [() => void, Set<Set<Listener>>];
+
+/**
+ * The current listener being tracked.
+ */
+let listener: Listener | undefined;
+
+/**
+ * Sets the current listener being tracked.
+ *
+ * @param newListener The new listener to set.
+ */
+export function setListener(newListener: Listener | undefined): void {
+  listener = newListener;
+}
+
+/**
+ * Subscribers collected during a batch.
+ */
+let batchSubscribers: Set<Listener> | undefined;
+
+/**
+ * Creates a reactive signal without an initial value.
+ *
+ * @returns The created signal.
+ */
+export function createSignal<T>(): Signal<T | undefined>;
+
+/**
+ * Creates a reactive signal with an initial value.
+ *
+ * @param value The initial value.
+ *
+ * @returns The created signal.
+ */
+export function createSignal<T>(value: T): Signal<T>;
+
+// @__NO_SIDE_EFFECTS__
+export function createSignal(value?: unknown): Signal<unknown> {
+  const subscribers = new Set<Listener>();
+  return {
+    get value() {
+      if (listener) {
+        subscribers.add(listener);
+        listener[1].add(subscribers);
+      }
+      return value;
+    },
+    set value(newValue: unknown) {
+      if (newValue !== value) {
+        value = newValue;
+        const localSubscribers: Listener[] = [];
+        for (const subscriber of subscribers) {
+          if (batchSubscribers) {
+            batchSubscribers.add(subscriber);
+          } else {
+            localSubscribers.push(subscriber);
+          }
+          subscriber[1].delete(subscribers);
+        }
+        subscribers.clear();
+        for (const subscriber of localSubscribers) {
+          subscriber[0]();
+        }
+      }
+    },
+  };
+}
+
+// Global batch depth counter
+let batchDepth = 0;
+
+/**
+ * Batches multiple signal updates into a single update cycle.
+ *
+ * @param fn The function to execute in batch.
+ *
+ * @returns The return value of the function.
+ */
+export function batch<T>(fn: () => T): T {
+  batchDepth++;
+  if (!batchSubscribers) {
+    batchSubscribers = new Set();
+  }
+  try {
+    return fn();
+  } finally {
+    batchDepth--;
+    if (batchDepth === 0) {
+      const subscribers = batchSubscribers;
+      batchSubscribers = undefined;
+      for (const subscriber of subscribers) {
+        subscriber[0]();
+      }
+    }
+  }
+}
+
+/**
+ * Executes a function without tracking reactive dependencies.
+ *
+ * @param fn The function to execute without tracking.
+ *
+ * @returns The return value of the function.
+ */
+export function untrack<T>(fn: () => T): T {
+  const prev = listener;
+  listener = undefined;
+  try {
+    return fn();
+  } finally {
+    listener = prev;
+  }
+}

--- a/packages/core/src/framework/index.ts
+++ b/packages/core/src/framework/index.ts
@@ -7,6 +7,7 @@ import type { Signal } from '../types/index.ts';
  */
 export type Framework =
   | 'angular'
+  | 'honox'
   | 'preact'
   | 'qwik'
   | 'react'

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, type UserConfig, type UserConfigFn } from 'tsdown';
 
 type Framework =
   | 'angular'
+  | 'honox'
   | 'preact'
   | 'qwik'
   | 'react'
@@ -125,6 +126,7 @@ function defineFrameworkConfig(
 const config: (UserConfig | UserConfigFn)[] = [
   defineFrameworkConfig(null),
   defineFrameworkConfig('angular'),
+  defineFrameworkConfig('honox'),
   defineFrameworkConfig('preact'),
   defineFrameworkConfig('qwik'),
   defineFrameworkConfig('react'),


### PR DESCRIPTION
resolves: #175
Adds the hono/jsx reactivity adapter to `@formisch/core` and exposes it through the `./honox` subpath.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Honox as a supported framework option.
  * Added a reactive runtime with signals, batched updates, dependency tracking, and untracked execution.
  * Added unique identifier generation for reactive elements.
  * Exposed the Honox package export for application use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->