### PR TITLE
Add shadcn/ui integration guide

### DIFF
--- a/.agents/skills/repo-website-guide-create/SKILL.md
+++ b/.agents/skills/repo-website-guide-create/SKILL.md
@@ -29,6 +29,7 @@ website/src/routes/{framework}/guides/
 - `(main-concepts)` - Core library concepts
 - `(advanced-guides)` - Advanced features
 - `(migration-guides)` - Migration from other form libraries
+- `(integration-guides)` - Integration with UI component libraries
 
 ## Step-by-Step Process
 
@@ -40,6 +41,7 @@ Determine the appropriate category:
 - **(main-concepts)**: Define form, Create form, Add fields, Handle submission
 - **(advanced-guides)**: Controlled fields, Field arrays, TypeScript
 - **(migration-guides)**: Migrate from React Hook Form, Migrate from TanStack Form
+- **(integration-guides)**: shadcn/ui, Chakra UI, Mantine (see `repo-website-integration-guide-create` for the required structure)
 
 ### Step 2: Create Guide Directory
 

--- a/.agents/skills/repo-website-integration-guide-create/SKILL.md
+++ b/.agents/skills/repo-website-integration-guide-create/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: repo-website-integration-guide-create
+description: Add integration guides for using Formisch with UI component libraries (e.g. shadcn/ui, Mantine, Chakra UI) to the Formisch website. Use when documenting how to wire Formisch fields to a component library's inputs.
+metadata:
+  author: formisch
+  version: '1.1'
+---
+
+# Adding Integration Guides
+
+Use this skill to add a UI component library integration guide to the Formisch website. Read `repo-website-guide-create` first for the shared front matter, links, code fences and formatting conventions. This skill adds the integration-specific structure and verification requirements.
+
+## Location and Registration
+
+- File: `website/src/routes/(docs)/{framework}/guides/(integration-guides)/{library-slug}/index.mdx`
+- Slug: kebab-case library name (`shadcn-ui`, `chakra-ui`, `mantine`)
+- Menu label and H1: the library's display name (`shadcn/ui`, `Chakra UI`)
+- Register the guide in `website/src/routes/(docs)/{framework}/guides/menu.md` under `## Integration guides`, after `Migration guides`.
+- Keep the heading exactly `Integration guides`. `DocsLayout.tsx` derives the `(integration-guides)` folder name from it for the Edit page link.
+- Do not manually edit generated llms.txt, sitemap, OG image or public `.md` files.
+
+## Reader Experience
+
+Make the shortest guide that still produces a correct, accessible integration:
+
+- Start with the decision the reader needs to make, then show the code.
+- Explain why only where it prevents a likely mistake, such as a value conversion, hidden input ref or accessibility association.
+- Keep introductory prose and caveats brief. Put component-specific details beside the relevant snippet instead of in a long notes section.
+- Use consistent names and page-unique DOM IDs so snippets can be combined safely.
+- Prefer complete, copy-safe snippets over shorter examples that silently omit validation, focus or accessibility behavior.
+- Avoid claiming that two library backends have the same API. State the exact library major version and primitive backend the guide targets. Treat visual styles separately: do not require a design preset unless the integration depends on it.
+
+## Guide Structure
+
+Use this section order. FIXED parts stay consistent across integration guides; LIBRARY parts follow the verified component APIs.
+
+```
+# {Library}                     LIBRARY  2-3 sentence introduction with external
+                                         link, targeted major version/backend,
+                                         and the two Formisch wiring patterns
+## Installation                 LIBRARY  Formisch + Valibot + verified library or
+                                         CLI commands
+## Wiring patterns              FIXED decision rule, LIBRARY snippets
+### Spreading field.props                minimal native-forwarding text input
+### Controlled components                minimal composite control with value,
+                                         lifecycle and focus wiring
+## Displaying errors            LIBRARY  error mapping, visual invalid state and
+                                         accessible error association; link to
+                                         validation timing
+## Login form example           FIXED schema and structure, LIBRARY components;
+                                         email + password + remember-me checkbox;
+                                         submit disabled while submitting
+## Component reference          FIXED H3 set and order, LIBRARY snippets
+### Text input                           include a one-line textarea note
+### Checkbox
+### Select
+### Radio group
+### Slider
+## Library-specific notes       OPTIONAL only verified caveats that do not fit
+                                         beside a component
+## Next steps                   FIXED links to input-components,
+                                         controlled-fields and validation
+```
+
+If the library has no direct counterpart for a reference component, say so briefly instead of inventing an API.
+
+## Canonical Login Schema
+
+Use this schema verbatim so integration guides remain comparable:
+
+```ts
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+```
+
+Initialize controlled values in the complete example unless the component explicitly supports `undefined`. This avoids uncontrolled-to-controlled transitions and makes the first render match the schema input.
+
+## Wiring Decision Rule
+
+### Native-forwarding components
+
+If a component forwards props and its ref to a native `<input>`, `<select>` or `<textarea>`:
+
+- spread `field.props`
+- pass `field.input` as `value` or `checked`
+- use a nullish fallback when the native prop does not accept `undefined`
+- place explicit props after the spread when they intentionally override Formisch's native handler
+
+### Controlled components
+
+If a component exposes `onCheckedChange`, `onValueChange` or another value callback, `field.onChange` is only the value portion of the integration. Preserve the complete field contract:
+
+| Formisch behavior       | Typical component-library target                        |
+| ----------------------- | ------------------------------------------------------- |
+| `field.input`           | `value` or `checked`                                    |
+| `field.onChange`        | custom value callback                                   |
+| `field.props.name`      | root `name` or hidden native input                      |
+| `field.props.ref`       | public `inputRef` or another focusable native target    |
+| `field.props.autoFocus` | visible trigger, first group item or registered input   |
+| `field.props.onFocus`   | focus event on the visible interactive control or group |
+| `field.props.onBlur`    | blur event on the visible interactive control or group  |
+
+The lifecycle mapping keeps `isTouched`, touch/blur validation, `focus()` and submit-time error focusing working. If the public wrapper hides the necessary primitive ref or event prop, adapt the copied local component and document that small change. A scoped ref lookup inside the owned wrapper is an acceptable fallback when the generated structure has been runtime-verified.
+
+Formisch's focus and blur handlers are parameterless lifecycle callbacks. Pass them directly to component event props; any event argument supplied by the component is intentionally ignored. Do not add a cast or wrapper solely to erase an event parameter. Adapt a callback only when Formisch or the component actually needs a different value.
+
+Field API source of truth: `frameworks/{framework}/src/types/field.ts`.
+
+| API                                                   | Purpose                                            |
+| ----------------------------------------------------- | -------------------------------------------------- |
+| `field.props`                                         | Native name, ref, autofocus and lifecycle handlers |
+| `field.input`                                         | Current controlled value                           |
+| `field.onChange`                                      | Programmatic update and input/change validation    |
+| `field.errors`                                        | `[string, ...string[]] \| null` error messages     |
+| `field.isTouched` / `field.isDirty` / `field.isValid` | Current field state                                |
+
+## Accessibility and Copy Safety
+
+Every example that displays a label or error must preserve its semantic relationship:
+
+- Use a page-unique DOM ID; do not assume a field name is globally unique.
+- Connect a native or button-like control with `htmlFor` and `id`.
+- Give composite widgets an accessible name with the library's label primitive or `aria-labelledby`.
+- Connect a group legend to the actual `radiogroup`; a surrounding `fieldset` may not name a nested composite root.
+- Set `aria-invalid` on the interactive element or group and reference a stable error ID with `aria-errormessage` or `aria-describedby` when errors are present.
+- Match structural values to the widget. For example, array-driven sliders must receive one value per intended thumb.
+- Normalize nullable, union or sentinel callback values explicitly before passing them to `field.onChange`.
+
+## Verify Library APIs (Mandatory)
+
+Do not write component props, event signatures or installation commands from memory.
+
+1. **Identify the target.** Record the current library major version and, when applicable, the generated primitive backend. Determine separately whether visual styles change the component APIs used by the integration. Do not force a design choice merely to make the scaffold reproducible.
+2. **Read authoritative docs.** Prefer the library's official documentation and generated source. Context7 may be used to retrieve it; use web search only as a fallback. Check Formisch's current field types and implementation locally.
+3. **Scaffold the real output.** In a temporary directory, use the documented CLI or package versions to create the same components readers will receive. Inspect the generated wrapper and its primitive type declarations, especially hidden inputs, refs and event targets. If the guide is design-agnostic, compare the relevant generated APIs across the supported visual styles.
+4. **Compile every pattern.** Install `valibot` and the Formisch package that matches the documented API, then typecheck and production-build the transcribed examples. Use the published `@formisch/{framework}` for released behavior. For an unreleased repository change, build and pack the local framework package instead of installing it through a workspace symlink, which can introduce a second framework runtime. Do not rely on MDX syntax highlighting as verification.
+5. **Exercise behavior in a browser.** Verify that:
+   - visible labels are the accessible names returned by role queries
+   - each label targets the intended control and group labels name the group
+   - errors render and are associated with the invalid control
+   - controlled values update and the submitted output contains parsed values
+   - focus marks the field as touched and triggers touch validation, while blur triggers blur validation
+   - `focus()` and submit-time error focusing reach controlled fields
+   - composite structure matches the value shape, such as one slider thumb per value
+6. **Add focused automated coverage.** When a generated wrapper has non-obvious behavior such as thumb derivation or focus delegation, add or run a small runtime test in the scaffold. Use a real browser for layout, visibility and focus claims that DOM emulators cannot model reliably.
+
+Transcribe only the verified, minimal wiring into the guide. Delete the temporary scaffold after recording the results if it lives inside the repository.
+
+## Porting to Other Frameworks
+
+Use the same skeleton and schema, then replace package and API names according to the framework terminology table in `repo-website-guide-create`. Confirm that the UI library supports the framework before creating the guide. Register it under the same `## Integration guides` heading for that framework.
+
+## Cross-Linking
+
+Integration guides are cross-linked as Markdown lists with one `<Link>` per guide, introduced by this exact sentence:
+
+> For ready-made wiring recipes, check out our integration guides:
+
+Maintain the list in two places per framework:
+
+- the end of the input-components guide's `Using component libraries` section
+- the end of the controlled-fields guide's `Custom inputs and component libraries` section
+
+Append the new guide to `menu.md` and both lists. Create the lists if necessary. Keep these lists and the menu as the only inbound guide indexes so they stay easy to maintain.
+
+## Checklist
+
+Before submitting:
+
+- [ ] Route and menu entry follow the required location and heading
+- [ ] Section order matches this skill
+- [ ] Targeted library version and backend are explicit and verified without imposing an unrelated visual style
+- [ ] Canonical login schema is verbatim and controlled values are initialized
+- [ ] Native and controlled patterns preserve the full Formisch field contract
+- [ ] Labels, groups, errors and IDs are accessible and safe when snippets are combined
+- [ ] Value conversions and widget structure match the actual component API
+- [ ] Every example typechecks and the production build passes in a real scaffold
+- [ ] Browser checks cover input, errors, touch/blur, focus and submission
+- [ ] Non-obvious runtime behavior has focused coverage
+- [ ] Menu and both inbound cross-link lists are updated

--- a/.agents/skills/repo-website-integration-guide-create/SKILL.md
+++ b/.agents/skills/repo-website-integration-guide-create/SKILL.md
@@ -28,7 +28,7 @@ Make the shortest guide that still produces a correct, accessible integration:
 - Keep introductory prose and caveats brief. Put component-specific details beside the relevant snippet instead of in a long notes section.
 - Use consistent names and page-unique DOM IDs so snippets can be combined safely.
 - Prefer complete, copy-safe snippets over shorter examples that silently omit validation, focus or accessibility behavior.
-- Avoid claiming that two library backends have the same API. State the exact library major version and primitive backend the guide targets. Treat visual styles separately: do not require a design preset unless the integration depends on it.
+- State the exact library major version. Mention a backend or preset only when the library offers one and it affects the integration. Do not impose an unrelated visual design choice.
 
 ## Guide Structure
 
@@ -36,7 +36,7 @@ Use this section order. FIXED parts stay consistent across integration guides; L
 
 ```
 # {Library}                     LIBRARY  2-3 sentence introduction with external
-                                         link, targeted major version/backend,
+                                         link, targeted major version/variant,
                                          and the two Formisch wiring patterns
 ## Installation                 LIBRARY  Formisch + Valibot + verified library or
                                          CLI commands
@@ -111,7 +111,7 @@ If a component exposes `onCheckedChange`, `onValueChange` or another value callb
 | `field.props.onFocus`   | focus event on the visible interactive control or group |
 | `field.props.onBlur`    | blur event on the visible interactive control or group  |
 
-The lifecycle mapping keeps `isTouched`, touch/blur validation, `focus()` and submit-time error focusing working. If the public wrapper hides the necessary primitive ref or event prop, adapt the copied local component and document that small change. A scoped ref lookup inside the owned wrapper is an acceptable fallback when the generated structure has been runtime-verified.
+The lifecycle mapping keeps `isTouched`, touch/blur validation, `focus()` and submit-time error focusing working. Prefer the library's public API or a local adapter when a component hides an essential ref or event prop. Only adapt the component itself when its source belongs to the reader. A scoped ref lookup inside owned source is an acceptable fallback when the structure has been runtime-verified.
 
 Formisch's focus and blur handlers are parameterless lifecycle callbacks. Pass them directly to component event props; any event argument supplied by the component is intentionally ignored. Do not add a cast or wrapper solely to erase an event parameter. Adapt a callback only when Formisch or the component actually needs a different value.
 
@@ -141,9 +141,9 @@ Every example that displays a label or error must preserve its semantic relation
 
 Do not write component props, event signatures or installation commands from memory.
 
-1. **Identify the target.** Record the current library major version and, when applicable, the generated primitive backend. Determine separately whether visual styles change the component APIs used by the integration. Do not force a design choice merely to make the scaffold reproducible.
-2. **Read authoritative docs.** Prefer the library's official documentation and generated source. Context7 may be used to retrieve it; use web search only as a fallback. Check Formisch's current field types and implementation locally.
-3. **Scaffold the real output.** In a temporary directory, use the documented CLI or package versions to create the same components readers will receive. Inspect the generated wrapper and its primitive type declarations, especially hidden inputs, refs and event targets. If the guide is design-agnostic, compare the relevant generated APIs across the supported visual styles.
+1. **Identify the target.** Record the current library major version and any variant that changes the API used by the guide.
+2. **Read authoritative docs.** Prefer the library's official documentation, public types and source. Check Formisch's current field types and implementation locally.
+3. **Reproduce the library.** In a temporary directory, install the documented package versions. If the library copies or generates components, run its official workflow and inspect the exact source readers receive. Compare variants only when they may change the documented API.
 4. **Compile every pattern.** Install `valibot` and the Formisch package that matches the documented API, then typecheck and production-build the transcribed examples. Use the published `@formisch/{framework}` for released behavior. For an unreleased repository change, build and pack the local framework package instead of installing it through a workspace symlink, which can introduce a second framework runtime. Do not rely on MDX syntax highlighting as verification.
 5. **Exercise behavior in a browser.** Verify that:
    - visible labels are the accessible names returned by role queries
@@ -153,7 +153,7 @@ Do not write component props, event signatures or installation commands from mem
    - focus marks the field as touched and triggers touch validation, while blur triggers blur validation
    - `focus()` and submit-time error focusing reach controlled fields
    - composite structure matches the value shape, such as one slider thumb per value
-6. **Add focused automated coverage.** When a generated wrapper has non-obvious behavior such as thumb derivation or focus delegation, add or run a small runtime test in the scaffold. Use a real browser for layout, visibility and focus claims that DOM emulators cannot model reliably.
+6. **Add focused automated coverage.** When a control has non-obvious behavior such as value-shape derivation or focus delegation, add or run a small runtime test in the temporary app. Use a real browser for layout, visibility and focus claims that DOM emulators cannot model reliably.
 
 Transcribe only the verified, minimal wiring into the guide. Delete the temporary scaffold after recording the results if it lives inside the repository.
 
@@ -180,7 +180,7 @@ Before submitting:
 
 - [ ] Route and menu entry follow the required location and heading
 - [ ] Section order matches this skill
-- [ ] Targeted library version and backend are explicit and verified without imposing an unrelated visual style
+- [ ] Targeted library version and relevant variants are explicit and verified without imposing an unrelated visual style
 - [ ] Canonical login schema is verbatim and controlled values are initialized
 - [ ] Native and controlled patterns preserve the full Formisch field contract
 - [ ] Labels, groups, errors and IDs are accessible and safe when snippets are combined

--- a/.agents/skills/repo-website-integration-guide-create/SKILL.md
+++ b/.agents/skills/repo-website-integration-guide-create/SKILL.md
@@ -34,7 +34,7 @@ Make the shortest guide that still produces a correct, accessible integration:
 
 Use this section order. FIXED parts stay consistent across integration guides; LIBRARY parts follow the verified component APIs.
 
-```
+```text
 # {Library}                     LIBRARY  2-3 sentence introduction with external
                                          link, targeted major version/variant,
                                          and the two Formisch wiring patterns
@@ -112,6 +112,8 @@ If a component exposes `onCheckedChange`, `onValueChange` or another value callb
 | `field.props.onBlur`    | blur event on the visible interactive control or group  |
 
 The lifecycle mapping keeps `isTouched`, touch/blur validation, `focus()` and submit-time error focusing working. Prefer the library's public API or a local adapter when a component hides an essential ref or event prop. Only adapt the component itself when its source belongs to the reader. A scoped ref lookup inside owned source is an acceptable fallback when the structure has been runtime-verified.
+
+For composite controls, only call the focus and blur handlers when focus enters or leaves the whole control, not when it moves between children.
 
 Formisch's focus and blur handlers are parameterless lifecycle callbacks. Pass them directly to component event props; any event argument supplied by the component is intentionally ignored. Do not add a cast or wrapper solely to erase an event parameter. Adapt a callback only when Formisch or the component actually needs a different value.
 

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -212,6 +212,10 @@ This is useful for:
 
 The `field.onChange` method updates the field value and triggers validation, just like a native input would.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/react/guides/shadcn-ui/">shadcn/ui</Link>
+
 ## Next steps
 
 Now that you understand controlled fields, you can explore more advanced topics like <Link href="/react/guides/nested-fields/">nested fields</Link> and <Link href="/react/guides/field-arrays/">field arrays</Link> to handle complex form structures.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
@@ -1,0 +1,423 @@
+---
+title: shadcn/ui
+description: >-
+  Learn how to connect Formisch fields to shadcn/ui inputs, selects, radio
+  groups, sliders and other form controls.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# shadcn/ui
+
+[shadcn/ui](https://ui.shadcn.com) is a collection of accessible components that you copy into your project and adapt to your needs. This guide targets shadcn CLI v4 components generated with Base UI v1 and works with every official visual style. No adapter package is needed: native controls receive `field.props`, while controlled components map Formisch's value and lifecycle APIs to the generated component.
+
+## Installation
+
+Initialize shadcn/ui with Base UI and choose whichever visual style fits your project. Then add the components used below:
+
+```bash
+npx shadcn@latest init --base base
+npm install @formisch/react valibot
+npx shadcn@latest add field input textarea checkbox select radio-group slider button
+```
+
+Skip the `init` command if shadcn/ui is already configured with Base UI. The generated `field` component provides the layout, label and error components used throughout this guide.
+
+## Wiring patterns
+
+Choose the wiring from the component's public API:
+
+- If it forwards props and a ref to a native form element, spread `field.props` and pass `field.input` as its value.
+- If it exposes a custom callback such as `onCheckedChange` or `onValueChange`, control it with `field.input` and `field.onChange`, then forward the remaining lifecycle props separately.
+
+### Spreading field.props
+
+shadcn's `Input` and `Textarea` render native elements, so their wiring is the same as a plain HTML input:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => <Input {...field.props} value={field.input ?? ''} type="email" />}
+</Field>
+```
+
+### Controlled components
+
+A controlled component needs more than its value callback. Preserve Formisch's lifecycle behavior by passing its field name and hidden-input ref, and by forwarding focus, blur and autofocus behavior to the visible control:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox
+      id="login-remember-me"
+      name={field.props.name}
+      inputRef={field.props.ref}
+      autoFocus={field.props.autoFocus}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      checked={field.input ?? false}
+      onCheckedChange={field.onChange}
+    />
+  )}
+</Field>
+```
+
+`inputRef` registers Base UI's hidden native input so Formisch can focus the field. Formisch's focus and blur handlers are parameterless because they only update field lifecycle state, so you can pass them directly even when the component supplies an event argument.
+
+These examples wire fields directly so you can see the complete integration. Once a pattern repeats, wrap the label, control, lifecycle props and errors in your own input component. This keeps forms concise and defines the wiring in one place. The <Link href="/react/guides/input-components/">input components guide</Link> shows how.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. shadcn's `FieldError` expects objects with a `message` property, so map the strings before passing them. Give the error a stable ID and reference it from the input when an error is present:
+
+```tsx
+<UIField data-invalid={field.errors !== null}>
+  <FieldLabel htmlFor="login-email">Email</FieldLabel>
+  <Input
+    {...field.props}
+    id="login-email"
+    value={field.input ?? ''}
+    aria-invalid={field.errors !== null}
+    aria-errormessage={field.errors ? 'login-email-error' : undefined}
+  />
+  <FieldError
+    id="login-email-error"
+    errors={field.errors?.map((message) => ({ message }))}
+  />
+</UIField>
+```
+
+Use page-unique IDs for labels and errors instead of assuming that a field name is unique in the DOM. By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs, a controlled checkbox and accessible errors:
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FieldError,
+  FieldLabel,
+  Field as UIField,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form
+      of={loginForm}
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-6"
+    >
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <UIField data-invalid={field.errors !== null}>
+            <FieldLabel htmlFor="login-email">Email</FieldLabel>
+            <Input
+              {...field.props}
+              id="login-email"
+              value={field.input ?? ''}
+              type="email"
+              autoComplete="email"
+              placeholder="jane@example.com"
+              aria-invalid={field.errors !== null}
+              aria-errormessage={field.errors ? 'login-email-error' : undefined}
+            />
+            <FieldError
+              id="login-email-error"
+              errors={field.errors?.map((message) => ({ message }))}
+            />
+          </UIField>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <UIField data-invalid={field.errors !== null}>
+            <FieldLabel htmlFor="login-password">Password</FieldLabel>
+            <Input
+              {...field.props}
+              id="login-password"
+              value={field.input ?? ''}
+              type="password"
+              autoComplete="current-password"
+              aria-invalid={field.errors !== null}
+              aria-errormessage={
+                field.errors ? 'login-password-error' : undefined
+              }
+            />
+            <FieldError
+              id="login-password-error"
+              errors={field.errors?.map((message) => ({ message }))}
+            />
+          </UIField>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <UIField orientation="horizontal">
+            <Checkbox
+              id="login-remember-me"
+              name={field.props.name}
+              inputRef={field.props.ref}
+              autoFocus={field.props.autoFocus}
+              onFocus={field.props.onFocus}
+              onBlur={field.props.onBlur}
+              checked={field.input ?? false}
+              onCheckedChange={field.onChange}
+            />
+            <FieldLabel htmlFor="login-remember-me">Remember me</FieldLabel>
+          </UIField>
+        )}
+      </Field>
+
+      <Button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </Button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. The native inputs use the `field.props` spread, while the checkbox maps Base UI's value and lifecycle APIs explicitly.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+`Input` forwards to a native `<input>`, so spread `field.props` directly:
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <UIField data-invalid={field.errors !== null}>
+      <FieldLabel htmlFor="profile-email">Email</FieldLabel>
+      <Input
+        {...field.props}
+        id="profile-email"
+        value={field.input ?? ''}
+        type="email"
+        aria-invalid={field.errors !== null}
+        aria-errormessage={field.errors ? 'profile-email-error' : undefined}
+      />
+      <FieldError
+        id="profile-email-error"
+        errors={field.errors?.map((message) => ({ message }))}
+      />
+    </UIField>
+  )}
+</Field>
+```
+
+`Textarea` works the same way because it also renders a native element.
+
+### Checkbox
+
+For a boolean field, control `checked` and register Base UI's hidden input:
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <UIField orientation="horizontal">
+      <Checkbox
+        id="settings-newsletter"
+        name={field.props.name}
+        inputRef={field.props.ref}
+        autoFocus={field.props.autoFocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+        checked={field.input ?? false}
+        onCheckedChange={field.onChange}
+      />
+      <FieldLabel htmlFor="settings-newsletter">Newsletter</FieldLabel>
+    </UIField>
+  )}
+</Field>
+```
+
+### Select
+
+Base UI represents no selection as `null`, while an optional Formisch value is `undefined`. Convert between them and put the lifecycle handlers on the visible trigger:
+
+```tsx
+const frameworks = [
+  { label: 'Angular', value: 'angular' },
+  { label: 'React', value: 'react' },
+  { label: 'Solid', value: 'solid' },
+  { label: 'Vue', value: 'vue' },
+];
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <UIField data-invalid={field.errors !== null}>
+      <FieldLabel htmlFor="project-framework">Framework</FieldLabel>
+      <Select
+        name={field.props.name}
+        inputRef={field.props.ref}
+        items={frameworks}
+        value={field.input ?? null}
+        onValueChange={(value) => field.onChange(value ?? undefined)}
+      >
+        <SelectTrigger
+          id="project-framework"
+          autoFocus={field.props.autoFocus}
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
+          aria-invalid={field.errors !== null}
+          aria-errormessage={
+            field.errors ? 'project-framework-error' : undefined
+          }
+        >
+          <SelectValue placeholder="Select a framework" />
+        </SelectTrigger>
+        <SelectContent>
+          {frameworks.map((item) => (
+            <SelectItem key={item.value} value={item.value}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <FieldError
+        id="project-framework-error"
+        errors={field.errors?.map((message) => ({ message }))}
+      />
+    </UIField>
+  )}
+</Field>
+```
+
+The `items` prop lets `SelectValue` display the selected item's label.
+
+### Radio group
+
+Connect the legend to the `radiogroup` explicitly. A surrounding `fieldset` alone does not give Base UI's nested group an accessible name:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <FieldSet data-invalid={field.errors !== null}>
+      <FieldLegend id="plan-label" variant="label">
+        Plan
+      </FieldLegend>
+      <RadioGroup
+        aria-labelledby="plan-label"
+        aria-invalid={field.errors !== null}
+        aria-errormessage={field.errors ? 'plan-error' : undefined}
+        name={field.props.name}
+        inputRef={field.props.ref}
+        value={field.input}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+        onValueChange={field.onChange}
+      >
+        <UIField orientation="horizontal">
+          <RadioGroupItem
+            id="plan-hobby"
+            value="hobby"
+            autoFocus={field.props.autoFocus}
+          />
+          <FieldLabel htmlFor="plan-hobby">Hobby</FieldLabel>
+        </UIField>
+        <UIField orientation="horizontal">
+          <RadioGroupItem id="plan-pro" value="pro" />
+          <FieldLabel htmlFor="plan-pro">Pro</FieldLabel>
+        </UIField>
+      </RadioGroup>
+      <FieldError
+        id="plan-error"
+        errors={field.errors?.map((message) => ({ message }))}
+      />
+    </FieldSet>
+  )}
+</Field>
+```
+
+Place `autoFocus` on the first radio item so Formisch can move focus into the group after validation.
+
+### Slider
+
+Pass a one-element array for one thumb. A scalar value makes the generated shadcn wrapper fall back to `[min, max]` and render two thumbs. Also give the visible label an ID because a slider cannot be associated with `htmlFor`:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <UIField data-invalid={field.errors !== null}>
+      <FieldLabel id="volume-label">Volume</FieldLabel>
+      <Slider
+        aria-labelledby="volume-label"
+        aria-invalid={field.errors !== null}
+        aria-errormessage={field.errors ? 'volume-error' : undefined}
+        name={field.props.name}
+        value={[field.input ?? 50]}
+        onValueChange={(value) =>
+          field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
+        }
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+        ref={(root) => {
+          const input =
+            root?.querySelector<HTMLInputElement>('input[type="range"]') ??
+            null;
+          field.props.ref(input);
+          if (field.props.autoFocus) input?.focus();
+        }}
+        min={0}
+        max={100}
+      />
+      <FieldError
+        id="volume-error"
+        errors={field.errors?.map((message) => ({ message }))}
+      />
+    </UIField>
+  )}
+</Field>
+```
+
+The generated `Slider` does not expose Base UI's thumb `inputRef`, so the ref callback registers its nested range input. If sliders appear throughout your app, expose that ref from your local shadcn component once and reuse the simpler API.
+
+## Library-specific notes
+
+shadcn/ui also publishes a [Formisch forms guide](https://ui.shadcn.com/docs/forms/formisch) with complete form examples. This guide focuses on the details behind each field binding so you can adapt them to your own components.
+
+The generated APIs depend on the primitive selected during `shadcn init`. Radix UI and React Aria components use different refs and callback signatures, so verify their generated source instead of copying the Base UI-specific props from this guide.
+
+## Next steps
+
+Read the <Link href="/react/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
@@ -381,48 +381,40 @@ The focus guards treat the composite group as one field, so arrow-key navigation
 
 ### Slider
 
-Pass a one-element array for one thumb. A scalar value makes the generated shadcn wrapper fall back to `[min, max]` and render two thumbs. Also give the visible label an ID because a slider cannot be associated with `htmlFor`:
+The generated `Slider` does not expose Base UI's thumb `inputRef`. Since shadcn adds the component source to your project, update `components/ui/slider.tsx` once: extend `SliderPrimitive.Root.Props` with `inputRef?: SliderPrimitive.Thumb.Props['inputRef']`, destructure it in `Slider`, and pass `inputRef={index === 0 ? inputRef : undefined}` to the generated `SliderPrimitive.Thumb`.
+
+The Formisch wiring then stays simple. Pass a one-element array for one thumb because a scalar value makes the generated wrapper fall back to `[min, max]` and render two thumbs. Also give the visible label an ID because a slider cannot be associated with `htmlFor`:
 
 ```tsx
-const field = useField(form, { path: ['volume'] });
-const { autoFocus, ref } = field.props;
-const sliderRef = useCallback(
-  (root: HTMLElement | null) => {
-    const input =
-      root?.querySelector<HTMLInputElement>('input[type="range"]') ?? null;
-    ref(input);
-    if (autoFocus) input?.focus();
-  },
-  [autoFocus, ref]
-);
-
-return (
-  <UIField data-invalid={field.errors !== null}>
-    <FieldLabel id="volume-label">Volume</FieldLabel>
-    <Slider
-      aria-labelledby="volume-label"
-      aria-invalid={field.errors !== null}
-      aria-errormessage={field.errors ? 'volume-error' : undefined}
-      name={field.props.name}
-      value={[field.input ?? 50]}
-      onValueChange={(value) =>
-        field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
-      }
-      onFocus={field.props.onFocus}
-      onBlur={field.props.onBlur}
-      ref={sliderRef}
-      min={0}
-      max={100}
-    />
-    <FieldError
-      id="volume-error"
-      errors={field.errors?.map((message) => ({ message }))}
-    />
-  </UIField>
-);
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <UIField data-invalid={field.errors !== null}>
+      <FieldLabel id="volume-label">Volume</FieldLabel>
+      <Slider
+        aria-labelledby="volume-label"
+        aria-invalid={field.errors !== null}
+        aria-errormessage={field.errors ? 'volume-error' : undefined}
+        name={field.props.name}
+        inputRef={field.props.ref}
+        value={[field.input ?? 50]}
+        onValueChange={(value) =>
+          field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
+        }
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+        min={0}
+        max={100}
+      />
+      <FieldError
+        id="volume-error"
+        errors={field.errors?.map((message) => ({ message }))}
+      />
+    </UIField>
+  )}
+</Field>
 ```
 
-The generated `Slider` does not expose Base UI's thumb `inputRef`, so the ref callback registers its nested range input. `useCallback` keeps that ref stable when the controlled value updates. If sliders appear throughout your app, expose the input ref from your local shadcn component once and reuse the simpler API.
+The ref registers the thumb's nested range input, so Formisch's `focus()` method and submit-time error focusing work without querying the DOM. Base UI's slider thumb does not expose an input-level `autoFocus` prop, but registering the input preserves Formisch's programmatic focusing.
 
 ## Library-specific notes
 

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
@@ -343,8 +343,16 @@ Connect the legend to the `radiogroup` explicitly. A surrounding `fieldset` alon
         name={field.props.name}
         inputRef={field.props.ref}
         value={field.input}
-        onFocus={field.props.onFocus}
-        onBlur={field.props.onBlur}
+        onFocus={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) {
+            field.props.onFocus();
+          }
+        }}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) {
+            field.props.onBlur();
+          }
+        }}
         onValueChange={field.onChange}
       >
         <UIField orientation="horizontal">
@@ -369,48 +377,52 @@ Connect the legend to the `radiogroup` explicitly. A surrounding `fieldset` alon
 </Field>
 ```
 
-Place `autoFocus` on the first radio item so Formisch can move focus into the group after validation.
+The focus guards treat the composite group as one field, so arrow-key navigation between items does not trigger blur validation. Place `autoFocus` on the first radio item so Formisch can move focus into the group after validation.
 
 ### Slider
 
 Pass a one-element array for one thumb. A scalar value makes the generated shadcn wrapper fall back to `[min, max]` and render two thumbs. Also give the visible label an ID because a slider cannot be associated with `htmlFor`:
 
 ```tsx
-<Field of={form} path={['volume']}>
-  {(field) => (
-    <UIField data-invalid={field.errors !== null}>
-      <FieldLabel id="volume-label">Volume</FieldLabel>
-      <Slider
-        aria-labelledby="volume-label"
-        aria-invalid={field.errors !== null}
-        aria-errormessage={field.errors ? 'volume-error' : undefined}
-        name={field.props.name}
-        value={[field.input ?? 50]}
-        onValueChange={(value) =>
-          field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
-        }
-        onFocus={field.props.onFocus}
-        onBlur={field.props.onBlur}
-        ref={(root) => {
-          const input =
-            root?.querySelector<HTMLInputElement>('input[type="range"]') ??
-            null;
-          field.props.ref(input);
-          if (field.props.autoFocus) input?.focus();
-        }}
-        min={0}
-        max={100}
-      />
-      <FieldError
-        id="volume-error"
-        errors={field.errors?.map((message) => ({ message }))}
-      />
-    </UIField>
-  )}
-</Field>
+const field = useField(form, { path: ['volume'] });
+const { autoFocus, ref } = field.props;
+const sliderRef = useCallback(
+  (root: HTMLElement | null) => {
+    const input =
+      root?.querySelector<HTMLInputElement>('input[type="range"]') ?? null;
+    ref(input);
+    if (autoFocus) input?.focus();
+  },
+  [autoFocus, ref]
+);
+
+return (
+  <UIField data-invalid={field.errors !== null}>
+    <FieldLabel id="volume-label">Volume</FieldLabel>
+    <Slider
+      aria-labelledby="volume-label"
+      aria-invalid={field.errors !== null}
+      aria-errormessage={field.errors ? 'volume-error' : undefined}
+      name={field.props.name}
+      value={[field.input ?? 50]}
+      onValueChange={(value) =>
+        field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
+      }
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      ref={sliderRef}
+      min={0}
+      max={100}
+    />
+    <FieldError
+      id="volume-error"
+      errors={field.errors?.map((message) => ({ message }))}
+    />
+  </UIField>
+);
 ```
 
-The generated `Slider` does not expose Base UI's thumb `inputRef`, so the ref callback registers its nested range input. If sliders appear throughout your app, expose that ref from your local shadcn component once and reuse the simpler API.
+The generated `Slider` does not expose Base UI's thumb `inputRef`, so the ref callback registers its nested range input. `useCallback` keeps that ref stable when the controlled value updates. If sliders appear throughout your app, expose the input ref from your local shadcn component once and reuse the simpler API.
 
 ## Library-specific notes
 

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/input-components/index.mdx
@@ -187,6 +187,10 @@ import { DatePicker } from 'some-component-library';
 
 The `field.onChange` method updates the field value and triggers validation. For more details, see the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/react/guides/shadcn-ui/">shadcn/ui</Link>
+
 ## Next steps
 
 Now that you know how to create reusable input components, continue to the <Link href="/react/guides/handle-submission/">handle submission</Link> guide to learn how to process form data when the user submits the form.

--- a/website/src/routes/(docs)/react/guides/menu.md
+++ b/website/src/routes/(docs)/react/guides/menu.md
@@ -32,3 +32,7 @@
 - [From React Hook Form](/react/guides/migrate-from-react-hook-form/)
 - [From TanStack Form](/react/guides/migrate-from-tanstack-form/)
 - [From Formik](/react/guides/migrate-from-formik/)
+
+## Integration guides
+
+- [shadcn/ui](/react/guides/shadcn-ui/)


### PR DESCRIPTION
## Summary

- add a React integration guide for shadcn/ui CLI v4 components backed by Base UI v1
- document native and controlled field wiring, accessible errors, lifecycle handlers, focus behavior, and component-specific value conversions
- add contextual links from the input-components and controlled-fields guides and list integrations after migration guides
- add a repository skill for creating and verifying future UI-library integration guides

## Why

Component-library controls often use custom value callbacks and hidden native inputs. Showing only `field.onChange` omits touch and blur validation, field focusing, and accessible error relationships. This guide provides complete, copy-safe patterns while recommending reusable input components when the wiring repeats.

The guide is design-agnostic. The documented APIs were compared across all current shadcn visual styles while keeping Base UI as the explicit behavioral backend.

## Validation

- compiled and production-built all examples in a fresh shadcn CLI v4/Base UI scaffold using the locally packed React package
- verified labels, errors, controlled values, submission, touch and blur validation, Formisch focus behavior, and single-thumb Slider structure in headless Chrome
- compared Input, Textarea, Checkbox, Select, Radio Group, Slider, and Field registry APIs across all eight current shadcn visual styles
- passed website formatting, lint, TypeScript, client build, static server build, and SSG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive Formisch integration guide for shadcn/ui, covering shadcn CLI v4 with Base UI v1, native and controlled fields, validation, accessibility, errors, and common components.
  - Included examples for inputs, checkboxes, selects, radio groups, sliders, and complete login forms.
  - Added links to the shadcn/ui integration guide throughout relevant React documentation sections.
- **Documentation**
  - Expanded guidance for creating and organizing UI component library integration guides.
  - Added support for integration-guide categories and references to additional component libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->