### PR TITLE
feat(honox): add @formisch/honox package

### DIFF
--- a/frameworks/honox/.gitignore
+++ b/frameworks/honox/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frameworks/honox/eslint.config.js
+++ b/frameworks/honox/eslint.config.js
@@ -1,0 +1,28 @@
+import {
+  baseConfigs,
+  commonRules,
+  componentRules,
+  importConfig,
+  jsdoc,
+} from '@formisch/eslint-config';
+import { defineConfig, globalIgnores } from 'eslint/config';
+
+export default defineConfig([
+  globalIgnores(['dist', 'eslint.config.js']),
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [...baseConfigs, importConfig],
+    plugins: { jsdoc },
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: commonRules,
+  },
+  {
+    files: ['src/components/**/*.tsx'],
+    rules: componentRules,
+  },
+]);

--- a/frameworks/honox/package.json
+++ b/frameworks/honox/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@formisch/honox",
+  "description": "The lightweight, schema-first, and fully type-safe form library for hono/jsx and HonoX",
+  "version": "1.0.0-rc.0",
+  "license": "MIT",
+  "author": "Kanon",
+  "homepage": "https://formisch.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-circle/formisch.git"
+  },
+  "keywords": [
+    "hono",
+    "honox",
+    "hono-form",
+    "form",
+    "forms",
+    "form-validation",
+    "validation",
+    "schema",
+    "typescript",
+    "type-safe",
+    "signals",
+    "bundle-size",
+    "modular",
+    "valibot"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run --typecheck",
+    "lint": "eslint \"src/**/*.ts*\" && tsc --noEmit",
+    "lint.fix": "eslint \"src/**/*.ts*\" --fix",
+    "format": "prettier --write ./src",
+    "format.check": "prettier --check ./src"
+  },
+  "devDependencies": {
+    "@formisch/core": "workspace:*",
+    "@formisch/eslint-config": "workspace:*",
+    "@formisch/methods": "workspace:*",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.0",
+    "@types/node": "^24.10.1",
+    "@vitest/coverage-v8": "^4.1.7",
+    "eslint": "^9.39.1",
+    "hono": "4.12.32",
+    "jsdom": "^26.1.0",
+    "tsdown": "^0.16.8",
+    "typescript": "~5.9.3",
+    "valibot": "^1.4.1",
+    "vitest": "^4.1.7"
+  },
+  "peerDependencies": {
+    "hono": "^4.0.0",
+    "typescript": ">=5",
+    "valibot": "^1.4.1"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
+}

--- a/frameworks/honox/src/components/Field/Field.test.tsx
+++ b/frameworks/honox/src/components/Field/Field.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import * as v from 'valibot';
+import { describe, expect, test, vi } from 'vitest';
+import { useForm } from '../../hooks/index.ts';
+import type { FieldStore } from '../../types/index.ts';
+import { renderHono } from '../../vitest/render.tsx';
+import { Field } from './Field.tsx';
+
+const schema = v.object({ name: v.string() });
+type FormSchema = typeof schema;
+
+describe('Field', () => {
+  test('should render JSX returned from children', () => {
+    function Test(): JSX.Element {
+      const form = useForm({ schema });
+      return (
+        <Field of={form} path={['name']}>
+          {() => <span data-testid="content">hello</span>}
+        </Field>
+      );
+    }
+
+    renderHono(<Test />);
+
+    expect(screen.getByTestId('content')).toHaveTextContent('hello');
+  });
+
+  test('should invoke children with the field store', () => {
+    const renderProp = vi.fn<
+      (field: FieldStore<FormSchema, ['name']>) => JSX.Element
+    >(() => <span />);
+
+    function Test(): JSX.Element {
+      const form = useForm({ schema, initialInput: { name: 'John' } });
+      return (
+        <Field of={form} path={['name']}>
+          {renderProp}
+        </Field>
+      );
+    }
+
+    renderHono(<Test />);
+
+    expect(renderProp).toHaveBeenCalled();
+    const field = renderProp.mock.lastCall![0];
+    expect(field.path).toEqual(['name']);
+    expect(field.input).toBe('John');
+    expect(field.props.name).toBe('["name"]');
+    expect(typeof field.props.onChange).toBe('function');
+  });
+
+  test('should re-render when the field store updates', async () => {
+    function Test(): JSX.Element {
+      const form = useForm({ schema, initialInput: { name: 'initial' } });
+      return (
+        <Field of={form} path={['name']}>
+          {(field) => (
+            <>
+              <input
+                data-testid="input"
+                {...field.props}
+                value={field.input ?? ''}
+              />
+              <span data-testid="dirty">{String(field.isDirty)}</span>
+            </>
+          )}
+        </Field>
+      );
+    }
+
+    renderHono(<Test />);
+
+    const input = screen.getByTestId('input') as HTMLInputElement;
+    const dirty = screen.getByTestId('dirty');
+
+    expect(input.value).toBe('initial');
+    expect(dirty).toHaveTextContent('false');
+
+    // hono/jsx maps the `onChange` prop to a native `input` listener, the
+    // same normalization React applies for its synthetic `onChange`.
+    flushSync(() => {
+      fireEvent.input(input, { target: { value: 'changed' } });
+    });
+
+    await waitFor(() => {
+      expect(input.value).toBe('changed');
+      expect(dirty).toHaveTextContent('true');
+    });
+  });
+});

--- a/frameworks/honox/src/components/Field/Field.tsx
+++ b/frameworks/honox/src/components/Field/Field.tsx
@@ -1,0 +1,48 @@
+import {
+  type FormSchema,
+  type RequiredPath,
+  type ValidPath,
+} from '@formisch/core/honox';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import type * as v from 'valibot';
+import { useField } from '../../hooks/index.ts';
+import type { FieldStore, FormStore } from '../../types/index.ts';
+
+/**
+ * Field component props interface.
+ */
+export interface FieldProps<
+  TSchema extends FormSchema = FormSchema,
+  TFieldPath extends RequiredPath = RequiredPath,
+> {
+  /**
+   * The form store to which the field belongs.
+   */
+  readonly of: FormStore<TSchema>;
+  /**
+   * The path to the field within the form schema.
+   */
+  readonly path: ValidPath<v.InferInput<TSchema>, TFieldPath>;
+  /**
+   * The render function that receives the field store and returns JSX.
+   */
+  readonly children: (store: FieldStore<TSchema, TFieldPath>) => JSX.Element;
+}
+
+/**
+ * Headless form field component that provides reactive properties and state.
+ * The field component takes a form store, path to field, and a render function
+ * that receives a field store to display field state and handle user interactions.
+ *
+ * @param props The field component props.
+ *
+ * @returns The UI of the field to be rendered.
+ */
+// @__NO_SIDE_EFFECTS__
+export function Field<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>({ of, path, children }: FieldProps<TSchema, TFieldPath>): JSX.Element {
+  const field = useField(of, { path });
+  return children(field);
+}

--- a/frameworks/honox/src/components/Field/index.ts
+++ b/frameworks/honox/src/components/Field/index.ts
@@ -1,0 +1,1 @@
+export * from './Field.tsx';

--- a/frameworks/honox/src/components/FieldArray/FieldArray.test.tsx
+++ b/frameworks/honox/src/components/FieldArray/FieldArray.test.tsx
@@ -1,0 +1,86 @@
+import { insert } from '@formisch/methods/honox';
+import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import * as v from 'valibot';
+import { describe, expect, test, vi } from 'vitest';
+import { useForm } from '../../hooks/index.ts';
+import type { FieldArrayStore } from '../../types/index.ts';
+import { renderHono } from '../../vitest/render.tsx';
+import { FieldArray } from './FieldArray.tsx';
+
+const schema = v.object({ items: v.array(v.string()) });
+type FormSchema = typeof schema;
+
+describe('FieldArray', () => {
+  test('should render JSX returned from children', () => {
+    function Test(): JSX.Element {
+      const form = useForm({ schema });
+      return (
+        <FieldArray of={form} path={['items']}>
+          {() => <span data-testid="content">hello</span>}
+        </FieldArray>
+      );
+    }
+
+    renderHono(<Test />);
+
+    expect(screen.getByTestId('content')).toHaveTextContent('hello');
+  });
+
+  test('should invoke children with the field array store', () => {
+    const renderProp = vi.fn<
+      (field: FieldArrayStore<FormSchema, ['items']>) => JSX.Element
+    >(() => <span />);
+
+    function Test(): JSX.Element {
+      const form = useForm({ schema, initialInput: { items: ['a', 'b'] } });
+      return (
+        <FieldArray of={form} path={['items']}>
+          {renderProp}
+        </FieldArray>
+      );
+    }
+
+    renderHono(<Test />);
+
+    expect(renderProp).toHaveBeenCalled();
+    const field = renderProp.mock.lastCall![0];
+    expect(field.path).toEqual(['items']);
+    expect(field.items).toHaveLength(2);
+    expect(field.isValid).toBe(true);
+  });
+
+  test('should re-render when the field array store updates', async () => {
+    function Test(): JSX.Element {
+      const form = useForm({ schema, initialInput: { items: ['a', 'b'] } });
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => insert(form, { path: ['items'], initialInput: 'c' })}
+          >
+            Add
+          </button>
+          <FieldArray of={form} path={['items']}>
+            {(field) => <span data-testid="count">{field.items.length}</span>}
+          </FieldArray>
+        </div>
+      );
+    }
+
+    renderHono(<Test />);
+
+    const count = screen.getByTestId('count');
+
+    expect(count).toHaveTextContent('2');
+
+    flushSync(() => {
+      fireEvent.click(screen.getByText('Add'));
+    });
+
+    await waitFor(() => {
+      expect(count).toHaveTextContent('3');
+    });
+  });
+});

--- a/frameworks/honox/src/components/FieldArray/FieldArray.tsx
+++ b/frameworks/honox/src/components/FieldArray/FieldArray.tsx
@@ -1,0 +1,55 @@
+import {
+  type FormSchema,
+  type RequiredPath,
+  type ValidArrayPath,
+} from '@formisch/core/honox';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import type * as v from 'valibot';
+import { useFieldArray } from '../../hooks/index.ts';
+import type { FieldArrayStore, FormStore } from '../../types/index.ts';
+
+/**
+ * FieldArray component props interface.
+ */
+export interface FieldArrayProps<
+  TSchema extends FormSchema = FormSchema,
+  TFieldArrayPath extends RequiredPath = RequiredPath,
+> {
+  /**
+   * The form store to which the field array belongs.
+   */
+  readonly of: FormStore<TSchema>;
+  /**
+   * The path to the field array within the form schema.
+   */
+  readonly path: ValidArrayPath<v.InferInput<TSchema>, TFieldArrayPath>;
+  /**
+   * The render function that receives the field array store and returns JSX.
+   */
+  readonly children: (
+    store: FieldArrayStore<TSchema, TFieldArrayPath>
+  ) => JSX.Element;
+}
+
+/**
+ * Headless field array component that provides reactive properties and state.
+ * The field array component takes a form store, path to array field, and a render
+ * function that receives a field array store to manage array items and handle
+ * array operations.
+ *
+ * @param props The field array component props.
+ *
+ * @returns The UI of the field array to be rendered.
+ */
+// @__NO_SIDE_EFFECTS__
+export function FieldArray<
+  TSchema extends FormSchema,
+  TFieldArrayPath extends RequiredPath,
+>({
+  of,
+  path,
+  children,
+}: FieldArrayProps<TSchema, TFieldArrayPath>): JSX.Element {
+  const field = useFieldArray(of, { path });
+  return children(field);
+}

--- a/frameworks/honox/src/components/FieldArray/index.ts
+++ b/frameworks/honox/src/components/FieldArray/index.ts
@@ -1,0 +1,1 @@
+export * from './FieldArray.tsx';

--- a/frameworks/honox/src/components/Form/Form.test.tsx
+++ b/frameworks/honox/src/components/Form/Form.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import * as v from 'valibot';
+import { describe, expect, test, vi } from 'vitest';
+import { useForm } from '../../hooks/index.ts';
+import { renderHono } from '../../vitest/render.tsx';
+import { Form } from './Form.tsx';
+
+const schema = v.object({
+  email: v.pipe(v.string(), v.nonEmpty('Email is required')),
+});
+
+describe('Form', () => {
+  test('should render a form element with noValidate, children, and forwarded attributes', () => {
+    function Test(): JSX.Element {
+      const form = useForm({ schema });
+      return (
+        <Form
+          of={form}
+          onSubmit={vi.fn()}
+          aria-label="Test"
+          class="my-form"
+          id="signup"
+        >
+          <span data-testid="child">child</span>
+        </Form>
+      );
+    }
+
+    renderHono(<Test />);
+
+    const formElement = screen.getByRole('form', { name: 'Test' });
+    expect(formElement.tagName).toBe('FORM');
+    expect(formElement).toHaveAttribute('novalidate');
+    expect(formElement).toHaveClass('my-form');
+    expect(formElement).toHaveAttribute('id', 'signup');
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  test('should call onSubmit with the validated output when submitted', async () => {
+    const onSubmit = vi.fn();
+
+    function Test(): JSX.Element {
+      const form = useForm({
+        schema,
+        initialInput: { email: 'user@example.com' },
+      });
+      return (
+        <Form of={form} onSubmit={onSubmit} aria-label="Test">
+          <button type="submit">Submit</button>
+        </Form>
+      );
+    }
+
+    renderHono(<Test />);
+
+    // hono/jsx/dom wraps `<form />` with its own submit listener that treats
+    // every untrusted submit event as one of its own form actions, so the
+    // submission is driven through the button the way a user would
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        { email: 'user@example.com' },
+        expect.any(Object)
+      );
+    });
+  });
+
+  test('should not call onSubmit when validation fails', async () => {
+    const onSubmit = vi.fn();
+
+    function Test(): JSX.Element {
+      const form = useForm({ schema, initialInput: { email: '' } });
+      return (
+        <Form of={form} onSubmit={onSubmit} aria-label="Test">
+          <span data-testid="valid">{String(form.isValid)}</span>
+          <button type="submit">Submit</button>
+        </Form>
+      );
+    }
+
+    renderHono(<Test />);
+
+    const valid = screen.getByTestId('valid');
+
+    expect(valid).toHaveTextContent('true');
+
+    flushSync(() => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+
+    await waitFor(() => {
+      expect(valid).toHaveTextContent('false');
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frameworks/honox/src/components/Form/Form.tsx
+++ b/frameworks/honox/src/components/Form/Form.tsx
@@ -1,0 +1,54 @@
+import {
+  type FormSchema,
+  INTERNAL,
+  type SubmitEventHandler,
+} from '@formisch/core/honox';
+import { handleSubmit } from '@formisch/methods/honox';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import type { FormStore } from '../../types/index.ts';
+
+/**
+ * Form component props type.
+ */
+export type FormProps<TSchema extends FormSchema = FormSchema> = Omit<
+  JSX.IntrinsicElements['form'],
+  'onSubmit' | 'novalidate' | 'ref'
+> & {
+  /**
+   * The form store instance.
+   */
+  readonly of: FormStore<TSchema>;
+  /**
+   * The submit handler called when the form is submitted and validation succeeds.
+   */
+  readonly onSubmit: SubmitEventHandler<TSchema>;
+};
+
+/**
+ * Form component that manages form submission and applies internal state.
+ * Wraps a native form element and calls the provided handler with the validated
+ * form output and the submit event.
+ *
+ * @param props The form component props.
+ *
+ * @returns A native form element.
+ */
+export function Form<TSchema extends FormSchema>(
+  props: FormProps<TSchema>
+): JSX.Element;
+
+// @__NO_SIDE_EFFECTS__
+export function Form({ of, onSubmit, ...other }: FormProps): JSX.Element {
+  return (
+    <form
+      {...other}
+      novalidate
+      ref={(element: HTMLFormElement | null) => {
+        if (element) {
+          of[INTERNAL].element = element;
+        }
+      }}
+      onSubmit={handleSubmit(of, onSubmit)}
+    />
+  );
+}

--- a/frameworks/honox/src/components/Form/index.ts
+++ b/frameworks/honox/src/components/Form/index.ts
@@ -1,0 +1,1 @@
+export * from './Form.tsx';

--- a/frameworks/honox/src/components/index.ts
+++ b/frameworks/honox/src/components/index.ts
@@ -1,0 +1,3 @@
+export * from './Field/index.ts';
+export * from './FieldArray/index.ts';
+export * from './Form/index.ts';

--- a/frameworks/honox/src/hooks/index.ts
+++ b/frameworks/honox/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './useField/index.ts';
+export * from './useFieldArray/index.ts';
+export * from './useForm/index.ts';

--- a/frameworks/honox/src/hooks/useField/index.ts
+++ b/frameworks/honox/src/hooks/useField/index.ts
@@ -1,0 +1,1 @@
+export * from './useField.ts';

--- a/frameworks/honox/src/hooks/useField/useField.test-d.ts
+++ b/frameworks/honox/src/hooks/useField/useField.test-d.ts
@@ -1,0 +1,71 @@
+import * as v from 'valibot';
+import { describe, expectTypeOf, test } from 'vitest';
+import type { FieldStore, FormStore } from '../../types/index.ts';
+import { useForm } from '../useForm/index.ts';
+import { useField } from './useField.ts';
+
+describe('useField', () => {
+  test('should return a FieldStore typed against the form schema and path', () => {
+    const schema = v.object({ name: v.string() });
+    const form = useForm({ schema });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
+  });
+
+  test('should narrow input type for primitive leaves', () => {
+    const schema = v.object({ name: v.string(), age: v.number() });
+    const form = useForm({ schema });
+
+    expectTypeOf(useField(form, { path: ['name'] }).input).toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf(useField(form, { path: ['age'] }).input).toEqualTypeOf<
+      number | undefined
+    >();
+  });
+
+  test('should narrow input type through nested object and array index paths', () => {
+    const schema = v.object({
+      user: v.object({ email: v.string() }),
+      tags: v.array(v.string()),
+    });
+    const form = useForm({ schema });
+
+    expectTypeOf(
+      useField(form, { path: ['user', 'email'] }).input
+    ).toEqualTypeOf<string | undefined>();
+    expectTypeOf(useField(form, { path: ['tags', 0] }).input).toEqualTypeOf<
+      string | undefined
+    >();
+  });
+
+  test('should accept a partial FormStore typed with a generic object schema (#147)', () => {
+    // Reusable field logic (e.g. a custom hook) types its `FormStore`
+    // parameter with a generic object schema so it accepts any form whose
+    // input includes the required field. This must type-check against
+    // `useField`.
+    function useEmailField(
+      form: FormStore<v.GenericSchema<{ email: string }>>
+    ) {
+      return useField(form, { path: ['email'] });
+    }
+
+    const form = useForm({
+      schema: v.object({ email: v.string(), name: v.string() }),
+    });
+
+    expectTypeOf(useEmailField(form).input).toEqualTypeOf<string | undefined>();
+  });
+
+  test('should reject invalid paths', () => {
+    const schema = v.object({ name: v.string() });
+    const form = useForm({ schema });
+
+    // @ts-expect-error nonexistent field
+    useField(form, { path: ['nonexistent'] });
+
+    // @ts-expect-error path through a string leaf
+    useField(form, { path: ['name', 'nested'] });
+  });
+});

--- a/frameworks/honox/src/hooks/useField/useField.test.tsx
+++ b/frameworks/honox/src/hooks/useField/useField.test.tsx
@@ -1,0 +1,586 @@
+import { getFieldStore, INTERNAL } from '@formisch/core/honox';
+import { reset, swap } from '@formisch/methods/honox';
+import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { useState } from 'hono/jsx';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import * as v from 'valibot';
+import { describe, expect, test, vi } from 'vitest';
+import { Form } from '../../components/Form/index.ts';
+import type { FormStore } from '../../types/index.ts';
+import { renderHono } from '../../vitest/render.tsx';
+import { renderHook } from '../../vitest/renderHook.tsx';
+import { useFieldArray } from '../useFieldArray/index.ts';
+import { useForm } from '../useForm/index.ts';
+import { useField } from './useField.ts';
+
+describe('useField', () => {
+  describe('initialization', () => {
+    test('should return field store with default state and props', () => {
+      const { result } = renderHook(() => {
+        const form = useForm({ schema: v.object({ name: v.string() }) });
+        return useField(form, { path: ['name'] });
+      });
+
+      const field = result.current;
+      expect(field.path).toEqual(['name']);
+      expect(field.input).toBe('');
+      expect(field.errors).toBe(null);
+      expect(field.isTouched).toBe(false);
+      expect(field.isEdited).toBe(false);
+      expect(field.isDirty).toBe(false);
+      expect(field.isValid).toBe(true);
+      expect(field.props.name).toBe('["name"]');
+      expect(field.props.autofocus).toBe(false);
+    });
+
+    test('should reflect initialInput from form', () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: 'John' },
+        });
+        return useField(form, { path: ['name'] });
+      });
+
+      expect(result.current.input).toBe('John');
+    });
+  });
+
+  describe('input updates', () => {
+    test('should update input and isDirty via DOM onChange', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: 'initial' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="dirty">{String(field.isDirty)}</span>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const dirty = screen.getByTestId('dirty');
+      expect(input.value).toBe('initial');
+      expect(dirty).toHaveTextContent('false');
+
+      // hono/jsx maps the `onChange` prop to a native `input` listener, the
+      // same normalization React applies for its synthetic `onChange`
+      flushSync(() => {
+        fireEvent.input(input, { target: { value: 'changed' } });
+      });
+
+      await waitFor(() => {
+        expect(input.value).toBe('changed');
+        expect(dirty).toHaveTextContent('true');
+      });
+    });
+
+    test('should update input and trigger validation via imperative onChange', async () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.email('Invalid email')),
+          }),
+          validate: 'input',
+          initialInput: { email: '' },
+        });
+        return useField(form, { path: ['email'] });
+      });
+
+      flushSync(() => {
+        result.current.onChange('not-an-email');
+      });
+
+      expect(result.current.input).toBe('not-an-email');
+
+      await waitFor(() => {
+        expect(result.current.errors).toEqual(['Invalid email']);
+        expect(result.current.isValid).toBe(false);
+      });
+    });
+  });
+
+  describe('edited state', () => {
+    test('should not set isEdited on focus but should set isTouched', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: '' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input data-testid="input" {...field.props} />
+            <span data-testid="touched">{String(field.isTouched)}</span>
+            <span data-testid="edited">{String(field.isEdited)}</span>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const touched = screen.getByTestId('touched');
+      const edited = screen.getByTestId('edited');
+
+      flushSync(() => {
+        fireEvent.focus(screen.getByTestId('input'));
+      });
+
+      // Focusing marks the field as touched, but not as edited
+      await waitFor(() => {
+        expect(touched).toHaveTextContent('true');
+      });
+      expect(edited).toHaveTextContent('false');
+    });
+
+    test('should set isEdited on input', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: '' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited)}</span>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const edited = screen.getByTestId('edited');
+      expect(edited).toHaveTextContent('false');
+
+      flushSync(() => {
+        fireEvent.input(screen.getByTestId('input'), {
+          target: { value: 'changed' },
+        });
+      });
+
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+      });
+    });
+
+    test('should keep isEdited after reverting the value to its initial value', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({ name: v.string() }),
+          initialInput: { name: 'initial' },
+        });
+        const field = useField(form, { path: ['name'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="edited">{String(field.isEdited)}</span>
+            <span data-testid="dirty">{String(field.isDirty)}</span>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      const edited = screen.getByTestId('edited');
+      const dirty = screen.getByTestId('dirty');
+
+      flushSync(() => {
+        fireEvent.input(input, { target: { value: 'changed' } });
+      });
+      await waitFor(() => {
+        expect(edited).toHaveTextContent('true');
+        expect(dirty).toHaveTextContent('true');
+      });
+
+      // Reverting to the initial value clears isDirty but keeps isEdited
+      flushSync(() => {
+        fireEvent.input(input, { target: { value: 'initial' } });
+      });
+      await waitFor(() => {
+        expect(dirty).toHaveTextContent('false');
+      });
+      expect(edited).toHaveTextContent('true');
+    });
+  });
+
+  describe('validation modes', () => {
+    test('should run validate:"touch" on focus and flip isTouched', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.nonEmpty('Required')),
+          }),
+          validate: 'touch',
+          initialInput: { email: '' },
+        });
+        const field = useField(form, { path: ['email'] });
+        return (
+          <div>
+            <input data-testid="input" {...field.props} />
+            <span data-testid="touched">{String(field.isTouched)}</span>
+            <span data-testid="valid">{String(field.isValid)}</span>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const touched = screen.getByTestId('touched');
+      const valid = screen.getByTestId('valid');
+      expect(touched).toHaveTextContent('false');
+      expect(valid).toHaveTextContent('true');
+
+      flushSync(() => {
+        fireEvent.focus(screen.getByTestId('input'));
+      });
+
+      await waitFor(() => {
+        expect(touched).toHaveTextContent('true');
+        expect(valid).toHaveTextContent('false');
+      });
+    });
+
+    test('should run validate:"input" on change and surface errors', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.email('Invalid email')),
+          }),
+          validate: 'input',
+          initialInput: { email: '' },
+        });
+        const field = useField(form, { path: ['email'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="valid">{String(field.isValid)}</span>
+            {field.errors && <span data-testid="error">{field.errors[0]}</span>}
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const valid = screen.getByTestId('valid');
+      expect(valid).toHaveTextContent('true');
+
+      flushSync(() => {
+        fireEvent.input(screen.getByTestId('input'), {
+          target: { value: 'bad' },
+        });
+      });
+
+      await waitFor(() => {
+        expect(valid).toHaveTextContent('false');
+        expect(screen.getByTestId('error')).toHaveTextContent('Invalid email');
+      });
+    });
+
+    test('should run validate:"blur" on blur and surface errors', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.email('Invalid email')),
+          }),
+          validate: 'blur',
+          initialInput: { email: 'invalid' },
+        });
+        const field = useField(form, { path: ['email'] });
+        return (
+          <div>
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <span data-testid="valid">{String(field.isValid)}</span>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const valid = screen.getByTestId('valid');
+      expect(valid).toHaveTextContent('true');
+
+      flushSync(() => {
+        fireEvent.blur(screen.getByTestId('input'));
+      });
+
+      await waitFor(() => {
+        expect(valid).toHaveTextContent('false');
+      });
+    });
+  });
+
+  describe('store stability', () => {
+    test('should return memoized store reference across re-renders', () => {
+      const { result, rerender } = renderHook(() => {
+        const form = useForm({ schema: v.object({ name: v.string() }) });
+        return useField(form, { path: ['name'] });
+      });
+
+      const first = result.current;
+      rerender();
+      expect(result.current).toBe(first);
+    });
+  });
+
+  describe('element registration', () => {
+    test('should focus the registered element when validation fails on submit', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.nonEmpty('Required')),
+          }),
+          initialInput: { email: '' },
+        });
+        const field = useField(form, { path: ['email'] });
+        return (
+          <Form of={form} onSubmit={vi.fn()} aria-label="Test">
+            <input
+              data-testid="input"
+              {...field.props}
+              value={field.input ?? ''}
+            />
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const input = screen.getByTestId('input');
+      expect(document.activeElement).not.toBe(input);
+
+      // hono/jsx/dom wraps `<form />` with its own submit listener that treats
+      // every untrusted submit event as one of its own form actions, so the
+      // submission is driven through the button the way a user would
+      fireEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(input);
+      });
+    });
+
+    test('should focus a remounted field after reset instead of a stale element', async () => {
+      const schema = v.object({
+        email: v.pipe(v.string(), v.nonEmpty('Required')),
+      });
+
+      // The field lives in its own component so unmounting it runs the
+      // adapter cleanup (which reassigns `elements`), the way a real
+      // conditionally rendered field does
+      function EmailField({
+        form,
+      }: {
+        form: FormStore<typeof schema>;
+      }): JSX.Element {
+        const field = useField(form, { path: ['email'] });
+        return (
+          <input
+            data-testid="input"
+            {...field.props}
+            value={field.input ?? ''}
+          />
+        );
+      }
+
+      function Test(): JSX.Element {
+        const form = useForm({ schema, initialInput: { email: '' } });
+        const [show, setShow] = useState(true);
+        return (
+          <Form of={form} onSubmit={vi.fn()} aria-label="Test">
+            {show && <EmailField form={form} />}
+            <button type="button" onClick={() => setShow((value) => !value)}>
+              toggle
+            </button>
+            <button type="button" onClick={() => reset(form)}>
+              reset
+            </button>
+            <button type="submit">Submit</button>
+          </Form>
+        );
+      }
+
+      renderHono(<Test />);
+
+      // Unmount then remount the field so the adapter cleanup reassigns
+      // `elements` and a stale `initialElements` would diverge
+      flushSync(() => {
+        fireEvent.click(screen.getByText('toggle'));
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('input')).toBeNull();
+      });
+      flushSync(() => {
+        fireEvent.click(screen.getByText('toggle'));
+      });
+      await waitFor(() => {
+        expect(screen.queryByTestId('input')).not.toBeNull();
+      });
+
+      // Reset the form, then submit so validation focuses the first error field
+      flushSync(() => {
+        fireEvent.click(screen.getByText('reset'));
+      });
+      fireEvent.click(screen.getByText('Submit'));
+
+      // Focus must land on the live remounted input, not a detached baseline
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByTestId('input'));
+      });
+    });
+
+    test('should unmount cleanly when the registered element is removed', () => {
+      function Test(): JSX.Element {
+        const form = useForm({ schema: v.object({ name: v.string() }) });
+        const field = useField(form, { path: ['name'] });
+        return <input data-testid="input" {...field.props} />;
+      }
+
+      const { unmount } = renderHono(<Test />);
+      expect(screen.getByTestId('input')).toBeInTheDocument();
+
+      unmount();
+
+      expect(screen.queryByTestId('input')).toBeNull();
+    });
+
+    test('should not register an element that is already present', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = useForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
+        'name',
+      ]);
+      const element = document.createElement('input');
+      // Simulate an array reorder having already transferred the element
+      internalFieldStore.elements.push(element);
+      result.current.field.props.ref(element);
+      expect(internalFieldStore.elements).toEqual([element]);
+    });
+
+    // hono/jsx unregisters through the cleanup returned by the ref, but the
+    // ref signature still allows a `null` call, which must not register
+    // anything nor hand back a cleanup that would unregister the wrong element
+    test('should ignore a ref call without an element', () => {
+      const schema = v.object({ name: v.string() });
+      const { result } = renderHook(() => {
+        const form = useForm({ schema });
+        return { form, field: useField(form, { path: ['name'] }) };
+      });
+      const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
+        'name',
+      ]);
+
+      expect(result.current.field.props.ref(null)).toBeUndefined();
+      expect(internalFieldStore.elements).toEqual([]);
+    });
+
+    test('should not duplicate element registration after an array reorder', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      function Row(props: {
+        form: FormStore<typeof schema>;
+        index: number;
+      }): JSX.Element {
+        const field = useField(props.form, {
+          path: ['todos', props.index, 'label'],
+        });
+        return <input {...field.props} />;
+      }
+
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema,
+          initialInput: { todos: [{ label: 'a' }, { label: 'b' }] },
+        });
+        formStore = form;
+        const fieldArray = useFieldArray(form, { path: ['todos'] });
+        return (
+          <>
+            {fieldArray.items.map((id, index) => (
+              <Row key={id} form={form} index={index} />
+            ))}
+          </>
+        );
+      }
+
+      renderHono(<Test />);
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+      ).toHaveLength(1);
+
+      flushSync(() => {
+        swap(formStore!, { path: ['todos'], at: 0, and: 1 });
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        ).toHaveLength(1);
+        expect(
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+        ).toHaveLength(1);
+      });
+    });
+
+    test('should drop a detached element from the reset baseline after the elements moved', () => {
+      const schema = v.object({ name: v.string() });
+
+      let capturedForm: FormStore<typeof schema> | undefined;
+
+      function Test(): JSX.Element {
+        const form = useForm({ schema, initialInput: { name: '' } });
+        capturedForm = form;
+        const field = useField(form, { path: ['name'] });
+        return <input data-testid="input" {...field.props} />;
+      }
+
+      const { unmount } = renderHono(<Test />);
+      const element = screen.getByTestId('input');
+      const internalFieldStore = getFieldStore(capturedForm![INTERNAL], [
+        'name',
+      ]);
+      expect(internalFieldStore.initialElements).toContain(element);
+
+      // Simulate an array operation moving the elements to another store
+      internalFieldStore.elements = [];
+
+      // The detached element must not survive in the reset baseline
+      unmount();
+      expect(internalFieldStore.initialElements).not.toContain(element);
+    });
+  });
+});

--- a/frameworks/honox/src/hooks/useField/useField.ts
+++ b/frameworks/honox/src/hooks/useField/useField.ts
@@ -1,0 +1,144 @@
+import {
+  type FieldElement,
+  type FormSchema,
+  getElementInput,
+  getFieldBool,
+  getFieldInput,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldBool,
+  setFieldInput,
+  validateIfRequired,
+  type ValidPath,
+} from '@formisch/core/honox';
+import { useMemo } from 'hono/jsx';
+import type * as v from 'valibot';
+import type { FieldStore, FormStore } from '../../types/index.ts';
+import { useSignals } from '../useSignals/index.ts';
+
+/**
+ * Use field config interface.
+ */
+export interface UseFieldConfig<
+  TSchema extends FormSchema = FormSchema,
+  TFieldPath extends RequiredPath = RequiredPath,
+> {
+  /**
+   * The path to the field within the form schema.
+   */
+  readonly path: ValidPath<v.InferInput<TSchema>, TFieldPath>;
+}
+
+/**
+ * Creates a reactive field store for a specific field within a form store.
+ *
+ * @param form The form store instance.
+ * @param config The field configuration.
+ *
+ * @returns The field store with reactive properties and element props.
+ */
+export function useField<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: FormStore<TSchema>,
+  config: UseFieldConfig<TSchema, TFieldPath>
+): FieldStore<TSchema, TFieldPath>;
+
+// @__NO_SIDE_EFFECTS__
+export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
+  useSignals();
+
+  const internalFormStore = form[INTERNAL];
+  const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+  return useMemo(
+    () => ({
+      path: config.path,
+      get input() {
+        return getFieldInput(internalFieldStore);
+      },
+      get errors() {
+        return internalFieldStore.errors.value;
+      },
+      get isTouched() {
+        return getFieldBool(internalFieldStore, 'isTouched');
+      },
+      get isEdited() {
+        return getFieldBool(internalFieldStore, 'isEdited');
+      },
+      get isDirty() {
+        return getFieldBool(internalFieldStore, 'isDirty');
+      },
+      get isValid() {
+        return !getFieldBool(internalFieldStore, 'errors');
+      },
+      onChange(value) {
+        setFieldInput(internalFormStore, config.path, value);
+        validateIfRequired(internalFormStore, internalFieldStore, 'input');
+        validateIfRequired(internalFormStore, internalFieldStore, 'change');
+      },
+      props: {
+        name: internalFieldStore.name,
+        autofocus: !!internalFieldStore.errors.value,
+        ref(element) {
+          if (!element) {
+            return;
+          }
+          // An array reorder transfers registered elements between the field
+          // stores, so the element may already be present when the framework
+          // re-registers it against the destination store
+          if (!internalFieldStore.elements.includes(element)) {
+            internalFieldStore.elements.push(element);
+          }
+          // Hint: Unlike React, hono/jsx runs cleanups before it detaches the
+          // element from the DOM, so a removed element cannot be recognized by
+          // its `isConnected` flag. The cleanup returned here is called by
+          // hono/jsx with the exact element it removes, so it is unregistered
+          // by identity instead.
+          return () => {
+            // Keep `initialElements` aliased to `elements` while the store
+            // still owns it, so that a later reset does not resurrect the
+            // element through a diverged reset baseline
+            const isOwned =
+              internalFieldStore.elements ===
+              internalFieldStore.initialElements;
+            internalFieldStore.elements = internalFieldStore.elements.filter(
+              (registered) => registered !== element
+            );
+            internalFieldStore.initialElements = isOwned
+              ? internalFieldStore.elements
+              : internalFieldStore.initialElements.filter(
+                  (registered) => registered !== element
+                );
+          };
+        },
+        onFocus() {
+          setFieldBool(internalFieldStore, 'isTouched', true);
+          validateIfRequired(internalFormStore, internalFieldStore, 'touch');
+        },
+        onChange(event) {
+          setFieldInput(
+            internalFormStore,
+            config.path,
+            // Hint: Unlike React, hono/jsx types its event handlers with the
+            // native `Event`, whose `currentTarget` is a nullable `EventTarget`.
+            // Narrowing the handler signature instead is not an option, as it
+            // would no longer be assignable to the intrinsic element props.
+            getElementInput(
+              event.currentTarget as FieldElement,
+              internalFieldStore
+            )
+          );
+          validateIfRequired(internalFormStore, internalFieldStore, 'input');
+          validateIfRequired(internalFormStore, internalFieldStore, 'change');
+        },
+        onBlur() {
+          validateIfRequired(internalFormStore, internalFieldStore, 'blur');
+        },
+      },
+    }),
+    [internalFormStore, internalFieldStore]
+  );
+}

--- a/frameworks/honox/src/hooks/useFieldArray/index.ts
+++ b/frameworks/honox/src/hooks/useFieldArray/index.ts
@@ -1,0 +1,1 @@
+export * from './useFieldArray.ts';

--- a/frameworks/honox/src/hooks/useFieldArray/useFieldArray.test-d.ts
+++ b/frameworks/honox/src/hooks/useFieldArray/useFieldArray.test-d.ts
@@ -1,0 +1,74 @@
+import * as v from 'valibot';
+import { describe, expectTypeOf, test } from 'vitest';
+import type { FieldArrayStore } from '../../types/index.ts';
+import { useForm } from '../useForm/index.ts';
+import { useFieldArray } from './useFieldArray.ts';
+
+describe('useFieldArray', () => {
+  test('should return a FieldArrayStore typed against the form schema and path', () => {
+    const schema = v.object({ tags: v.array(v.string()) });
+    const form = useForm({ schema });
+    const fieldArray = useFieldArray(form, { path: ['tags'] });
+
+    expectTypeOf(fieldArray).toEqualTypeOf<
+      FieldArrayStore<typeof schema, ['tags']>
+    >();
+  });
+
+  test('should always type items as string[] regardless of element type', () => {
+    const stringForm = useForm({
+      schema: v.object({ tags: v.array(v.string()) }),
+    });
+    const objectForm = useForm({
+      schema: v.object({
+        users: v.array(v.object({ name: v.string(), age: v.number() })),
+      }),
+    });
+
+    expectTypeOf(
+      useFieldArray(stringForm, { path: ['tags'] }).items
+    ).toEqualTypeOf<string[]>();
+    expectTypeOf(
+      useFieldArray(objectForm, { path: ['users'] }).items
+    ).toEqualTypeOf<string[]>();
+  });
+
+  test('should narrow path through nested array paths', () => {
+    const schema = v.object({
+      user: v.object({ hobbies: v.array(v.string()) }),
+    });
+    const form = useForm({ schema });
+    const fieldArray = useFieldArray(form, { path: ['user', 'hobbies'] });
+
+    expectTypeOf(fieldArray.path).toEqualTypeOf<['user', 'hobbies']>();
+  });
+
+  test('should reject non-array and invalid paths', () => {
+    const schema = v.object({
+      name: v.string(),
+      tags: v.array(v.string()),
+    });
+    const form = useForm({ schema });
+
+    // @ts-expect-error name is a string field, not an array
+    useFieldArray(form, { path: ['name'] });
+
+    // @ts-expect-error nonexistent field
+    useFieldArray(form, { path: ['nonexistent'] });
+  });
+
+  test('should accept an array field present in only some variant options', () => {
+    const schema = v.object({
+      data: v.variant('type', [
+        v.object({ type: v.literal('a'), items: v.array(v.string()) }),
+        v.object({ type: v.literal('b'), name: v.string() }),
+      ]),
+    });
+    const form = useForm({ schema });
+    const fieldArray = useFieldArray(form, { path: ['data', 'items'] });
+
+    expectTypeOf(fieldArray).toEqualTypeOf<
+      FieldArrayStore<typeof schema, ['data', 'items']>
+    >();
+  });
+});

--- a/frameworks/honox/src/hooks/useFieldArray/useFieldArray.test.tsx
+++ b/frameworks/honox/src/hooks/useFieldArray/useFieldArray.test.tsx
@@ -1,0 +1,160 @@
+import { insert, swap } from '@formisch/methods/honox';
+import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import * as v from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { renderHono } from '../../vitest/render.tsx';
+import { renderHook } from '../../vitest/renderHook.tsx';
+import { useForm } from '../useForm/index.ts';
+import { useFieldArray } from './useFieldArray.ts';
+
+describe('useFieldArray', () => {
+  describe('initialization', () => {
+    test('should return field array store with default state and empty items', () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({ items: v.array(v.string()) }),
+        });
+        return useFieldArray(form, { path: ['items'] });
+      });
+
+      const fieldArray = result.current;
+      expect(fieldArray.path).toEqual(['items']);
+      expect(fieldArray.items).toEqual([]);
+      expect(fieldArray.errors).toBe(null);
+      expect(fieldArray.isTouched).toBe(false);
+      expect(fieldArray.isDirty).toBe(false);
+      expect(fieldArray.isValid).toBe(true);
+    });
+
+    test('should reflect initialInput from form', () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({ items: v.array(v.string()) }),
+          initialInput: { items: ['a', 'b', 'c'] },
+        });
+        return useFieldArray(form, { path: ['items'] });
+      });
+
+      expect(result.current.items).toHaveLength(3);
+    });
+  });
+
+  describe('reactivity', () => {
+    test('should grow items when insert is called', () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({ items: v.array(v.string()) }),
+          initialInput: { items: ['a', 'b'] },
+        });
+        const fieldArray = useFieldArray(form, { path: ['items'] });
+        return { form, fieldArray };
+      });
+
+      expect(result.current.fieldArray.items).toHaveLength(2);
+
+      flushSync(() => {
+        insert(result.current.form, {
+          path: ['items'],
+          initialInput: 'c',
+        });
+      });
+
+      expect(result.current.fieldArray.items).toHaveLength(3);
+    });
+
+    test('should preserve item keys when swap is called', () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({ items: v.array(v.string()) }),
+          initialInput: { items: ['a', 'b', 'c'] },
+        });
+        const fieldArray = useFieldArray(form, { path: ['items'] });
+        return { form, fieldArray };
+      });
+
+      const keysBefore = [...result.current.fieldArray.items];
+
+      flushSync(() => {
+        swap(result.current.form, { path: ['items'], at: 0, and: 2 });
+      });
+
+      const keysAfter = [...result.current.fieldArray.items];
+      expect(keysAfter[0]).toBe(keysBefore[2]);
+      expect(keysAfter[1]).toBe(keysBefore[1]);
+      expect(keysAfter[2]).toBe(keysBefore[0]);
+    });
+
+    test('should surface errors and isValid after validation', async () => {
+      const { result } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({
+            items: v.pipe(
+              v.array(v.string()),
+              v.minLength(2, 'Need at least 2 items')
+            ),
+          }),
+          validate: 'initial',
+          initialInput: { items: ['only-one'] },
+        });
+        return useFieldArray(form, { path: ['items'] });
+      });
+
+      await waitFor(() => {
+        expect(result.current.errors).toEqual(['Need at least 2 items']);
+        expect(result.current.isValid).toBe(false);
+      });
+    });
+
+    test('should re-render the component when items change', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({ items: v.array(v.string()) }),
+          initialInput: { items: ['a', 'b'] },
+        });
+        const fieldArray = useFieldArray(form, { path: ['items'] });
+        return (
+          <div>
+            <span data-testid="count">{fieldArray.items.length}</span>
+            <button
+              onClick={() =>
+                insert(form, { path: ['items'], initialInput: 'c' })
+              }
+            >
+              Add
+            </button>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const count = screen.getByTestId('count');
+      expect(count).toHaveTextContent('2');
+
+      flushSync(() => {
+        fireEvent.click(screen.getByText('Add'));
+      });
+
+      await waitFor(() => {
+        expect(count).toHaveTextContent('3');
+      });
+    });
+  });
+
+  describe('store stability', () => {
+    test('should return memoized store reference across re-renders', () => {
+      const { result, rerender } = renderHook(() => {
+        const form = useForm({
+          schema: v.object({ items: v.array(v.string()) }),
+        });
+        return useFieldArray(form, { path: ['items'] });
+      });
+
+      const first = result.current;
+      rerender();
+      expect(result.current).toBe(first);
+    });
+  });
+});

--- a/frameworks/honox/src/hooks/useFieldArray/useFieldArray.ts
+++ b/frameworks/honox/src/hooks/useFieldArray/useFieldArray.ts
@@ -1,0 +1,81 @@
+import {
+  type FormSchema,
+  getFieldBool,
+  getFieldStore,
+  INTERNAL,
+  type InternalArrayStore,
+  type RequiredPath,
+  type ValidArrayPath,
+} from '@formisch/core/honox';
+import { useMemo } from 'hono/jsx';
+import type * as v from 'valibot';
+import type { FieldArrayStore, FormStore } from '../../types/index.ts';
+import { useSignals } from '../useSignals/index.ts';
+
+/**
+ * Use field array config interface.
+ */
+export interface UseFieldArrayConfig<
+  TSchema extends FormSchema = FormSchema,
+  TFieldArrayPath extends RequiredPath = RequiredPath,
+> {
+  /**
+   * The path to the array field within the form schema.
+   */
+  readonly path: ValidArrayPath<v.InferInput<TSchema>, TFieldArrayPath>;
+}
+
+/**
+ * Creates a reactive field array store for a specific field array within a form store.
+ *
+ * @param form The form store instance.
+ * @param config The field array configuration.
+ *
+ * @returns The field array store with reactive properties for array management.
+ */
+export function useFieldArray<
+  TSchema extends FormSchema,
+  TFieldArrayPath extends RequiredPath,
+>(
+  form: FormStore<TSchema>,
+  config: UseFieldArrayConfig<TSchema, TFieldArrayPath>
+): FieldArrayStore<TSchema, TFieldArrayPath>;
+
+// @__NO_SIDE_EFFECTS__
+export function useFieldArray(
+  form: FormStore,
+  config: UseFieldArrayConfig
+): FieldArrayStore {
+  useSignals();
+
+  const internalFormStore = form[INTERNAL];
+  const internalFieldStore = getFieldStore(
+    internalFormStore,
+    config.path
+  ) as InternalArrayStore;
+
+  return useMemo(
+    () => ({
+      path: config.path,
+      get items() {
+        return internalFieldStore.items.value;
+      },
+      get errors() {
+        return internalFieldStore.errors.value;
+      },
+      get isTouched() {
+        return getFieldBool(internalFieldStore, 'isTouched');
+      },
+      get isEdited() {
+        return getFieldBool(internalFieldStore, 'isEdited');
+      },
+      get isDirty() {
+        return getFieldBool(internalFieldStore, 'isDirty');
+      },
+      get isValid() {
+        return !getFieldBool(internalFieldStore, 'errors');
+      },
+    }),
+    [internalFormStore, internalFieldStore]
+  );
+}

--- a/frameworks/honox/src/hooks/useForm/index.ts
+++ b/frameworks/honox/src/hooks/useForm/index.ts
@@ -1,0 +1,1 @@
+export * from './useForm.ts';

--- a/frameworks/honox/src/hooks/useForm/useForm.test-d.ts
+++ b/frameworks/honox/src/hooks/useForm/useForm.test-d.ts
@@ -1,0 +1,23 @@
+import * as v from 'valibot';
+import { describe, expectTypeOf, test } from 'vitest';
+import type { FormStore } from '../../types/index.ts';
+import { useForm } from './useForm.ts';
+
+describe('useForm', () => {
+  test('should return a FormStore typed against the schema', () => {
+    const schema = v.object({ name: v.string() });
+    const form = useForm({ schema });
+
+    expectTypeOf(form).toEqualTypeOf<FormStore<typeof schema>>();
+  });
+
+  test('should accept full, partial, and reject mistyped initialInput', () => {
+    const schema = v.object({ name: v.string(), age: v.number() });
+
+    useForm({ schema, initialInput: { name: 'John', age: 30 } });
+    useForm({ schema, initialInput: { name: 'John' } });
+
+    // @ts-expect-error wrong leaf type
+    useForm({ schema, initialInput: { name: 123 } });
+  });
+});

--- a/frameworks/honox/src/hooks/useForm/useForm.test.tsx
+++ b/frameworks/honox/src/hooks/useForm/useForm.test.tsx
@@ -1,0 +1,105 @@
+import { validate } from '@formisch/methods/honox';
+import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import * as v from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { renderHono } from '../../vitest/render.tsx';
+import { renderHook } from '../../vitest/renderHook.tsx';
+import { useForm } from './useForm.ts';
+
+describe('useForm', () => {
+  describe('initialization', () => {
+    test('should return form store with default state', () => {
+      const { result } = renderHook(() =>
+        useForm({ schema: v.object({ name: v.string() }) })
+      );
+
+      const form = result.current;
+      expect(form.isSubmitting).toBe(false);
+      expect(form.isSubmitted).toBe(false);
+      expect(form.isValidating).toBe(false);
+      expect(form.isTouched).toBe(false);
+      expect(form.isDirty).toBe(false);
+      expect(form.isValid).toBe(true);
+      expect(form.errors).toBe(null);
+    });
+  });
+
+  describe('initial validation', () => {
+    test('should run validation on mount when validate is "initial"', async () => {
+      const { result } = renderHook(() =>
+        useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.email('Invalid email')),
+          }),
+          validate: 'initial',
+          initialInput: { email: 'invalid' },
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isValid).toBe(false);
+      });
+    });
+
+    test('should not run validation on mount otherwise', () => {
+      const { result } = renderHook(() =>
+        useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.email('Invalid email')),
+          }),
+          validate: 'blur',
+          initialInput: { email: 'invalid' },
+        })
+      );
+
+      expect(result.current.isValidating).toBe(false);
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe('reactivity', () => {
+    test('should re-render the component when form state changes', async () => {
+      function Test(): JSX.Element {
+        const form = useForm({
+          schema: v.object({
+            email: v.pipe(v.string(), v.email('Invalid email')),
+          }),
+          initialInput: { email: 'invalid' },
+        });
+        return (
+          <div>
+            <span data-testid="valid">{String(form.isValid)}</span>
+            <button onClick={() => validate(form)}>Validate</button>
+          </div>
+        );
+      }
+
+      renderHono(<Test />);
+
+      const valid = screen.getByTestId('valid');
+      expect(valid).toHaveTextContent('true');
+
+      flushSync(() => {
+        fireEvent.click(screen.getByText('Validate'));
+      });
+
+      await waitFor(() => {
+        expect(valid).toHaveTextContent('false');
+      });
+    });
+  });
+
+  describe('store stability', () => {
+    test('should return memoized store reference across re-renders', () => {
+      const { result, rerender } = renderHook(() =>
+        useForm({ schema: v.object({ name: v.string() }) })
+      );
+
+      const first = result.current;
+      rerender();
+      expect(result.current).toBe(first);
+    });
+  });
+});

--- a/frameworks/honox/src/hooks/useForm/useForm.ts
+++ b/frameworks/honox/src/hooks/useForm/useForm.ts
@@ -1,0 +1,74 @@
+import {
+  createFormStore,
+  type FormConfig,
+  type FormSchema,
+  getFieldBool,
+  INTERNAL,
+  validateFormInput,
+} from '@formisch/core/honox';
+import { useLayoutEffect, useMemo } from 'hono/jsx';
+import * as v from 'valibot';
+import type { FormStore } from '../../types/index.ts';
+import { useSignals } from '../useSignals/index.ts';
+
+/**
+ * Creates a reactive form store from a form configuration. The form store
+ * manages form state and provides reactive properties.
+ *
+ * @param config The form configuration.
+ *
+ * @returns The form store with reactive properties.
+ */
+export function useForm<TSchema extends FormSchema>(
+  config: FormConfig<TSchema>
+): FormStore<TSchema>;
+
+// @__NO_SIDE_EFFECTS__
+export function useForm(config: FormConfig): FormStore {
+  useSignals();
+
+  const internalFormStore = useMemo(
+    () =>
+      createFormStore(config, (input) =>
+        v.safeParseAsync(config.schema, input)
+      ),
+    []
+  );
+
+  useLayoutEffect(() => {
+    if (config.validate === 'initial') {
+      validateFormInput(internalFormStore);
+    }
+  }, []);
+
+  return useMemo(
+    () => ({
+      [INTERNAL]: internalFormStore,
+      get isSubmitting() {
+        return internalFormStore.isSubmitting.value;
+      },
+      get isSubmitted() {
+        return internalFormStore.isSubmitted.value;
+      },
+      get isValidating() {
+        return internalFormStore.isValidating.value;
+      },
+      get isTouched() {
+        return getFieldBool(internalFormStore, 'isTouched');
+      },
+      get isEdited() {
+        return getFieldBool(internalFormStore, 'isEdited');
+      },
+      get isDirty() {
+        return getFieldBool(internalFormStore, 'isDirty');
+      },
+      get isValid() {
+        return !getFieldBool(internalFormStore, 'errors');
+      },
+      get errors() {
+        return internalFormStore.errors.value;
+      },
+    }),
+    [internalFormStore]
+  );
+}

--- a/frameworks/honox/src/hooks/useSignals/index.ts
+++ b/frameworks/honox/src/hooks/useSignals/index.ts
@@ -1,0 +1,1 @@
+export * from './useSignals.ts';

--- a/frameworks/honox/src/hooks/useSignals/useSignals.test.tsx
+++ b/frameworks/honox/src/hooks/useSignals/useSignals.test.tsx
@@ -1,0 +1,181 @@
+import { batch, createSignal } from '@formisch/core/honox';
+import { fireEvent, screen } from '@testing-library/dom';
+import { useState } from 'hono/jsx';
+import { flushSync } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+import { describe, expect, test } from 'vitest';
+import { renderHono } from '../../vitest/render.tsx';
+import { useSignals } from './useSignals.ts';
+
+// Note: React additionally covers a `<StrictMode>` test, because its dev mode
+// mounts, unmounts and re-mounts a component so the subscription cleanup has to
+// survive that cycle. hono/jsx aliases `StrictMode` to a fragment and never
+// re-runs effects on mount, so there is no such cycle to cover here.
+describe('useSignals', () => {
+  describe('signal subscription', () => {
+    test('should re-render the component when a tracked signal changes', () => {
+      const signal = createSignal(0);
+
+      function TrackedComponent(): JSX.Element {
+        useSignals();
+        return <span data-testid="value">{signal.value}</span>;
+      }
+
+      renderHono(<TrackedComponent />);
+      expect(screen.getByTestId('value')).toHaveTextContent('0');
+
+      flushSync(() => {
+        signal.value = 5;
+      });
+
+      expect(screen.getByTestId('value')).toHaveTextContent('5');
+    });
+
+    test('should not re-render the component for signals that were not read', () => {
+      const tracked = createSignal('a');
+      const untracked = createSignal('x');
+      let renderCount = 0;
+
+      function PartialTrackComponent(): JSX.Element {
+        useSignals();
+        renderCount++;
+        return <span data-testid="value">{tracked.value}</span>;
+      }
+
+      renderHono(<PartialTrackComponent />);
+      const initialRenderCount = renderCount;
+
+      flushSync(() => {
+        untracked.value = 'y';
+      });
+
+      expect(renderCount).toBe(initialRenderCount);
+    });
+
+    test('should re-render once per batched signal update cycle', () => {
+      const signalA = createSignal(0);
+      const signalB = createSignal(0);
+      let renderCount = 0;
+
+      function BatchedComponent(): JSX.Element {
+        useSignals();
+        renderCount++;
+        return <span data-testid="sum">{signalA.value + signalB.value}</span>;
+      }
+
+      renderHono(<BatchedComponent />);
+      const initialRenderCount = renderCount;
+
+      flushSync(() => {
+        batch(() => {
+          signalA.value = 1;
+          signalB.value = 2;
+        });
+      });
+
+      expect(screen.getByTestId('sum')).toHaveTextContent('3');
+      // Both signals share a single subscriber, so a single notification fires
+      expect(renderCount - initialRenderCount).toBe(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    test('should not re-render after unmount when a tracked signal changes', () => {
+      const signal = createSignal('initial');
+      let renderCount = 0;
+
+      function TrackedComponent(): JSX.Element {
+        useSignals();
+        renderCount++;
+        return <span data-testid="value">{signal.value}</span>;
+      }
+
+      const { unmount } = renderHono(<TrackedComponent />);
+      const renderCountBeforeUnmount = renderCount;
+
+      unmount();
+
+      flushSync(() => {
+        signal.value = 'after-unmount';
+      });
+
+      expect(renderCount).toBe(renderCountBeforeUnmount);
+    });
+  });
+
+  describe('multiple components', () => {
+    test('should only re-render components that read the changed signal', () => {
+      const signalA = createSignal(0);
+      const signalB = createSignal(0);
+      let renderCountA = 0;
+      let renderCountB = 0;
+
+      function CounterA(): JSX.Element {
+        useSignals();
+        renderCountA++;
+        return <span data-testid="a">{signalA.value}</span>;
+      }
+
+      function CounterB(): JSX.Element {
+        useSignals();
+        renderCountB++;
+        return <span data-testid="b">{signalB.value}</span>;
+      }
+
+      renderHono(
+        <>
+          <CounterA />
+          <CounterB />
+        </>
+      );
+
+      const initialA = renderCountA;
+      const initialB = renderCountB;
+
+      flushSync(() => {
+        signalA.value = 1;
+      });
+
+      expect(screen.getByTestId('a')).toHaveTextContent('1');
+      expect(screen.getByTestId('b')).toHaveTextContent('0');
+      expect(renderCountA - initialA).toBe(1);
+      expect(renderCountB).toBe(initialB);
+    });
+  });
+
+  describe('coexistence with component state', () => {
+    test('should update signals and useState independently in the same component', () => {
+      const signal = createSignal('signal-initial');
+
+      function StateComponent(): JSX.Element {
+        useSignals();
+        const [count, setCount] = useState(0);
+        return (
+          <div>
+            <span data-testid="count">{count}</span>
+            <span data-testid="signal">{signal.value}</span>
+            <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+          </div>
+        );
+      }
+
+      renderHono(<StateComponent />);
+      const count = screen.getByTestId('count');
+      const signalText = screen.getByTestId('signal');
+      expect(count).toHaveTextContent('0');
+      expect(signalText).toHaveTextContent('signal-initial');
+
+      flushSync(() => {
+        fireEvent.click(screen.getByText('Increment'));
+      });
+      expect(count).toHaveTextContent('1');
+      expect(signalText).toHaveTextContent('signal-initial');
+
+      flushSync(() => {
+        signal.value = 'signal-updated';
+      });
+      expect(count).toHaveTextContent('1');
+      expect(signalText).toHaveTextContent('signal-updated');
+    });
+  });
+});

--- a/frameworks/honox/src/hooks/useSignals/useSignals.ts
+++ b/frameworks/honox/src/hooks/useSignals/useSignals.ts
@@ -1,0 +1,46 @@
+import { type Listener, setListener } from '@formisch/core/honox';
+import { useCallback, useLayoutEffect, useMemo, useReducer } from 'hono/jsx';
+
+/**
+ * Hook to enable reactive signals within a hono/jsx component.
+ */
+export function useSignals(): void {
+  // Create a force update function to trigger re-renders
+  //
+  // Hint: Unlike React, hono/jsx's `useReducer` has no special zero-argument
+  // dispatch overload for single-parameter reducers, so the dispatch function
+  // is wrapped to match the zero-argument `Listener` execute function shape.
+  const [, dispatch] = useReducer((count: number) => count + 1, 0);
+  const forceUpdate = useCallback((): void => {
+    dispatch(undefined);
+  }, [dispatch]);
+
+  // Create listener tuple for current component
+  const listener = useMemo<Listener>(() => [forceUpdate, new Set()], []);
+
+  // Create cleanup function to remove listener from subscribers
+  const cleanSubscribers = useCallback(() => {
+    for (const subscriber of listener[1]) {
+      subscriber.delete(listener);
+    }
+  }, [listener]);
+
+  // Clean previously registered subscribers
+  cleanSubscribers();
+
+  // Set listener for tracking signals
+  setListener(listener);
+
+  // Clear listener directly after render
+  useLayoutEffect(() => setListener(undefined));
+
+  // Cleanup registered subscribers on unmount
+  //
+  // Hint: Unlike React, hono/jsx defers `useEffect` callbacks to the next
+  // animation frame, so a component that unmounts before that frame would
+  // never have registered its cleanup and would keep being notified about
+  // signal updates. A layout effect is committed synchronously instead.
+  // hono/jsx also aliases `<StrictMode>` to a fragment and never re-runs
+  // effects on mount, so no timeout is needed to survive a second mount.
+  useLayoutEffect(() => () => cleanSubscribers(), [cleanSubscribers]);
+}

--- a/frameworks/honox/src/index.ts
+++ b/frameworks/honox/src/index.ts
@@ -1,0 +1,19 @@
+export type {
+  DeepPartial,
+  FieldElement,
+  FormConfig,
+  PartialValues,
+  PathValue,
+  RequiredPath,
+  FormSchema,
+  Schema,
+  SubmitEventHandler,
+  SubmitHandler,
+  ValidArrayPath,
+  ValidationMode,
+  ValidPath,
+} from '@formisch/core/honox';
+export * from '@formisch/methods/honox';
+export * from './components/index.ts';
+export * from './hooks/index.ts';
+export * from './types/index.ts';

--- a/frameworks/honox/src/types/field.ts
+++ b/frameworks/honox/src/types/field.ts
@@ -1,0 +1,127 @@
+import type {
+  FieldElement,
+  FormSchema,
+  PartialValues,
+  PathValue,
+  RequiredPath,
+  ValidArrayPath,
+  ValidPath,
+} from '@formisch/core/honox';
+import type * as v from 'valibot';
+
+/**
+ * Field element props interface.
+ */
+export interface FieldElementProps {
+  /**
+   * The name attribute of the field element.
+   */
+  readonly name: string;
+  /**
+   * Whether to autofocus the field element when there are errors.
+   */
+  readonly autofocus: boolean;
+  /**
+   * The ref callback to register the field element.
+   *
+   * Hint: Unlike React, hono/jsx calls the function returned here when it
+   * removes the element again, which is how the field unregisters it.
+   */
+  readonly ref: (element: FieldElement | null) => (() => void) | undefined;
+  /**
+   * The focus event handler of the field element.
+   */
+  readonly onFocus: (event: FocusEvent) => void;
+  /**
+   * The change event handler of the field element.
+   */
+  readonly onChange: (event: Event) => void;
+  /**
+   * The blur event handler of the field element.
+   */
+  readonly onBlur: (event: FocusEvent) => void;
+}
+
+/**
+ * Field store interface.
+ */
+export interface FieldStore<
+  TSchema extends FormSchema = FormSchema,
+  TFieldPath extends RequiredPath = RequiredPath,
+> {
+  /**
+   * The path to the field within the form.
+   */
+  readonly path: ValidPath<v.InferInput<TSchema>, TFieldPath>;
+  /**
+   * The current input value of the field.
+   */
+  readonly input: PartialValues<PathValue<v.InferInput<TSchema>, TFieldPath>>;
+  /**
+   * The current error messages of the field.
+   */
+  readonly errors: [string, ...string[]] | null;
+  /**
+   * Whether the field has been touched.
+   */
+  readonly isTouched: boolean;
+  /**
+   * Whether the field value has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
+   * Whether the field input differs from its initial value.
+   */
+  readonly isDirty: boolean;
+  /**
+   * Whether the field is valid according to the schema.
+   */
+  readonly isValid: boolean;
+  /**
+   * Sets the field input value programmatically.
+   */
+  readonly onChange: (
+    value: PartialValues<PathValue<v.InferInput<TSchema>, TFieldPath>>
+  ) => void;
+  /**
+   * The props to spread onto the field element for integration.
+   */
+  readonly props: FieldElementProps;
+}
+
+/**
+ * Field array store interface.
+ */
+export interface FieldArrayStore<
+  TSchema extends FormSchema = FormSchema,
+  TFieldArrayPath extends RequiredPath = RequiredPath,
+> {
+  /**
+   * The path to the array field within the form.
+   */
+  readonly path: ValidArrayPath<v.InferInput<TSchema>, TFieldArrayPath>;
+  /**
+   * The item IDs of the array field.
+   */
+  readonly items: string[];
+  /**
+   * The current error messages of the field array.
+   */
+  readonly errors: [string, ...string[]] | null;
+  /**
+   * Whether the field array has been touched.
+   */
+  readonly isTouched: boolean;
+  /**
+   * Whether the field array value has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
+   * Whether the field array input differs from its initial value.
+   */
+  readonly isDirty: boolean;
+  /**
+   * Whether the field array is valid according to the schema.
+   */
+  readonly isValid: boolean;
+}

--- a/frameworks/honox/src/types/form.ts
+++ b/frameworks/honox/src/types/form.ts
@@ -1,0 +1,43 @@
+import type { BaseFormStore, FormSchema } from '@formisch/core/honox';
+
+/**
+ * Form store interface.
+ */
+export interface FormStore<TSchema extends FormSchema = FormSchema>
+  extends BaseFormStore<TSchema> {
+  /**
+   * Whether the form is currently submitting.
+   */
+  readonly isSubmitting: boolean;
+  /**
+   * Whether the form has been submitted.
+   */
+  readonly isSubmitted: boolean;
+  /**
+   * Whether the form is currently validating.
+   */
+  readonly isValidating: boolean;
+  /**
+   * Whether any field in the form has been touched.
+   */
+  readonly isTouched: boolean;
+  /**
+   * Whether any field in the form has been edited.
+   */
+  readonly isEdited: boolean;
+  /**
+   * Whether any field in the form differs from its initial value.
+   */
+  readonly isDirty: boolean;
+  /**
+   * Whether the form is valid according to the schema.
+   */
+  readonly isValid: boolean;
+  /**
+   * The current error messages of the form.
+   *
+   * Hint: This property only contains validation errors at the root level
+   * of the form. To get all errors from all fields, use `getDeepErrors`.
+   */
+  readonly errors: [string, ...string[]] | null;
+}

--- a/frameworks/honox/src/types/index.ts
+++ b/frameworks/honox/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './field.ts';
+export * from './form.ts';

--- a/frameworks/honox/src/vitest/render.tsx
+++ b/frameworks/honox/src/vitest/render.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'hono/jsx';
+import { flushSync, render as honoRender } from 'hono/jsx/dom';
+import type { JSX } from 'hono/jsx/jsx-runtime';
+
+/**
+ * Render result interface.
+ */
+export interface RenderResult {
+  /**
+   * The container the JSX node was mounted into.
+   */
+  readonly container: HTMLDivElement;
+  /**
+   * Unmounts the JSX node and removes the container.
+   */
+  readonly unmount: () => void;
+}
+
+/**
+ * The unmount functions of the containers that are still mounted.
+ */
+const mountedUnmountFns = new Set<() => void>();
+
+/**
+ * Mounts a hono/jsx element into a fresh container appended to `document.body`.
+ *
+ * Hint: There is no official `@testing-library/hono` package yet, so this is a
+ * small stand-in for the `render` helper the other framework packages get from
+ * `@testing-library/*`.
+ */
+export function renderHono(jsxNode: JSX.Element): RenderResult {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  // Hint: Rendering into the container a second time builds a fresh tree
+  // instead of diffing against the mounted one, which would drop the DOM
+  // without ever running the effect cleanups. Toggling the children of a root
+  // component makes hono/jsx remove the subtree the way it does in an app.
+  let setMounted: (mounted: boolean) => void = () => {};
+  function Root(): JSX.Element | null {
+    const [mounted, setMountedState] = useState(true);
+    setMounted = setMountedState;
+    return mounted ? jsxNode : null;
+  }
+  honoRender(<Root />, container);
+
+  const unmount = (): void => {
+    flushSync(() => setMounted(false));
+    container.remove();
+    mountedUnmountFns.delete(unmount);
+  };
+  mountedUnmountFns.add(unmount);
+
+  return { container, unmount };
+}
+
+/**
+ * Unmounts every container that is still mounted.
+ */
+export function cleanup(): void {
+  for (const unmount of mountedUnmountFns) {
+    unmount();
+  }
+}

--- a/frameworks/honox/src/vitest/renderHook.tsx
+++ b/frameworks/honox/src/vitest/renderHook.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'hono/jsx';
+import { flushSync } from 'hono/jsx/dom';
+import { renderHono } from './render.tsx';
+
+/**
+ * Render hook result interface.
+ */
+export interface RenderHookResult<TValue> {
+  /**
+   * The latest value returned by the hook.
+   */
+  readonly result: { current: TValue };
+  /**
+   * Re-renders the host component to run the hook again.
+   */
+  readonly rerender: () => void;
+  /**
+   * Unmounts the host component.
+   */
+  readonly unmount: () => void;
+}
+
+/**
+ * Runs a hook inside a host component and exposes its latest return value.
+ *
+ * Hint: There is no official `@testing-library/hono` package yet, so this is a
+ * small stand-in for the `renderHook` helper the other framework packages get
+ * from `@testing-library/*`.
+ */
+export function renderHook<TValue>(
+  hook: () => TValue
+): RenderHookResult<TValue> {
+  const result = { current: undefined as TValue };
+  let forceRerender = (): void => {};
+
+  function HookHost(): null {
+    const [, setRenderCount] = useState(0);
+    forceRerender = () => setRenderCount((count) => count + 1);
+    result.current = hook();
+    return null;
+  }
+
+  const { unmount } = renderHono(<HookHost />);
+
+  return {
+    result,
+    rerender: () => flushSync(forceRerender),
+    unmount,
+  };
+}

--- a/frameworks/honox/src/vitest/setup.ts
+++ b/frameworks/honox/src/vitest/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/dom';
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from './render.tsx';
+
+// Cleanup after each test
+afterEach(() => {
+  cleanup();
+});

--- a/frameworks/honox/tsconfig.json
+++ b/frameworks/honox/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "isolatedDeclarations": true,
+    "declaration": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+
+    /* Hono JSX Config */
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/frameworks/honox/tsdown.config.ts
+++ b/frameworks/honox/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  outDir: 'dist',
+  outExtensions: () => ({
+    js: '.js',
+    dts: '.d.ts',
+  }),
+  dts: {
+    resolve: ['@formisch/core/honox', '@formisch/methods/honox'],
+  },
+});

--- a/frameworks/honox/vitest.config.ts
+++ b/frameworks/honox/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/vitest/setup.ts'],
+    coverage: {
+      include: ['src'],
+      exclude: [
+        'src/types',
+        'src/vitest',
+        '**/index.ts',
+        '**/index.tsx',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/*.test-d.ts',
+      ],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 7.27.1(@babel/core@7.29.7)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
-        version: 5.2.2(@vue/compiler-sfc@3.5.22)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1)
+        version: 5.2.2(@vue/compiler-sfc@3.5.40)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1)
       cve-lite-cli:
         specifier: ^1.17.3
         version: 1.18.1
@@ -65,7 +65,7 @@ importers:
         version: 3.4.0(prettier@3.6.2)(svelte@5.42.1)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
-        version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.22)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1))(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)
+        version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.40)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1))(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -74,7 +74,7 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.5.2
-        version: 2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.20)(stylus@0.62.0)(tailwindcss@4.3.3)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.20)(stylus@0.62.0)(tailwindcss@4.3.3)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@angular/common':
         specifier: ^22.0.0
         version: 22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2)
@@ -123,6 +123,51 @@ importers:
       valibot:
         specifier: ^1.4.1
         version: 1.4.1(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@edge-runtime/vm@3.1.7)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.7)(jsdom@26.1.0)(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+
+  frameworks/honox:
+    devDependencies:
+      '@formisch/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@formisch/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@formisch/methods':
+        specifier: workspace:*
+        version: link:../../packages/methods
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.6.0
+        version: 6.9.1
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.7.0)
+      hono:
+        specifier: 4.12.32
+        version: 4.12.32
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      tsdown:
+        specifier: ^0.16.8
+        version: 0.16.8(publint@0.3.15)(typescript@5.9.3)(vue-tsc@3.1.2(typescript@5.9.3))
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.2(typescript@5.9.3)
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@edge-runtime/vm@3.1.7)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.7)(jsdom@26.1.0)(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
@@ -538,7 +583,7 @@ importers:
         version: 14.6.0(eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.65.0(eslint@9.38.0(jiti@2.7.0))(typescript@5.8.3))(eslint@9.38.0(jiti@2.7.0))(vue-eslint-parser@10.2.0(eslint@9.38.0(jiti@2.7.0))))(eslint@9.38.0(jiti@2.7.0))(typescript@5.8.3)
       '@vue/test-utils':
         specifier: ^2.4.6
-        version: 2.4.10(@vue/compiler-dom@3.5.22)(@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.8.3)))(vue@3.5.22(typescript@5.8.3))
+        version: 2.4.10(@vue/compiler-dom@3.5.40)(@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.8.3)))(vue@3.5.22(typescript@5.8.3))
       eslint:
         specifier: ^9.32.0
         version: 9.38.0(jiti@2.7.0)
@@ -738,7 +783,7 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.5.2
-        version: 2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.6)(stylus@0.62.0)(tailwindcss@4.1.17)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.6)(stylus@0.62.0)(tailwindcss@4.1.17)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@angular/build':
         specifier: ^22.0.0
         version: 22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.6)(stylus@0.62.0)(tailwindcss@4.1.17)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1)
@@ -754,6 +799,55 @@ importers:
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
+      vite:
+        specifier: 7.3.2
+        version: 7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  playgrounds/honox:
+    dependencies:
+      '@formisch/honox':
+        specifier: workspace:*
+        version: link:../../frameworks/honox
+      '@formkit/auto-animate':
+        specifier: ^0.8.2
+        version: 0.8.4
+      '@hono/node-server':
+        specifier: ^1.19.15
+        version: 1.19.15(hono@4.12.32)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      hono:
+        specifier: 4.12.32
+        version: 4.12.32
+      honox:
+        specifier: 0.1.59
+        version: 0.1.59(hono@4.12.32)(miniflare@4.20260603.0)(wrangler@4.98.0)
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.2(typescript@5.9.3)
+    devDependencies:
+      '@formisch/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@hono/vite-build':
+        specifier: 1.11.1
+        version: 1.11.1(hono@4.12.32)
+      '@tailwindcss/vite':
+        specifier: ^4.1.17
+        version: 4.1.17(vite@7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.7.0)
+      tailwindcss:
+        specifier: ^4.1.17
+        version: 4.3.3
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
       vite:
         specifier: 7.3.2
         version: 7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
@@ -851,7 +945,7 @@ importers:
         version: 3.6.2
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
-        version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.22)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1))(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)
+        version: 0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.40)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1))(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.16
@@ -1517,6 +1611,10 @@ packages:
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
@@ -1684,6 +1782,11 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2242,12 +2345,20 @@ packages:
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -2343,6 +2454,10 @@ packages:
   '@deno/shim-deno@0.19.2':
     resolution: {integrity: sha512-q3VTHl44ad8T2Tw2SpeAvghdGOjlnLPDNO2cpOxwMrBE/PVas6geWpbpIgrM+czOCH0yejp0yi8OaTuB+NU40Q==}
 
+  '@dependents/detective-less@5.0.3':
+    resolution: {integrity: sha512-v6oD9Ukp+N7V4n6p5I/+mM5fIohSfkrDSGlFm5w/pYmchvbk+sMIHsLxrFJ5Lnujewj1BzWL0K84d88lwZAMQA==}
+    engines: {node: '>=18'}
+
   '@edge-runtime/cookies@3.4.1':
     resolution: {integrity: sha512-z27BvgPxI73CgSlxU/NAUf1Q/shnqi6cobHEowf6VuLdSjGR3NjI2Y5dZUIBbK2zOJVZbXcHsVzJjz8LklteFQ==}
     engines: {node: '>=16'}
@@ -2375,6 +2490,9 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/runtime@1.6.0':
     resolution: {integrity: sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==}
@@ -3455,6 +3573,31 @@ packages:
 
   '@harperfast/extended-iterable@1.0.3':
     resolution: {integrity: sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==}
+
+  '@hono/node-server@1.19.15':
+    resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/vite-build@1.11.1':
+    resolution: {integrity: sha512-EQJmFL7G+71MXZQ/mmywNl4qW6DSyjTdC30cq7mlDS451a1/jE86old0M2DCWzNGCO50sv7CzQDYkz4L5dq5VQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: '*'
+
+  '@hono/vite-dev-server@0.25.3':
+    resolution: {integrity: sha512-w3uQ0KQF0i/SDcJ6+d5njEFTr6pbolajrt/GxV0pliYL+4ywiBqiOFRWSpwW3mTuZ80boww7+ZxJTGTBIzyBQg==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: '*'
+      miniflare: '*'
+      wrangler: '*'
+    peerDependenciesMeta:
+      miniflare:
+        optional: true
+      wrangler:
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -6478,14 +6621,26 @@ packages:
   '@vue/compiler-core@3.5.22':
     resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
 
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
   '@vue/compiler-dom@3.5.22':
     resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
 
   '@vue/compiler-sfc@3.5.22':
     resolution: {integrity: sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==}
 
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
   '@vue/compiler-ssr@3.5.22':
     resolution: {integrity: sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -6536,6 +6691,9 @@ packages:
 
   '@vue/shared@3.5.22':
     resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
   '@vue/test-utils@2.4.10':
     resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
@@ -6811,6 +6969,10 @@ packages:
 
   ast-metadata-inferer@0.8.1:
     resolution: {integrity: sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==}
+
+  ast-module-types@6.0.2:
+    resolution: {integrity: sha512-6KuK/7nZ/2Qh7sGuVEiwxjCxzTY2Pdb5mTo5z1e6/J8BA0tvjR7G8vQJKrQMTqwmnA3UPEyKIFX4YUS1DO1Hvw==}
+    engines: {node: '>=18'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -7651,6 +7813,49 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  detective-amd@6.1.0:
+    resolution: {integrity: sha512-fmI6LGMvotqd49QaA3ZYw+q0aGp2yXmMjzIuY6fH9j9YFIXY/73yDhMwhX9cPbhWd+AH06NH1Di/LKOuCH0Ubg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  detective-cjs@6.1.1:
+    resolution: {integrity: sha512-pSh7mkCKEtLlmANqLu3KDFS3NV8Hx41jy/JF1/gAWOgU+Uo5QTkeI1tWNP4dWGo4L0E9j18Ez9EPsTleautKqA==}
+    engines: {node: '>=18'}
+
+  detective-es6@5.0.2:
+    resolution: {integrity: sha512-+qHHGYhjupiVs4rnIpI9nZ5B130A4AmE35ZX1w33hb46vcZ7T3jfDbvmPw0FhWtMHn5BS5HHu7ZtnZ53bMcXZA==}
+    engines: {node: '>=18'}
+
+  detective-postcss@7.0.1:
+    resolution: {integrity: sha512-bEOVpHU9picRZux5XnwGsmCN4+8oZo7vSW0O0/Enq/TO5R2pIAP2279NsszpJR7ocnQt4WXU0+nnh/0JuK4KHQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
+    peerDependencies:
+      postcss: ^8.4.47
+
+  detective-sass@6.0.2:
+    resolution: {integrity: sha512-i3xpXHDKS0qI2aFW4asQ7fqlPK00ndOVZELvQapFJCaF0VxYmsNWtd0AmvXbTLMk7bfO5VdIeorhY9KfmHVoVA==}
+    engines: {node: '>=18'}
+
+  detective-scss@5.0.2:
+    resolution: {integrity: sha512-9JOEMZ8pDh3ShXmftq7hoQqqJsClaGgxo1hghfCeFlmKf5TC/Twtwb0PAaK8dXwpg9Z0uCmEYSrCxO+kel2eEg==}
+    engines: {node: '>=18'}
+
+  detective-stylus@5.0.1:
+    resolution: {integrity: sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA==}
+    engines: {node: '>=18'}
+
+  detective-typescript@14.1.2:
+    resolution: {integrity: sha512-bIeEn0eVi/JRsE1YizBR2ilnMlWRAIBJJ6kXCKNFxEEWhUcEY3R6I3KYIAy48ieURbD1hcb3Ebvl8AqeoPMSzg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      typescript: ^5.4.4 || ^6.0.2
+
+  detective-vue2@2.3.0:
+    resolution: {integrity: sha512-3gwbZPqVTm9sL9XdZsgEJ7x4x99O853VVZHapQAiEkGuMJMpFPjHDrecSgfqnS5JW3FJfYXesLZGvUOibjn49g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      typescript: ^5.4.4 || ^6.0.2
+
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
@@ -8165,6 +8370,11 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-expo@57.0.0:
     resolution: {integrity: sha512-T7OTN9xrSZYjLw4qTkL1Mn2WfAUVmMGY38+OYAcraI1uiTFVH6jfkSkv84WLTqnneblLcb6AsMDV+SHcUj3hGw==}
@@ -8821,6 +9031,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-amd-module-type@6.0.2:
+    resolution: {integrity: sha512-7zShVYAYtMnj9S65CfN+hvpBCByfuB1OY8xID01nZEzXTZbx4YyysAfi+nMl95JSR6odt4q8TCj2W63KAoyVLQ==}
+    engines: {node: '>=18'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -8933,6 +9147,11 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  gonzales-pe@4.3.0:
+    resolution: {integrity: sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==}
+    engines: {node: '>=0.6.0'}
+    hasBin: true
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -9040,6 +9259,16 @@ packages:
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
+
+  hono@4.12.32:
+    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+    engines: {node: '>=16.9.0'}
+
+  honox@0.1.59:
+    resolution: {integrity: sha512-/Glbw0/CG/J3yTCrCkyS0+Xnq3H8LgnNgpGgdH3xLZpEDN4c4P4IM/Mjjx7LsKTFrUwbg3s59d/v4uD+YBFuew==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: '>=4.*'
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -9387,6 +9616,13 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-url-superb@4.0.0:
+    resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
+    engines: {node: '>=10'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -10251,6 +10487,11 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  module-definition@6.0.2:
+    resolution: {integrity: sha512-SvAU3lB0+Yjbq55yHY3wkRZBOh+fhU1SnIF3IFbTewv6mtAh7yUT8ACHAJ2mGIJ7tCes2QuCL/cl6m0JSZ/ArA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -10414,6 +10655,10 @@ packages:
 
   node-releases@2.0.26:
     resolution: {integrity: sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==}
+
+  node-source-walk@7.0.2:
+    resolution: {integrity: sha512-71kFFjYaSshDTA8/a2HiTYPLdASWjLJxUyJxGE+ffxU+KhxSBtM9kiLUX+R2yooFdSFKMFpi4n3PFtDy6qXv8A==}
+    engines: {node: '>=18'}
 
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -10844,6 +11089,12 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss-values-parser@6.0.2:
+    resolution: {integrity: sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      postcss: ^8.2.9
+
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
     engines: {node: ^10 || ^12 || >=14}
@@ -10870,6 +11121,11 @@ packages:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  precinct@12.2.0:
+    resolution: {integrity: sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w==}
+    engines: {node: '>=18'}
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -11028,6 +11284,9 @@ packages:
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  quote-unquote@1.0.0:
+    resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -13305,11 +13564,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.20)(stylus@0.62.0)(tailwindcss@4.3.3)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.20)(stylus@0.62.0)(tailwindcss@4.3.3)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
-      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
       tinyglobby: 0.2.16
       ts-morph: 21.0.1
     optionalDependencies:
@@ -13319,11 +13578,11 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.6)(stylus@0.62.0)(tailwindcss@4.1.17)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@analogjs/vite-plugin-angular@2.6.3(@angular/build@22.0.7(@angular/compiler-cli@22.0.7(@angular/compiler@22.0.7)(typescript@6.0.3))(@angular/compiler@22.0.7)(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(@angular/platform-browser@22.0.7(@angular/common@22.0.7(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.0.7(@angular/compiler@22.0.7)(rxjs@7.8.2)))(@types/node@24.10.1)(chokidar@5.0.0)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.6)(stylus@0.62.0)(tailwindcss@4.1.17)(terser@5.44.0)(tslib@2.8.1)(tsx@4.20.6)(typescript@6.0.3)(vitest@4.1.7)(yaml@2.8.1))(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
-      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
       tinyglobby: 0.2.16
       ts-morph: 21.0.1
     optionalDependencies:
@@ -13535,7 +13794,7 @@ snapshots:
 
   '@babel/core@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
@@ -13585,6 +13844,14 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -13867,6 +14134,10 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -14781,6 +15052,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -14797,6 +15080,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.7':
     dependencies:
@@ -14863,6 +15151,11 @@ snapshots:
       '@deno/shim-deno-test': 0.5.0
       which: 4.0.0
 
+  '@dependents/detective-less@5.0.3':
+    dependencies:
+      gonzales-pe: 4.3.0
+      node-source-walk: 7.0.2
+
   '@edge-runtime/cookies@3.4.1': {}
 
   '@edge-runtime/format@2.2.0': {}
@@ -14892,6 +15185,11 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -15817,6 +16115,23 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
+  '@hono/node-server@1.19.15(hono@4.12.32)':
+    dependencies:
+      hono: 4.12.32
+
+  '@hono/vite-build@1.11.1(hono@4.12.32)':
+    dependencies:
+      hono: 4.12.32
+
+  '@hono/vite-dev-server@0.25.3(hono@4.12.32)(miniflare@4.20260603.0)(wrangler@4.98.0)':
+    dependencies:
+      '@hono/node-server': 1.19.15(hono@4.12.32)
+      hono: 4.12.32
+      minimatch: 9.0.7
+    optionalDependencies:
+      miniflare: 4.20260603.0
+      wrangler: 4.98.0
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -16373,6 +16688,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.11.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
@@ -16509,9 +16831,9 @@ snapshots:
   '@oxc-parser/binding-openharmony-arm64@0.121.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-parser/binding-wasm32-wasi@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -16979,20 +17301,20 @@ snapshots:
       '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.7)
       '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.29.7)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.7)
-      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
       '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.7)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.29.7)
-      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.29.7)
@@ -17858,7 +18180,7 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.7)
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/directive-functions-plugin': 1.121.21(vite@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.99.0)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       babel-dead-code-elimination: 1.0.10
@@ -17869,7 +18191,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -17942,7 +18264,7 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.22)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1)':
+  '@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.40)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1)':
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -17952,7 +18274,7 @@ snapshots:
       lodash: 4.18.0
       prettier: 3.6.2
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.22
+      '@vue/compiler-sfc': 3.5.40
       prettier-plugin-svelte: 3.4.0(prettier@3.6.2)(svelte@5.42.1)
       svelte: 5.42.1
     transitivePeerDependencies:
@@ -19259,10 +19581,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.22':
     dependencies:
       '@vue/compiler-core': 3.5.22
       '@vue/shared': 3.5.22
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/compiler-sfc@3.5.22':
     dependencies:
@@ -19276,10 +19611,27 @@ snapshots:
       postcss: 8.5.6
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.20
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.22':
     dependencies:
       '@vue/compiler-dom': 3.5.22
       '@vue/shared': 3.5.22
+
+  '@vue/compiler-ssr@3.5.40':
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -19397,9 +19749,11 @@ snapshots:
 
   '@vue/shared@3.5.22': {}
 
-  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.22)(@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.8.3)))(vue@3.5.22(typescript@5.8.3))':
+  '@vue/shared@3.5.40': {}
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.40)(@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.8.3)))(vue@3.5.22(typescript@5.8.3))':
     dependencies:
-      '@vue/compiler-dom': 3.5.22
+      '@vue/compiler-dom': 3.5.40
       js-beautify: 1.15.4
       vue: 3.5.22(typescript@5.8.3)
       vue-component-type-helpers: 3.2.8
@@ -19683,6 +20037,8 @@ snapshots:
   ast-metadata-inferer@0.8.1:
     dependencies:
       '@mdn/browser-compat-data': 5.7.6
+
+  ast-module-types@6.0.2: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -20562,6 +20918,62 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  detective-amd@6.1.0:
+    dependencies:
+      ast-module-types: 6.0.2
+      escodegen: 2.1.0
+      get-amd-module-type: 6.0.2
+      node-source-walk: 7.0.2
+
+  detective-cjs@6.1.1:
+    dependencies:
+      ast-module-types: 6.0.2
+      node-source-walk: 7.0.2
+
+  detective-es6@5.0.2:
+    dependencies:
+      node-source-walk: 7.0.2
+
+  detective-postcss@7.0.1(postcss@8.5.20):
+    dependencies:
+      is-url: 1.2.4
+      postcss: 8.5.20
+      postcss-values-parser: 6.0.2(postcss@8.5.20)
+
+  detective-sass@6.0.2:
+    dependencies:
+      gonzales-pe: 4.3.0
+      node-source-walk: 7.0.2
+
+  detective-scss@5.0.2:
+    dependencies:
+      gonzales-pe: 4.3.0
+      node-source-walk: 7.0.2
+
+  detective-stylus@5.0.1: {}
+
+  detective-typescript@14.1.2(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      ast-module-types: 6.0.2
+      node-source-walk: 7.0.2
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  detective-vue2@2.3.0(typescript@5.9.3):
+    dependencies:
+      '@dependents/detective-less': 5.0.3
+      '@vue/compiler-sfc': 3.5.40
+      detective-es6: 5.0.2
+      detective-sass: 6.0.2
+      detective-scss: 5.0.2
+      detective-stylus: 5.0.1
+      detective-typescript: 14.1.2(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   devalue@5.8.1: {}
 
   devlop@1.1.0:
@@ -21162,6 +21574,14 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-expo@57.0.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
@@ -22248,6 +22668,11 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-amd-module-type@6.0.2:
+    dependencies:
+      ast-module-types: 6.0.2
+      node-source-walk: 7.0.2
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
@@ -22368,6 +22793,10 @@ snapshots:
       unicorn-magic: 0.3.0
 
   globrex@0.1.2: {}
+
+  gonzales-pe@4.3.0:
+    dependencies:
+      minimist: 1.2.8
 
   gopd@1.2.0: {}
 
@@ -22520,6 +22949,25 @@ snapshots:
       hermes-estree: 0.36.1
 
   hex-rgb@4.3.0: {}
+
+  hono@4.12.32: {}
+
+  honox@0.1.59(hono@4.12.32)(miniflare@4.20260603.0)(wrangler@4.98.0):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@hono/vite-dev-server': 0.25.3(hono@4.12.32)(miniflare@4.20260603.0)(wrangler@4.98.0)
+      hono: 4.12.32
+      jsonc-parser: 3.3.1
+      precinct: 12.2.0
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+    transitivePeerDependencies:
+      - miniflare
+      - supports-color
+      - wrangler
 
   hookable@5.5.3: {}
 
@@ -22862,6 +23310,10 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.19
+
+  is-url-superb@4.0.0: {}
+
+  is-url@1.2.4: {}
 
   is-weakmap@2.0.2: {}
 
@@ -23986,6 +24438,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  module-definition@6.0.2:
+    dependencies:
+      ast-module-types: 6.0.2
+      node-source-walk: 7.0.2
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -24201,6 +24658,10 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.26: {}
+
+  node-source-walk@7.0.2:
+    dependencies:
+      '@babel/parser': 7.29.7
 
   nopt@5.0.0:
     dependencies:
@@ -24423,7 +24884,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-parser@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-parser@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3):
     dependencies:
       '@oxc-project/types': 0.121.0
     optionalDependencies:
@@ -24443,7 +24904,7 @@ snapshots:
       '@oxc-parser/binding-linux-x64-gnu': 0.121.0
       '@oxc-parser/binding-linux-x64-musl': 0.121.0
       '@oxc-parser/binding-openharmony-arm64': 0.121.0
-      '@oxc-parser/binding-wasm32-wasi': 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-parser/binding-wasm32-wasi': 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.3)
       '@oxc-parser/binding-win32-arm64-msvc': 0.121.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.121.0
       '@oxc-parser/binding-win32-x64-msvc': 0.121.0
@@ -24675,6 +25136,13 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
+  postcss-values-parser@6.0.2(postcss@8.5.20):
+    dependencies:
+      color-name: 1.1.4
+      is-url-superb: 4.0.0
+      postcss: 8.5.20
+      quote-unquote: 1.0.0
+
   postcss@8.5.20:
     dependencies:
       nanoid: 3.3.16
@@ -24713,6 +25181,26 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
+  precinct@12.2.0:
+    dependencies:
+      '@dependents/detective-less': 5.0.3
+      commander: 12.1.0
+      detective-amd: 6.1.0
+      detective-cjs: 6.1.1
+      detective-es6: 5.0.2
+      detective-postcss: 7.0.1(postcss@8.5.20)
+      detective-sass: 6.0.2
+      detective-scss: 5.0.2
+      detective-stylus: 5.0.1
+      detective-typescript: 14.1.2(typescript@5.9.3)
+      detective-vue2: 2.3.0(typescript@5.9.3)
+      module-definition: 6.0.2
+      node-source-walk: 7.0.2
+      postcss: 8.5.20
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1):
@@ -24720,11 +25208,11 @@ snapshots:
       prettier: 3.6.2
       svelte: 5.42.1
 
-  prettier-plugin-tailwindcss@0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.22)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1))(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2):
+  prettier-plugin-tailwindcss@0.6.14(@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.40)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1))(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2):
     dependencies:
       prettier: 3.6.2
     optionalDependencies:
-      '@trivago/prettier-plugin-sort-imports': 5.2.2(@vue/compiler-sfc@3.5.22)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1)
+      '@trivago/prettier-plugin-sort-imports': 5.2.2(@vue/compiler-sfc@3.5.40)(prettier-plugin-svelte@3.4.0(prettier@3.6.2)(svelte@5.42.1))(prettier@3.6.2)(svelte@5.42.1)
       prettier-plugin-svelte: 3.4.0(prettier@3.6.2)(svelte@5.42.1)
 
   prettier@3.6.2: {}
@@ -24811,6 +25299,8 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+
+  quote-unquote@1.0.0: {}
 
   radix3@1.1.2: {}
 
@@ -26509,7 +26999,7 @@ snapshots:
       rolldown-plugin-dts: 0.18.1(rolldown@1.0.0-beta.52)(typescript@5.8.3)(vue-tsc@3.1.2(typescript@5.8.3))
       semver: 7.5.2
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.4.1
       unrun: 0.2.14
@@ -26536,7 +27026,7 @@ snapshots:
       rolldown-plugin-dts: 0.18.1(rolldown@1.0.0-beta.52)(typescript@5.9.3)(vue-tsc@3.1.2(typescript@5.9.3))
       semver: 7.5.2
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.4.1
       unrun: 0.2.14


### PR DESCRIPTION
resolves: #175
Adds `@formisch/honox`: `useForm`, `useField`, `useFieldArray` and the `Form`, `Field`, `FieldArray` components, ported from `frameworks/react`. Test names, schemas and expectations match the React package.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>