### PR TITLE
Fix concurrent validation race condition

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the library will be documented in this file.
 - Add React Native specific `FieldElement` type, internal form store types and `focusFieldElement` function that work without DOM APIs (issue #117)
 - Remove `getElementInput` and `decodeFormData` from the React Native build output as they depend on DOM APIs (issue #117)
 - Add missing `createSignal` overload without an initial value to the React framework adapter
+- Fix concurrent validation so an older result cannot overwrite newer errors or reset the validating state
+- Remove internal `validators` counter in favor of the new internal validation ID
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/packages/core/src/form/createFormStore/createFormStore.test.ts
+++ b/packages/core/src/form/createFormStore/createFormStore.test.ts
@@ -13,12 +13,12 @@ describe('createFormStore', () => {
       expect(store.revalidate).toBe('input');
     });
 
-    test('should initialize validators to 0', () => {
+    test('should initialize validation ID to 0', () => {
       const schema = v.object({ name: v.string() });
       const parse = vi.fn();
       const store = createFormStore({ schema }, parse);
 
-      expect(store.validators).toBe(0);
+      expect(store.validationId).toBe(0);
     });
 
     test('should initialize all boolean signals to false', () => {

--- a/packages/core/src/form/createFormStore/createFormStore.ts
+++ b/packages/core/src/form/createFormStore/createFormStore.ts
@@ -37,7 +37,7 @@ export function createFormStore(
   store.emptyInput = { ...DEFAULT_EMPTY_INPUT, ...config.emptyInput };
 
   // Set form config and validation
-  store.validators = 0;
+  store.validationId = 0;
   store.validate = config.validate ?? 'submit';
   store.revalidate = config.revalidate ?? 'input';
   store.parse = parse;

--- a/packages/core/src/form/validateFormInput/validateFormInput.test.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.test.ts
@@ -515,5 +515,47 @@ describe('validateFormInput', () => {
       expect(store.children.name.errors.value).toStrictEqual(['New error']);
       expect(store.isValidating.value).toBe(false);
     });
+
+    test('should not clear validating state when focusing starts a new validation', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('Error')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+      let resolveSecond: (value: ParseResult) => void;
+      const secondResult = new Promise<ParseResult>((resolve) => {
+        resolveSecond = resolve;
+      });
+      const parse = vi
+        .fn()
+        .mockResolvedValueOnce(v.safeParse(schema, { name: '' }))
+        .mockReturnValueOnce(secondResult);
+      const store = createFormStore({ schema }, parse);
+
+      // Register an element for the erroring field so it can receive focus
+      const nameInput = document.createElement('input');
+      document.body.appendChild(nameInput);
+      store.children.name.elements.push(nameInput);
+
+      // Focus another element whose blur handler synchronously starts a new
+      // validation when the focus moves to the erroring field
+      let secondValidation: Promise<unknown> | undefined;
+      const otherInput = document.createElement('input');
+      document.body.appendChild(otherInput);
+      otherInput.addEventListener('blur', () => {
+        secondValidation = validateFormInput(store);
+      });
+      otherInput.focus();
+
+      await validateFormInput(store, { shouldFocus: true });
+
+      // The synchronously started validation is still pending, so the older
+      // validation must not clear its validating state
+      expect(secondValidation).toBeDefined();
+      expect(store.isValidating.value).toBe(true);
+
+      resolveSecond!(v.safeParse(schema, { name: '' }));
+      await secondValidation;
+      expect(store.isValidating.value).toBe(false);
+    });
   });
 });

--- a/packages/core/src/form/validateFormInput/validateFormInput.test.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.test.ts
@@ -404,13 +404,15 @@ describe('validateFormInput', () => {
       expect(store.isValidating.value).toBe(false);
     });
 
-    test('should increment and decrement validators counter', async () => {
+    test('should increment validation ID for each validation', async () => {
       const schema = v.object({ name: v.string() });
       const store = createTestStore(schema, { initialInput: { name: 'John' } });
 
-      expect(store.validators).toBe(0);
+      expect(store.validationId).toBe(0);
       await validateFormInput(store);
-      expect(store.validators).toBe(0);
+      expect(store.validationId).toBe(1);
+      await validateFormInput(store);
+      expect(store.validationId).toBe(2);
     });
 
     test('should reset validation state when parse rejects', async () => {
@@ -420,8 +422,7 @@ describe('validateFormInput', () => {
 
       await expect(validateFormInput(store)).rejects.toThrow('Parse failed');
 
-      // The validators counter and isValidating must not leak on error
-      expect(store.validators).toBe(0);
+      // The validating state must not leak on error
       expect(store.isValidating.value).toBe(false);
     });
 
@@ -450,7 +451,6 @@ describe('validateFormInput', () => {
       const validation1 = validateFormInput(store);
       const validation2 = validateFormInput(store);
 
-      expect(store.validators).toBe(2);
       expect(store.isValidating.value).toBe(true);
 
       // Resolve first validation
@@ -462,7 +462,8 @@ describe('validateFormInput', () => {
       });
       await validation1;
 
-      expect(store.validators).toBe(1);
+      // The first validation is stale, so it must not reset the validating
+      // state of the second validation that is still pending
       expect(store.isValidating.value).toBe(true);
 
       // Resolve second validation
@@ -474,7 +475,44 @@ describe('validateFormInput', () => {
       });
       await validation2;
 
-      expect(store.validators).toBe(0);
+      expect(store.isValidating.value).toBe(false);
+    });
+
+    test('should not let an older validation overwrite newer errors', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('New error')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+      let resolveFirst: (value: ParseResult) => void;
+      let resolveSecond: (value: ParseResult) => void;
+      const firstResult = new Promise<ParseResult>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const secondResult = new Promise<ParseResult>((resolve) => {
+        resolveSecond = resolve;
+      });
+      const parse = vi
+        .fn()
+        .mockReturnValueOnce(firstResult)
+        .mockReturnValueOnce(secondResult);
+      const store = createFormStore({ schema }, parse);
+
+      const firstValidation = validateFormInput(store);
+      const secondValidation = validateFormInput(store);
+
+      resolveSecond!(v.safeParse(schema, { name: '' }));
+      await secondValidation;
+      expect(store.children.name.errors.value).toStrictEqual(['New error']);
+
+      resolveFirst!({
+        typed: true,
+        success: true,
+        output: { name: 'valid' },
+        issues: undefined,
+      });
+      await firstValidation;
+
+      expect(store.children.name.errors.value).toStrictEqual(['New error']);
       expect(store.isValidating.value).toBe(false);
     });
   });

--- a/packages/core/src/form/validateFormInput/validateFormInput.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.ts
@@ -31,8 +31,8 @@ export async function validateFormInput(
   internalFormStore: InternalFormStore,
   config?: ValidateFormInputConfig
 ): Promise<v.SafeParseResult<Schema>> {
-  // Update validation state
-  internalFormStore.validators++;
+  // Record validation order and mark form as validating
+  const validationId = ++internalFormStore.validationId;
   internalFormStore.isValidating.value = true;
 
   try {
@@ -40,6 +40,15 @@ export async function validateFormInput(
     const result = await internalFormStore.parse(
       untrack(() => getFieldInput(internalFormStore))
     );
+
+    // Return outdated result without processing it if a newer validation was
+    // started in the meantime
+    // Hint: Only the newest validation may write errors or reset the validating
+    // state, so an older async result that settles late cannot overwrite the
+    // state of a newer validation.
+    if (internalFormStore.validationId !== validationId) {
+      return result;
+    }
 
     // Create variables for root and nested errors
     let rootErrors: [string, ...string[]] | undefined;
@@ -131,8 +140,7 @@ export async function validateFormInput(
       });
 
       // Reset validation state of form
-      internalFormStore.validators--;
-      internalFormStore.isValidating.value = internalFormStore.validators > 0;
+      internalFormStore.isValidating.value = false;
     });
 
     // Return validation result
@@ -141,10 +149,11 @@ export async function validateFormInput(
     // If parsing throws, still reset validation state so form does not stay
     // stuck in a validating state
   } catch (error) {
-    batch(() => {
-      internalFormStore.validators--;
-      internalFormStore.isValidating.value = internalFormStore.validators > 0;
-    });
+    // Hint: The reset is guarded so a stale validation cannot clear the
+    // validating state of a newer validation that is still pending.
+    if (internalFormStore.validationId === validationId) {
+      internalFormStore.isValidating.value = false;
+    }
     throw error;
   }
 }

--- a/packages/core/src/form/validateFormInput/validateFormInput.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.ts
@@ -140,7 +140,12 @@ export async function validateFormInput(
       });
 
       // Reset validation state of form
-      internalFormStore.isValidating.value = false;
+      // Hint: The validation ID must be rechecked because focusing an erroring
+      // field can blur another field whose blur handler synchronously starts a
+      // new validation, which must keep its validating state.
+      if (internalFormStore.validationId === validationId) {
+        internalFormStore.isValidating.value = false;
+      }
     });
 
     // Return validation result

--- a/packages/core/src/form/validateIfRequired/validateIfRequired.test.ts
+++ b/packages/core/src/form/validateIfRequired/validateIfRequired.test.ts
@@ -17,7 +17,7 @@ describe('validateIfRequired', () => {
       validateIfRequired(store, store.children.name, 'input');
 
       // Validation triggered because mode matches revalidate
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should not validate when mode does not match revalidate', () => {
@@ -29,7 +29,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'blur');
 
-      expect(store.validators).toBe(0);
+      expect(store.validationId).toBe(0);
     });
   });
 
@@ -46,7 +46,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'input');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should use validate mode when form is not submitted', () => {
@@ -59,7 +59,7 @@ describe('validateIfRequired', () => {
       // Form is not submitted (default)
       validateIfRequired(store, store.children.name, 'submit');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should not validate when mode does not match and not submitted', () => {
@@ -72,7 +72,7 @@ describe('validateIfRequired', () => {
       // Form is not submitted, mode is 'input' but validate='submit'
       validateIfRequired(store, store.children.name, 'input');
 
-      expect(store.validators).toBe(0);
+      expect(store.validationId).toBe(0);
     });
   });
 
@@ -89,7 +89,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'blur');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should use validate mode when field has no errors', () => {
@@ -102,7 +102,7 @@ describe('validateIfRequired', () => {
       // No errors on field
       validateIfRequired(store, store.children.name, 'input');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should not validate when mode does not match and no errors', () => {
@@ -115,7 +115,7 @@ describe('validateIfRequired', () => {
       // No errors, mode is 'blur' but validate='input'
       validateIfRequired(store, store.children.name, 'blur');
 
-      expect(store.validators).toBe(0);
+      expect(store.validationId).toBe(0);
     });
   });
 
@@ -129,7 +129,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'blur');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should validate on input when has errors (revalidate)', () => {
@@ -143,7 +143,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'input');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
   });
 
@@ -157,7 +157,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'touch');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should validate on change when has errors (revalidate)', () => {
@@ -171,7 +171,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'change');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
   });
 
@@ -185,7 +185,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'change');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should validate on blur when has errors (revalidate)', () => {
@@ -199,7 +199,7 @@ describe('validateIfRequired', () => {
 
       validateIfRequired(store, store.children.name, 'blur');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
   });
 
@@ -224,7 +224,7 @@ describe('validateIfRequired', () => {
       // getFieldBool should detect nested error
       validateIfRequired(store, store.children.items, 'input');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
 
     test('should check nested field errors for objects', () => {
@@ -249,7 +249,7 @@ describe('validateIfRequired', () => {
       // getFieldBool should detect nested error
       validateIfRequired(store, store.children.user, 'input');
 
-      expect(store.validators).toBe(1);
+      expect(store.validationId).toBe(1);
     });
   });
 
@@ -268,7 +268,7 @@ describe('validateIfRequired', () => {
 
         validateIfRequired(store, store.children.name, mode);
 
-        expect(store.validators).toBe(1);
+        expect(store.validationId).toBe(1);
       }
     );
 
@@ -289,7 +289,7 @@ describe('validateIfRequired', () => {
 
         validateIfRequired(store, store.children.name, mode);
 
-        expect(store.validators).toBe(1);
+        expect(store.validationId).toBe(1);
       }
     );
   });

--- a/packages/core/src/types/form/form.qwik.ts
+++ b/packages/core/src/types/form/form.qwik.ts
@@ -50,9 +50,9 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
   element?: HTMLFormElement | undefined;
 
   /**
-   * The number of active validators.
+   * The ID of the latest validation.
    */
-  validators: number;
+  validationId: number;
   /**
    * The resolved empty input of the form, keyed by field type.
    */

--- a/packages/core/src/types/form/form.react-native.ts
+++ b/packages/core/src/types/form/form.react-native.ts
@@ -17,9 +17,9 @@ import type {
 export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
   extends InternalObjectStore {
   /**
-   * The number of active validators.
+   * The ID of the latest validation.
    */
-  validators: number;
+  validationId: number;
   /**
    * The resolved empty input of the form, keyed by field type.
    */

--- a/packages/core/src/types/form/form.ts
+++ b/packages/core/src/types/form/form.ts
@@ -83,9 +83,9 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
   element?: HTMLFormElement | undefined;
 
   /**
-   * The number of active validators.
+   * The ID of the latest validation.
    */
-  validators: number;
+  validationId: number;
   /**
    * The resolved empty input of the form, keyed by field type.
    */

--- a/packages/methods/src/setInput/setInput.test.ts
+++ b/packages/methods/src/setInput/setInput.test.ts
@@ -82,7 +82,7 @@ describe('setInput', () => {
 
     setInput(store, { path: ['name'], input: 'John' });
 
-    // Check that validators count increased, indicating validation was triggered
-    expect(store.validators).toBe(1);
+    // Check that validation ID increased, indicating validation was triggered
+    expect(store.validationId).toBe(1);
   });
 });

--- a/website/src/routes/(docs)/core/api/(types)/InternalFormStore/index.mdx
+++ b/website/src/routes/(docs)/core/api/(types)/InternalFormStore/index.mdx
@@ -21,7 +21,7 @@ Internal interface for form stores that contains the core form logic, validation
 
 - `InternalFormStore`
   - `element` <Property {...properties.element} />
-  - `validators` <Property {...properties.validators} />
+  - `validationId` <Property {...properties.validationId} />
   - `emptyInput` <Property {...properties.emptyInput} />
   - `validate` <Property {...properties.validate} />
   - `revalidate` <Property {...properties.revalidate} />

--- a/website/src/routes/(docs)/core/api/(types)/InternalFormStore/properties.ts
+++ b/website/src/routes/(docs)/core/api/(types)/InternalFormStore/properties.ts
@@ -26,7 +26,7 @@ export const properties: Record<string, PropertyProps> = {
       ],
     },
   },
-  validators: {
+  validationId: {
     type: 'number',
   },
   emptyInput: {


### PR DESCRIPTION
## Summary

When two validations overlapped, the one that resolved last wrote its errors — even if a newer validation had already resolved with fresher results. A slow async validation could therefore overwrite newer errors with stale ones.

Each validation now records a monotonically increasing `validationId` on the form store when it starts. After parsing, a validation whose ID is no longer current returns its result to the caller without touching the form: it writes no errors, moves no focus, and does not reset the validating state.

This also replaces the `validators` counter: since a stale validation can no longer produce any observable state change, "still validating" only meaningfully applies to the newest validation, so `isValidating` is now cleared by the newest validation instead of counting all in-flight ones. Errors and validating state settle together. A number is used instead of an identity token so the internal store stays serializable for Qwik.

## Test plan

- New test: an older validation resolving after a newer one does not overwrite the newer errors.
- Updated tests: concurrent validation keeps `isValidating` true while the newest validation is pending, including when a stale validation settles first; the validating state does not leak when parsing throws.
- Tests that used the `validators` counter as a "validation was started" probe now use `validationId`.
- All core and methods tests pass (`pnpm -C packages/core test`, `pnpm -C packages/methods test`, plus lint in both).