### PR TITLE
Recompute dirty state of parent fields

### DIFF
--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -108,6 +108,21 @@ describe('setFieldInput', () => {
       expect(store.children.user.isDirty.value).toBe(false);
       expect(getFieldBool(store, 'isDirty')).toBe(false);
     });
+
+    test('should clear parent dirty state when nested input restores it', () => {
+      const store = createTestStore(
+        v.object({ user: v.nullish(v.object({ name: v.string() })) }),
+        { initialInput: { user: { name: 'John' } } }
+      );
+
+      setFieldInput(store, ['user'], null);
+      expect(getFieldBool(store, 'isDirty')).toBe(true);
+
+      setFieldInput(store, ['user', 'name'], 'John');
+      expect(getFieldInput(store)).toStrictEqual({ user: { name: 'John' } });
+      expect(store.children.user.isDirty.value).toBe(false);
+      expect(getFieldBool(store, 'isDirty')).toBe(false);
+    });
   });
 
   describe('array fields', () => {

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -176,16 +176,17 @@ export function setFieldInput(
         if (index < path.length - 1) {
           internalFieldStore.input.value = true;
 
-          // Mark parent as dirty if it was not present at its baseline
+          // Update dirty state based on input change
           // Hint: A nullish container becomes present even when the target
           // child's value equals its own baseline (e.g. `undefined` to
-          // `{ name: '' }`). The dirty state is only ever added to and never
-          // recomputed, because dirtiness from other sources, such as a
-          // changed item order or length of an array, cannot be derived from
-          // the presence of the container.
-          internalFieldStore.isDirty.value ||=
+          // `{ name: '' }`). Arrays also compare item IDs so structural dirty
+          // state from a changed length, order or item is preserved.
+          internalFieldStore.isDirty.value =
             internalFieldStore.startInput.value !==
-            internalFieldStore.input.value;
+              internalFieldStore.input.value ||
+            (internalFieldStore.kind === 'array' &&
+              internalFieldStore.startItems.value.join() !==
+                internalFieldStore.items.value.join());
         }
       }
 


### PR DESCRIPTION
## Summary

- recompute parent container dirty state when setting nested input
- preserve array structural dirtiness by comparing the complete item identity sequence
- add a regression test for reconstructing a nullable object back to its initial input

## Root cause

PR #189 used logical OR assignment when updating parent dirty state. That correctly marked an absent parent dirty when it became present, but it also latched an existing dirty flag. A nullable object changed to `null` and then reconstructed through a nested field therefore remained dirty even after its complete input matched the baseline again.

## Impact

Parent and form-level `isDirty` now return to `false` when nested updates restore the original container input, without clearing dirty state caused by array length, order, or item identity changes.

## Validation

- `pnpm -C packages/core test` (461 tests)
- `pnpm -C packages/core lint`
- `pnpm -C packages/core format.check`
- `pnpm -C packages/methods test` (215 tests)
- `pnpm -C packages/methods lint`
- `pnpm -C packages/methods format.check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form change tracking when updating nested fields.
  * Correctly detects changes to array length and item order.
  * Restores clean parent and form states when values return to their original state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->