### PR TITLE
Fix select and file input value shape for array fields

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the library will be documented in this file.
 - Add React Native specific `FieldElement` type, internal form store types and `focusFieldElement` function that work without DOM APIs (issue #117)
 - Remove `getElementInput` and `decodeFormData` from the React Native build output as they depend on DOM APIs (issue #117)
 - Add missing `createSignal` overload without an initial value to the React framework adapter
+- Fix select and file inputs bound to array fields to always return an array by deriving the value shape from the schema instead of the `multiple` attribute
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/packages/core/src/field/getElementInput/getElementInput.test.ts
+++ b/packages/core/src/field/getElementInput/getElementInput.test.ts
@@ -138,6 +138,20 @@ describe('getElementInput', () => {
       ).toStrictEqual(['us', 'de']);
     });
 
+    test('should return array for select bound to array field without multiple attribute', () => {
+      const store = createTestStore(
+        v.object({ countries: v.array(v.string()) })
+      );
+      const select = document.createElement('select');
+      select.innerHTML = `
+        <option value="us" selected>US</option>
+        <option value="uk">UK</option>
+      `;
+      expect(
+        getElementInput(select, getChild(store, 'countries'))
+      ).toStrictEqual(['us']);
+    });
+
     test('should exclude disabled options from multiple select', () => {
       const store = createTestStore(
         v.object({ countries: v.array(v.string()) })
@@ -164,16 +178,25 @@ describe('getElementInput', () => {
     });
 
     test('should return files array for multiple file input', () => {
-      const store = createTestStore(v.object({ documents: v.any() }));
+      const store = createTestStore(v.object({ documents: v.array(v.any()) }));
       const input = createInput('file', '');
       input.multiple = true;
       const file1 = new File(['content1'], 'test1.txt');
       const file2 = new File(['content2'], 'test2.txt');
       Object.defineProperty(input, 'files', { value: [file1, file2] });
-      expect(getElementInput(input, store.children.documents)).toStrictEqual([
-        file1,
-        file2,
-      ]);
+      expect(
+        getElementInput(input, getChild(store, 'documents'))
+      ).toStrictEqual([file1, file2]);
+    });
+
+    test('should return files array for array field without multiple attribute', () => {
+      const store = createTestStore(v.object({ documents: v.array(v.any()) }));
+      const input = createInput('file', '');
+      const file = new File(['content'], 'test.txt');
+      Object.defineProperty(input, 'files', { value: [file] });
+      expect(
+        getElementInput(input, getChild(store, 'documents'))
+      ).toStrictEqual([file]);
     });
   });
 

--- a/packages/core/src/field/getElementInput/getElementInput.ts
+++ b/packages/core/src/field/getElementInput/getElementInput.ts
@@ -16,9 +16,11 @@ export function getElementInput(
   element: FieldElement,
   internalFieldStore: InternalFieldStore
 ): unknown {
-  // If element is select with multiple option, return selected values
+  // If a select element is bound to an array field, return selected values
+  // Hint: The schema decides the value shape instead of the `multiple`
+  // attribute so a misconfigured element cannot corrupt the field input.
   // @ts-expect-error
-  if (element.options && element.multiple) {
+  if (element.options && internalFieldStore.kind === 'array') {
     // @ts-expect-error
     return [...element.options]
       .filter((option) => option.selected && !option.disabled)
@@ -57,9 +59,10 @@ export function getElementInput(
 
   // If element is file input, handle single or multiple
   if (element.type === 'file') {
-    // If multiple files allowed, return files array
-    // @ts-expect-error
-    if (element.multiple) {
+    // If field is array, return files array
+    // Hint: The schema decides the value shape, so an array field returns a
+    // list of files even if the element is missing the `multiple` attribute.
+    if (internalFieldStore.kind === 'array') {
       return [
         // @ts-expect-error
         ...element.files,


### PR DESCRIPTION
## Summary

`getElementInput` decided whether a select or file input produces an array based on the element's `multiple` attribute. When the attribute and the schema disagreed, the field input shape was corrupted:

- An array field (e.g. `v.array(v.file())`) whose element was missing the `multiple` attribute received a single value instead of an array.
- A single-value field whose element carried a stray `multiple` attribute received an array.

The value shape is now derived from the schema, which is the source of truth (`decodeFormData` already works schema-driven): a select or file input bound to an array field always returns an array of selected values or files, and a value field always returns a single value. For correctly configured elements the behavior is unchanged, including the empty cases.

## Test plan

- New test: a select bound to an array field without the `multiple` attribute returns a one-element array.
- New test: a file input bound to an array field without the `multiple` attribute returns a files array.
- Updated test: the multiple file input test now uses an array schema, matching the shape it asserts.
- All existing core tests pass (`pnpm -C packages/core test`, `pnpm -C packages/core lint`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select and file inputs bound to array fields now consistently return arrays, even when the `multiple` attribute is not set.
  * Input value shapes now follow the configured field schema rather than relying on HTML attributes.
* **Documentation**
  * Added a changelog entry describing the updated array-field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->