### PR TITLE
feat(methods): add honox framework target

### DIFF
--- a/packages/methods/package.json
+++ b/packages/methods/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/index.angular.d.ts",
       "default": "./dist/index.angular.js"
     },
+    "./honox": {
+      "types": "./dist/index.honox.d.ts",
+      "default": "./dist/index.honox.js"
+    },
     "./preact": {
       "types": "./dist/index.preact.d.ts",
       "default": "./dist/index.preact.js"

--- a/packages/methods/tsdown.config.ts
+++ b/packages/methods/tsdown.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, type UserConfig, type UserConfigFn } from 'tsdown';
 
 type Framework =
   | 'angular'
+  | 'honox'
   | 'preact'
   | 'qwik'
   | 'react'
@@ -123,6 +124,7 @@ function defineFrameworkConfig(
 
 const config: (UserConfig | UserConfigFn)[] = [
   defineFrameworkConfig('angular'),
+  defineFrameworkConfig('honox'),
   defineFrameworkConfig('preact'),
   defineFrameworkConfig('qwik'),
   defineFrameworkConfig('react'),


### PR DESCRIPTION
resolves: #175
Adds the honox build target to `@formisch/methods` and exposes it through the `./honox` subpath.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>