### PR TITLE
ci: add honox jobs to CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,43 @@ jobs:
         run: pnpm test
         working-directory: frameworks/react-native
 
+  # frameworks/honox
+  honox_prettier:
+    name: Run Prettier in frameworks/honox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup environment
+        uses: ./.github/actions/environment
+      - name: Prettier check
+        run: pnpm format.check
+        working-directory: frameworks/honox
+
+  honox_eslint:
+    name: Run ESLint in frameworks/honox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup environment
+        uses: ./.github/actions/environment
+      - name: ESLint check
+        run: pnpm lint
+        working-directory: frameworks/honox
+
+  honox_vitest:
+    name: Run Vitest in frameworks/honox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup environment
+        uses: ./.github/actions/environment
+      - name: Vitest tests
+        run: pnpm test
+        working-directory: frameworks/honox
+
   # website
   website_prettier:
     name: Run Prettier in website

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,31 @@ jobs:
         working-directory: frameworks/angular
         continue-on-error: true
 
+  honox_npm:
+    name: Publish HonoX to NPM
+    needs: default_ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup environment
+        uses: ./.github/actions/environment
+      - name: Build library
+        run: pnpm build
+        working-directory: frameworks/honox
+      - name: Publish library
+        run: |
+          # Resolve dist-tag from version: stable releases and the v1.0.0 release
+          # candidates go to "latest"; all other prereleases (e.g. later rc, beta,
+          # next) publish under their own tag so they never override a stable.
+          TAG=$(node -p "(() => { const [b, p] = require('./package.json').version.split('-'); const id = p?.split('.')[0]; return !id || (b === '1.0.0' && id === 'rc') ? 'latest' : id; })()")
+          npm publish --access public --tag "$TAG"
+        working-directory: frameworks/honox
+        continue-on-error: true
+
   preact_npm:
     name: Publish Preact to NPM
     needs: default_ci


### PR DESCRIPTION
resolves: #175
Adds the workflow jobs for `@formisch/honox`, matching the other framework packages.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>