### PR TITLE
Simplify focus and blur handler types

### DIFF
--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Fix duplicate element registration in `useField` after array reorders
+- Change the `FieldElementProps` focus and blur handlers to parameterless callbacks
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/frameworks/preact/src/hooks/useField/useField.test-d.ts
+++ b/frameworks/preact/src/hooks/useField/useField.test-d.ts
@@ -14,6 +14,14 @@ describe('useField', () => {
     expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
   });
 
+  test('should expose focus and blur handlers without event parameters', () => {
+    const form = useForm({ schema: v.object({ name: v.string() }) });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field.props.onFocus).toEqualTypeOf<() => void>();
+    expectTypeOf(field.props.onBlur).toEqualTypeOf<() => void>();
+  });
+
   test('should narrow input type for primitive leaves', () => {
     const schema = v.object({ name: v.string(), age: v.number() });
     const form = useForm({ schema });

--- a/frameworks/preact/src/types/field.ts
+++ b/frameworks/preact/src/types/field.ts
@@ -28,7 +28,7 @@ export interface FieldElementProps {
    */
   readonly ref: (element: FieldElement | null) => void;
   /**
-   * Marks the field as touched and runs touch validation.
+   * The focus event handler of the field element.
    */
   readonly onFocus: () => void;
   /**
@@ -40,7 +40,7 @@ export interface FieldElementProps {
    */
   readonly onChange: GenericEventHandler<FieldElement>;
   /**
-   * Runs blur validation for the field.
+   * The blur event handler of the field element.
    */
   readonly onBlur: () => void;
 }

--- a/frameworks/preact/src/types/field.ts
+++ b/frameworks/preact/src/types/field.ts
@@ -8,11 +8,7 @@ import type {
   ValidPath,
 } from '@formisch/core/preact';
 import type { ReadonlySignal } from '@preact/signals';
-import type {
-  FocusEventHandler,
-  GenericEventHandler,
-  InputEventHandler,
-} from 'preact';
+import type { GenericEventHandler, InputEventHandler } from 'preact';
 import type * as v from 'valibot';
 
 /**
@@ -32,9 +28,9 @@ export interface FieldElementProps {
    */
   readonly ref: (element: FieldElement | null) => void;
   /**
-   * The focus event handler of the field element.
+   * Marks the field as touched and runs touch validation.
    */
-  readonly onFocus: FocusEventHandler<FieldElement>;
+  readonly onFocus: () => void;
   /**
    * The input event handler of the field element.
    */
@@ -44,9 +40,9 @@ export interface FieldElementProps {
    */
   readonly onChange: GenericEventHandler<FieldElement>;
   /**
-   * The blur event handler of the field element.
+   * Runs blur validation for the field.
    */
-  readonly onBlur: FocusEventHandler<FieldElement>;
+  readonly onBlur: () => void;
 }
 
 /**

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the library will be documented in this file.
 
 - Fix duplicate element registration in `useField` after array reorders
 - Fix `useField` cleanup to drop detached elements from the reset baseline
+- Change the `FieldElementProps` focus and blur handlers to parameterless callbacks
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/frameworks/qwik/src/types/field.ts
+++ b/frameworks/qwik/src/types/field.ts
@@ -27,7 +27,7 @@ export interface FieldElementProps {
    */
   readonly ref: QRL<(element: FieldElement) => void>;
   /**
-   * Marks the field as touched and runs touch validation.
+   * The focus event handler of the field element.
    */
   readonly onFocus$: QRL<() => void>;
   /**
@@ -39,7 +39,7 @@ export interface FieldElementProps {
    */
   readonly onChange$: QRL<(event: Event, element: FieldElement) => void>;
   /**
-   * Runs blur validation for the field.
+   * The blur event handler of the field element.
    */
   readonly onBlur$: QRL<() => void>;
 }

--- a/frameworks/qwik/src/types/field.ts
+++ b/frameworks/qwik/src/types/field.ts
@@ -27,9 +27,9 @@ export interface FieldElementProps {
    */
   readonly ref: QRL<(element: FieldElement) => void>;
   /**
-   * The focus event handler of the field element.
+   * Marks the field as touched and runs touch validation.
    */
-  readonly onFocus$: QRL<(event: FocusEvent, element: FieldElement) => void>;
+  readonly onFocus$: QRL<() => void>;
   /**
    * The input event handler of the field element.
    */
@@ -39,9 +39,9 @@ export interface FieldElementProps {
    */
   readonly onChange$: QRL<(event: Event, element: FieldElement) => void>;
   /**
-   * The blur event handler of the field element.
+   * Runs blur validation for the field.
    */
-  readonly onBlur$: QRL<(event: FocusEvent, element: FieldElement) => void>;
+  readonly onBlur$: QRL<() => void>;
 }
 
 /**

--- a/frameworks/react-native/src/hooks/useField/useField.test-d.ts
+++ b/frameworks/react-native/src/hooks/useField/useField.test-d.ts
@@ -13,6 +13,14 @@ describe('useField', () => {
     expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
   });
 
+  test('should expose focus and blur handlers without event parameters', () => {
+    const form = useForm({ schema: v.object({ name: v.string() }) });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field.props.onFocus).toEqualTypeOf<() => void>();
+    expectTypeOf(field.props.onBlur).toEqualTypeOf<() => void>();
+  });
+
   test('should narrow input type for primitive leaves', () => {
     const schema = v.object({ name: v.string(), age: v.number() });
     const form = useForm({ schema });

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the library will be documented in this file.
 
 - Fix duplicate element registration in `useField` after array reorders
 - Fix `useField` cleanup to drop detached elements from the reset baseline
+- Change the `FieldElementProps` focus and blur handlers to parameterless callbacks
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/frameworks/react/src/hooks/useField/useField.test-d.ts
+++ b/frameworks/react/src/hooks/useField/useField.test-d.ts
@@ -13,6 +13,14 @@ describe('useField', () => {
     expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
   });
 
+  test('should expose focus and blur handlers without event parameters', () => {
+    const form = useForm({ schema: v.object({ name: v.string() }) });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field.props.onFocus).toEqualTypeOf<() => void>();
+    expectTypeOf(field.props.onBlur).toEqualTypeOf<() => void>();
+  });
+
   test('should narrow input type for primitive leaves', () => {
     const schema = v.object({ name: v.string(), age: v.number() });
     const form = useForm({ schema });

--- a/frameworks/react/src/types/field.ts
+++ b/frameworks/react/src/types/field.ts
@@ -27,7 +27,7 @@ export interface FieldElementProps {
    */
   readonly ref: (element: FieldElement | null) => void;
   /**
-   * Marks the field as touched and runs touch validation.
+   * The focus event handler of the field element.
    */
   readonly onFocus: () => void;
   /**
@@ -35,7 +35,7 @@ export interface FieldElementProps {
    */
   readonly onChange: ChangeEventHandler<FieldElement>;
   /**
-   * Runs blur validation for the field.
+   * The blur event handler of the field element.
    */
   readonly onBlur: () => void;
 }

--- a/frameworks/react/src/types/field.ts
+++ b/frameworks/react/src/types/field.ts
@@ -7,7 +7,7 @@ import type {
   ValidArrayPath,
   ValidPath,
 } from '@formisch/core/react';
-import type { ChangeEventHandler, FocusEventHandler } from 'react';
+import type { ChangeEventHandler } from 'react';
 import type * as v from 'valibot';
 
 /**
@@ -27,17 +27,17 @@ export interface FieldElementProps {
    */
   readonly ref: (element: FieldElement | null) => void;
   /**
-   * The focus event handler of the field element.
+   * Marks the field as touched and runs touch validation.
    */
-  readonly onFocus: FocusEventHandler<FieldElement>;
+  readonly onFocus: () => void;
   /**
    * The change event handler of the field element.
    */
   readonly onChange: ChangeEventHandler<FieldElement>;
   /**
-   * The blur event handler of the field element.
+   * Runs blur validation for the field.
    */
-  readonly onBlur: FocusEventHandler<FieldElement>;
+  readonly onBlur: () => void;
 }
 
 /**

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the library will be documented in this file.
 
 - Fix duplicate element registration in `useField` after array reorders
 - Fix `useField` cleanup to drop detached elements from the reset baseline
+- Change the `FieldElementProps` focus and blur handlers to parameterless callbacks
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/frameworks/solid/src/primitives/useField/useField.test-d.ts
+++ b/frameworks/solid/src/primitives/useField/useField.test-d.ts
@@ -13,6 +13,14 @@ describe('useField', () => {
     expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
   });
 
+  test('should expose focus and blur handlers without event parameters', () => {
+    const form = createForm({ schema: v.object({ name: v.string() }) });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field.props.onFocus).toEqualTypeOf<() => void>();
+    expectTypeOf(field.props.onBlur).toEqualTypeOf<() => void>();
+  });
+
   test('should narrow input type for primitive leaves', () => {
     const schema = v.object({ name: v.string(), age: v.number() });
     const form = createForm({ schema });

--- a/frameworks/solid/src/types/field.ts
+++ b/frameworks/solid/src/types/field.ts
@@ -27,7 +27,7 @@ export interface FieldElementProps {
    */
   readonly ref: (element: FieldElement) => void;
   /**
-   * Marks the field as touched and runs touch validation.
+   * The focus event handler of the field element.
    */
   readonly onFocus: () => void;
   /**
@@ -39,7 +39,7 @@ export interface FieldElementProps {
    */
   readonly onChange: JSX.EventHandler<FieldElement, Event>;
   /**
-   * Runs blur validation for the field.
+   * The blur event handler of the field element.
    */
   readonly onBlur: () => void;
 }

--- a/frameworks/solid/src/types/field.ts
+++ b/frameworks/solid/src/types/field.ts
@@ -27,9 +27,9 @@ export interface FieldElementProps {
    */
   readonly ref: (element: FieldElement) => void;
   /**
-   * The focus event handler of the field element.
+   * Marks the field as touched and runs touch validation.
    */
-  readonly onFocus: JSX.EventHandler<FieldElement, FocusEvent>;
+  readonly onFocus: () => void;
   /**
    * The input event handler of the field element.
    */
@@ -39,9 +39,9 @@ export interface FieldElementProps {
    */
   readonly onChange: JSX.EventHandler<FieldElement, Event>;
   /**
-   * The blur event handler of the field element.
+   * Runs blur validation for the field.
    */
-  readonly onBlur: JSX.EventHandler<FieldElement, FocusEvent>;
+  readonly onBlur: () => void;
 }
 
 /**

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Fix duplicate element registration in `useField` after array reorders
+- Change the `FieldElementProps` focus and blur handlers to parameterless callbacks
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/frameworks/svelte/src/runes/useField/useField.test-d.ts
+++ b/frameworks/svelte/src/runes/useField/useField.test-d.ts
@@ -13,6 +13,14 @@ describe('useField', () => {
     expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
   });
 
+  test('should expose focus and blur handlers without event parameters', () => {
+    const form = createForm({ schema: v.object({ name: v.string() }) });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field.props.onfocus).toEqualTypeOf<() => void>();
+    expectTypeOf(field.props.onblur).toEqualTypeOf<() => void>();
+  });
+
   test('should narrow input type for primitive leaves', () => {
     const schema = v.object({ name: v.string(), age: v.number() });
     const form = createForm({ schema });

--- a/frameworks/svelte/src/types/field.ts
+++ b/frameworks/svelte/src/types/field.ts
@@ -27,7 +27,7 @@ export interface FieldElementProps {
    */
   readonly [ref: symbol]: (element: FieldElement) => () => void;
   /**
-   * Marks the field as touched and runs touch validation.
+   * The focus event handler of the field element.
    */
   readonly onfocus: () => void;
   /**
@@ -39,7 +39,7 @@ export interface FieldElementProps {
    */
   readonly onchange: FormEventHandler<FieldElement>;
   /**
-   * Runs blur validation for the field.
+   * The blur event handler of the field element.
    */
   readonly onblur: () => void;
 }

--- a/frameworks/svelte/src/types/field.ts
+++ b/frameworks/svelte/src/types/field.ts
@@ -7,7 +7,7 @@ import type {
   ValidArrayPath,
   ValidPath,
 } from '@formisch/core/svelte';
-import type { FocusEventHandler, FormEventHandler } from 'svelte/elements';
+import type { FormEventHandler } from 'svelte/elements';
 import type * as v from 'valibot';
 
 /**
@@ -27,9 +27,9 @@ export interface FieldElementProps {
    */
   readonly [ref: symbol]: (element: FieldElement) => () => void;
   /**
-   * The focus event handler of the field element.
+   * Marks the field as touched and runs touch validation.
    */
-  readonly onfocus: FocusEventHandler<FieldElement>;
+  readonly onfocus: () => void;
   /**
    * The input event handler of the field element.
    */
@@ -39,9 +39,9 @@ export interface FieldElementProps {
    */
   readonly onchange: FormEventHandler<FieldElement>;
   /**
-   * The blur event handler of the field element.
+   * Runs blur validation for the field.
    */
-  readonly onblur: FocusEventHandler<FieldElement>;
+  readonly onblur: () => void;
 }
 
 /**

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the library will be documented in this file.
 
 - Fix duplicate element registration in `useField` after array reorders
 - Fix `useField` cleanup to drop detached elements from the reset baseline
+- Change the `FieldElementProps` focus and blur handlers to parameterless callbacks
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/frameworks/vue/src/composables/useField/useField.test-d.ts
+++ b/frameworks/vue/src/composables/useField/useField.test-d.ts
@@ -13,6 +13,14 @@ describe('useField', () => {
     expectTypeOf(field).toEqualTypeOf<FieldStore<typeof schema, ['name']>>();
   });
 
+  test('should expose focus and blur handlers without event parameters', () => {
+    const form = useForm({ schema: v.object({ name: v.string() }) });
+    const field = useField(form, { path: ['name'] });
+
+    expectTypeOf(field.props.onFocus).toEqualTypeOf<() => void>();
+    expectTypeOf(field.props.onBlur).toEqualTypeOf<() => void>();
+  });
+
   test('should narrow input type for primitive leaves', () => {
     const schema = v.object({ name: v.string(), age: v.number() });
     const form = useForm({ schema });

--- a/frameworks/vue/src/types/field.ts
+++ b/frameworks/vue/src/types/field.ts
@@ -26,7 +26,7 @@ export interface FieldElementProps {
    */
   readonly ref: (element: Element | ComponentPublicInstance | null) => void;
   /**
-   * Marks the field as touched and runs touch validation.
+   * The focus event handler of the field element.
    */
   readonly onFocus: () => void;
   /**
@@ -34,7 +34,7 @@ export interface FieldElementProps {
    */
   readonly onChange: (event: Event) => void;
   /**
-   * Runs blur validation for the field.
+   * The blur event handler of the field element.
    */
   readonly onBlur: () => void;
 }

--- a/frameworks/vue/src/types/field.ts
+++ b/frameworks/vue/src/types/field.ts
@@ -26,17 +26,17 @@ export interface FieldElementProps {
    */
   readonly ref: (element: Element | ComponentPublicInstance | null) => void;
   /**
-   * The focus event handler of the field element.
+   * Marks the field as touched and runs touch validation.
    */
-  readonly onFocus: (event: FocusEvent) => void;
+  readonly onFocus: () => void;
   /**
    * The change event handler of the field element.
    */
   readonly onChange: (event: Event) => void;
   /**
-   * The blur event handler of the field element.
+   * Runs blur validation for the field.
    */
-  readonly onBlur: (event: FocusEvent) => void;
+  readonly onBlur: () => void;
 }
 
 /**

--- a/website/src/routes/(docs)/preact/api/(types)/FieldElementProps/index.mdx
+++ b/website/src/routes/(docs)/preact/api/(types)/FieldElementProps/index.mdx
@@ -23,3 +23,7 @@ Props to spread onto a field element for integration with Preact form handling.
   - `onInput` <Property {...properties.onInput} />
   - `onChange` <Property {...properties.onChange} />
   - `onBlur` <Property {...properties.onBlur} />
+
+### Explanation
+
+`onFocus` marks the field as touched and runs the configured `'touch'` validation, while `onBlur` runs the configured `'blur'` validation. Neither handler uses the event object, so both are typed as `() => void` and can be passed to native elements or custom components with different focus event types.

--- a/website/src/routes/(docs)/preact/api/(types)/FieldElementProps/properties.ts
+++ b/website/src/routes/(docs)/preact/api/(types)/FieldElementProps/properties.ts
@@ -39,15 +39,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onFocus',
           value: {
-            type: 'custom',
-            name: 'JSX.FocusEventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
         {
@@ -81,15 +75,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onBlur',
           value: {
-            type: 'custom',
-            name: 'JSX.FocusEventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
       ],
@@ -125,15 +113,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onFocus: {
     type: {
-      type: 'custom',
-      name: 'JSX.FocusEventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
   onInput: {
@@ -164,15 +146,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onBlur: {
     type: {
-      type: 'custom',
-      name: 'JSX.FocusEventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
 };

--- a/website/src/routes/(docs)/qwik/api/(types)/FieldElementProps/index.mdx
+++ b/website/src/routes/(docs)/qwik/api/(types)/FieldElementProps/index.mdx
@@ -23,3 +23,7 @@ Props to spread onto a field element for integration with Qwik form handling.
   - `onInput$` <Property {...properties.onInput$} />
   - `onChange$` <Property {...properties.onChange$} />
   - `onBlur$` <Property {...properties.onBlur$} />
+
+### Explanation
+
+`onFocus$` marks the field as touched and runs the configured `'touch'` validation, while `onBlur$` runs the configured `'blur'` validation. Neither handler uses the event object, so their wrapped callbacks are typed as `() => void` and can be passed to native elements or custom components with different focus event types.

--- a/website/src/routes/(docs)/qwik/api/(types)/FieldElementProps/properties.ts
+++ b/website/src/routes/(docs)/qwik/api/(types)/FieldElementProps/properties.ts
@@ -44,23 +44,7 @@ export const properties: Record<string, PropertyProps> = {
             generics: [
               {
                 type: 'function',
-                params: [
-                  {
-                    name: 'event',
-                    type: {
-                      type: 'custom',
-                      name: 'FocusEvent',
-                    },
-                  },
-                  {
-                    name: 'element',
-                    type: {
-                      type: 'custom',
-                      name: 'FieldElement',
-                      href: '/core/api/FieldElement/',
-                    },
-                  },
-                ],
+                params: [],
                 return: 'void',
               },
             ],
@@ -134,23 +118,7 @@ export const properties: Record<string, PropertyProps> = {
             generics: [
               {
                 type: 'function',
-                params: [
-                  {
-                    name: 'event',
-                    type: {
-                      type: 'custom',
-                      name: 'FocusEvent',
-                    },
-                  },
-                  {
-                    name: 'element',
-                    type: {
-                      type: 'custom',
-                      name: 'FieldElement',
-                      href: '/core/api/FieldElement/',
-                    },
-                  },
-                ],
+                params: [],
                 return: 'void',
               },
             ],
@@ -194,23 +162,7 @@ export const properties: Record<string, PropertyProps> = {
       generics: [
         {
           type: 'function',
-          params: [
-            {
-              name: 'event',
-              type: {
-                type: 'custom',
-                name: 'FocusEvent',
-              },
-            },
-            {
-              name: 'element',
-              type: {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            },
-          ],
+          params: [],
           return: 'void',
         },
       ],
@@ -281,23 +233,7 @@ export const properties: Record<string, PropertyProps> = {
       generics: [
         {
           type: 'function',
-          params: [
-            {
-              name: 'event',
-              type: {
-                type: 'custom',
-                name: 'FocusEvent',
-              },
-            },
-            {
-              name: 'element',
-              type: {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            },
-          ],
+          params: [],
           return: 'void',
         },
       ],

--- a/website/src/routes/(docs)/react/api/(types)/FieldElementProps/index.mdx
+++ b/website/src/routes/(docs)/react/api/(types)/FieldElementProps/index.mdx
@@ -22,3 +22,7 @@ Props to spread onto a field element for integration with React form handling.
   - `onFocus` <Property {...properties.onFocus} />
   - `onChange` <Property {...properties.onChange} />
   - `onBlur` <Property {...properties.onBlur} />
+
+### Explanation
+
+`onFocus` marks the field as touched and runs the configured `'touch'` validation, while `onBlur` runs the configured `'blur'` validation. Neither handler uses the event object, so both are typed as `() => void` and can be passed to native elements or custom components with different focus event types.

--- a/website/src/routes/(docs)/react/api/(types)/FieldElementProps/properties.ts
+++ b/website/src/routes/(docs)/react/api/(types)/FieldElementProps/properties.ts
@@ -39,15 +39,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onFocus',
           value: {
-            type: 'custom',
-            name: 'FocusEventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
         {
@@ -67,15 +61,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onBlur',
           value: {
-            type: 'custom',
-            name: 'FocusEventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
       ],
@@ -111,15 +99,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onFocus: {
     type: {
-      type: 'custom',
-      name: 'FocusEventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
   onChange: {
@@ -137,15 +119,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onBlur: {
     type: {
-      type: 'custom',
-      name: 'FocusEventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
 };

--- a/website/src/routes/(docs)/solid/api/(types)/FieldElementProps/index.mdx
+++ b/website/src/routes/(docs)/solid/api/(types)/FieldElementProps/index.mdx
@@ -23,3 +23,7 @@ Props to spread onto a field element for integration with SolidJS form handling.
   - `onInput` <Property {...properties.onInput} />
   - `onChange` <Property {...properties.onChange} />
   - `onBlur` <Property {...properties.onBlur} />
+
+### Explanation
+
+`onFocus` marks the field as touched and runs the configured `'touch'` validation, while `onBlur` runs the configured `'blur'` validation. Neither handler uses the event object, so both are typed as `() => void` and can be passed to native elements or custom components with different focus event types.

--- a/website/src/routes/(docs)/solid/api/(types)/FieldElementProps/properties.ts
+++ b/website/src/routes/(docs)/solid/api/(types)/FieldElementProps/properties.ts
@@ -33,19 +33,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onFocus',
           value: {
-            type: 'custom',
-            name: 'EventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-              {
-                type: 'custom',
-                name: 'FocusEvent',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
         {
@@ -87,19 +77,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onBlur',
           value: {
-            type: 'custom',
-            name: 'EventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-              {
-                type: 'custom',
-                name: 'FocusEvent',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
       ],
@@ -129,19 +109,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onFocus: {
     type: {
-      type: 'custom',
-      name: 'EventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-        {
-          type: 'custom',
-          name: 'FocusEvent',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
   onInput: {
@@ -180,19 +150,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onBlur: {
     type: {
-      type: 'custom',
-      name: 'EventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-        {
-          type: 'custom',
-          name: 'FocusEvent',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
 };

--- a/website/src/routes/(docs)/svelte/api/(types)/FieldElementProps/index.mdx
+++ b/website/src/routes/(docs)/svelte/api/(types)/FieldElementProps/index.mdx
@@ -23,3 +23,7 @@ Props to spread onto a field element for integration with Svelte form handling.
   - `oninput` <Property {...properties.oninput} />
   - `onchange` <Property {...properties.onchange} />
   - `onblur` <Property {...properties.onblur} />
+
+### Explanation
+
+`onfocus` marks the field as touched and runs the configured `'touch'` validation, while `onblur` runs the configured `'blur'` validation. Neither handler uses the event object, so both are typed as `() => void` and can be passed to native elements or custom components with different focus event types.

--- a/website/src/routes/(docs)/svelte/api/(types)/FieldElementProps/properties.ts
+++ b/website/src/routes/(docs)/svelte/api/(types)/FieldElementProps/properties.ts
@@ -37,15 +37,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onfocus',
           value: {
-            type: 'custom',
-            name: 'FocusEventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
         {
@@ -79,15 +73,9 @@ export const properties: Record<string, PropertyProps> = {
         {
           key: 'onblur',
           value: {
-            type: 'custom',
-            name: 'FocusEventHandler',
-            generics: [
-              {
-                type: 'custom',
-                name: 'FieldElement',
-                href: '/core/api/FieldElement/',
-              },
-            ],
+            type: 'function',
+            params: [],
+            return: 'void',
           },
         },
       ],
@@ -121,15 +109,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onfocus: {
     type: {
-      type: 'custom',
-      name: 'FocusEventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
   oninput: {
@@ -160,15 +142,9 @@ export const properties: Record<string, PropertyProps> = {
   },
   onblur: {
     type: {
-      type: 'custom',
-      name: 'FocusEventHandler',
-      generics: [
-        {
-          type: 'custom',
-          name: 'FieldElement',
-          href: '/core/api/FieldElement/',
-        },
-      ],
+      type: 'function',
+      params: [],
+      return: 'void',
     },
   },
 };

--- a/website/src/routes/(docs)/vue/api/(types)/FieldElementProps/index.mdx
+++ b/website/src/routes/(docs)/vue/api/(types)/FieldElementProps/index.mdx
@@ -22,3 +22,7 @@ Props to spread onto a field element for integration with Vue form handling.
   - `onFocus` <Property {...properties.onFocus} />
   - `onChange` <Property {...properties.onChange} />
   - `onBlur` <Property {...properties.onBlur} />
+
+### Explanation
+
+`onFocus` marks the field as touched and runs the configured `'touch'` validation, while `onBlur` runs the configured `'blur'` validation. Neither handler uses the event object, so both are typed as `() => void` and can be passed to native elements or custom components with different focus event types.

--- a/website/src/routes/(docs)/vue/api/(types)/FieldElementProps/properties.ts
+++ b/website/src/routes/(docs)/vue/api/(types)/FieldElementProps/properties.ts
@@ -43,15 +43,7 @@ export const properties: Record<string, PropertyProps> = {
           key: 'onFocus',
           value: {
             type: 'function',
-            params: [
-              {
-                name: 'event',
-                type: {
-                  type: 'custom',
-                  name: 'FocusEvent',
-                },
-              },
-            ],
+            params: [],
             return: 'void',
           },
         },
@@ -75,15 +67,7 @@ export const properties: Record<string, PropertyProps> = {
           key: 'onBlur',
           value: {
             type: 'function',
-            params: [
-              {
-                name: 'event',
-                type: {
-                  type: 'custom',
-                  name: 'FocusEvent',
-                },
-              },
-            ],
+            params: [],
             return: 'void',
           },
         },
@@ -124,15 +108,7 @@ export const properties: Record<string, PropertyProps> = {
   onFocus: {
     type: {
       type: 'function',
-      params: [
-        {
-          name: 'event',
-          type: {
-            type: 'custom',
-            name: 'FocusEvent',
-          },
-        },
-      ],
+      params: [],
       return: 'void',
     },
   },
@@ -154,15 +130,7 @@ export const properties: Record<string, PropertyProps> = {
   onBlur: {
     type: {
       type: 'function',
-      params: [
-        {
-          name: 'event',
-          type: {
-            type: 'custom',
-            name: 'FocusEvent',
-          },
-        },
-      ],
+      params: [],
       return: 'void',
     },
   },


### PR DESCRIPTION
## Summary

- change `FieldElementProps` focus and blur handlers to parameterless callbacks in Preact, Qwik, React, Solid, Svelte, and Vue
- add type-level regression coverage and changelog entries
- update the affected website API signatures and explain the handlers' lifecycle behavior

## Why

The focus and blur handlers do not consume their framework event objects. They only update touched state and trigger the configured touch or blur validation. Framework-specific focus event types therefore made controlled component integrations require unnecessary casts and could conflict with component libraries that expose different event types.

Using `() => void` keeps the handlers compatible with native controls while making them easier to forward to custom components. Angular and React Native already used parameterless handlers; React Native now also has regression coverage.

## Validation

- framework type tests for Preact, React, React Native, Solid, Svelte, and Vue
- production builds for all framework packages
- ESLint and TypeScript checks for every affected framework, including Qwik
- website ESLint and TypeScript checks
- website client production build and static server/SSG build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Focus and blur field handlers now use simple parameterless callbacks across supported frameworks.
  * Field focus triggers touch validation, while blur triggers blur validation.
* **Documentation**
  * Updated API references and changelogs to explain the new callback signatures and validation behavior.
* **Tests**
  * Added type checks confirming focus and blur handlers accept no arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->