### PR TITLE
Fix checkbox group input detection

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the library will be documented in this file.
 - Add React Native specific `FieldElement` type, internal form store types and `focusFieldElement` function that work without DOM APIs (issue #117)
 - Remove `getElementInput` and `decodeFormData` from the React Native build output as they depend on DOM APIs (issue #117)
 - Add missing `createSignal` overload without an initial value to the React framework adapter
+- Fix checkbox groups to stay array-valued with one rendered option and to ignore disabled or same-named controls from other forms
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/packages/core/src/field/getElementInput/getElementInput.test.ts
+++ b/packages/core/src/field/getElementInput/getElementInput.test.ts
@@ -90,6 +90,45 @@ describe('getElementInput', () => {
         'green',
       ]);
     });
+
+    test('should return an array for a checkbox group with one option', () => {
+      const store = createTestStore(v.object({ colors: v.array(v.string()) }));
+      const checkbox = createInput('checkbox', 'red', {
+        name: 'colors',
+        checked: true,
+      });
+      document.body.appendChild(checkbox);
+
+      expect(getElementInput(checkbox, store.children.colors)).toStrictEqual([
+        'red',
+      ]);
+    });
+
+    test('should only group enabled checkboxes owned by the same form', () => {
+      const store = createTestStore(v.object({ colors: v.array(v.string()) }));
+      const firstForm = document.createElement('form');
+      const secondForm = document.createElement('form');
+      const red = createInput('checkbox', 'red', {
+        name: 'colors',
+        checked: true,
+      });
+      const blue = createInput('checkbox', 'blue', {
+        name: 'colors',
+        checked: true,
+        disabled: true,
+      });
+      const green = createInput('checkbox', 'green', {
+        name: 'colors',
+        checked: true,
+      });
+      firstForm.append(red, blue);
+      secondForm.append(green);
+      document.body.append(firstForm, secondForm);
+
+      expect(getElementInput(red, store.children.colors)).toStrictEqual([
+        'red',
+      ]);
+    });
   });
 
   describe('radio inputs', () => {

--- a/packages/core/src/field/getElementInput/getElementInput.ts
+++ b/packages/core/src/field/getElementInput/getElementInput.ts
@@ -27,14 +27,20 @@ export function getElementInput(
 
   // If element is checkbox, handle single or group
   if (element.type === 'checkbox') {
-    // Get all checkboxes with same name
-    const options = document.getElementsByName(element.name);
-
-    // If checkbox group, return array of checked values
-    if (options.length > 1) {
-      // @ts-expect-error
-      return [...options]
-        .filter((option) => option.checked)
+    // If field is array, return array of checked values
+    // Hint: The schema decides that the checkbox is part of a group, even if
+    // only one option is currently rendered.
+    if (internalFieldStore.kind === 'array') {
+      return Array.from(
+        document.getElementsByName(element.name) as NodeListOf<HTMLInputElement>
+      )
+        .filter(
+          (option) =>
+            // Only input elements can have a truthy `checked`, so no further
+            // type checks are necessary to filter out other elements sharing
+            // the same name.
+            option.checked && !option.disabled && option.form === element.form
+        )
         .map((option) => option.value);
     }
 


### PR DESCRIPTION
## Summary

`getElementInput` decided whether a checkbox belongs to a group by counting same-named elements in the document (`options.length > 1`). This caused two bugs:

- A checkbox group with only one rendered option returned a boolean instead of an array, corrupting the input of array fields.
- The group collected every same-named checkbox in the document, including checked but disabled controls and controls belonging to other forms on the page.

The group decision is now schema-driven: a checkbox bound to an array field is always treated as a group. The collected options are filtered to enabled controls owned by the same form, matching HTML form submission semantics and the existing select multiple handling. Only `checked` (which only input elements can carry) plus the `form` and `disabled` checks are needed, keeping the filter minimal.

## Test plan

- New test: a checkbox group with a single rendered option returns an array.
- New test: disabled checkboxes and same-named checkboxes from other forms are excluded.
- All existing core tests pass (`pnpm -C packages/core test`, `pnpm -C packages/core lint`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox groups with a single option so their values remain array-based.
  * Disabled checkboxes and checkboxes belonging to other forms are now excluded from group values.
  * Preserved individual checkbox behavior for fields that are not configured as groups.

* **Tests**
  * Added coverage for single-option groups and checkbox filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->