### PR TITLE
Add component library integration guides for all supported frameworks

### DIFF
--- a/.agents/skills/repo-website-integration-guide-create/SKILL.md
+++ b/.agents/skills/repo-website-integration-guide-create/SKILL.md
@@ -3,7 +3,7 @@ name: repo-website-integration-guide-create
 description: Add integration guides for using Formisch with UI component libraries (e.g. shadcn/ui, Mantine, Chakra UI) to the Formisch website. Use when documenting how to wire Formisch fields to a component library's inputs.
 metadata:
   author: formisch
-  version: '1.1'
+  version: '1.2'
 ---
 
 # Adding Integration Guides
@@ -104,12 +104,14 @@ If a component exposes `onCheckedChange`, `onValueChange` or another value callb
 | Formisch behavior       | Typical component-library target                        |
 | ----------------------- | ------------------------------------------------------- |
 | `field.input`           | `value` or `checked`                                    |
-| `field.onChange`        | custom value callback                                   |
+| programmatic setter     | custom value callback                                   |
 | `field.props.name`      | root `name` or hidden native input                      |
 | `field.props.ref`       | public `inputRef` or another focusable native target    |
 | `field.props.autoFocus` | visible trigger, first group item or registered input   |
 | `field.props.onFocus`   | focus event on the visible interactive control or group |
 | `field.props.onBlur`    | blur event on the visible interactive control or group  |
+
+The setter is named differently per framework; see the porting table below.
 
 The lifecycle mapping keeps `isTouched`, touch/blur validation, `focus()` and submit-time error focusing working. Prefer the library's public API or a local adapter when a component hides an essential ref or event prop. Only adapt the component itself when its source belongs to the reader. A scoped ref lookup inside owned source is an acceptable fallback when the structure has been runtime-verified.
 
@@ -123,7 +125,7 @@ Field API source of truth: `frameworks/{framework}/src/types/field.ts`.
 | ----------------------------------------------------- | -------------------------------------------------- |
 | `field.props`                                         | Native name, ref, autofocus and lifecycle handlers |
 | `field.input`                                         | Current controlled value                           |
-| `field.onChange`                                      | Programmatic update and input/change validation    |
+| programmatic setter                                   | Programmatic update and validation                 |
 | `field.errors`                                        | `[string, ...string[]] \| null` error messages     |
 | `field.isTouched` / `field.isDirty` / `field.isValid` | Current field state                                |
 
@@ -162,6 +164,33 @@ Transcribe only the verified, minimal wiring into the guide. Delete the temporar
 ## Porting to Other Frameworks
 
 Use the same skeleton and schema, then replace package and API names according to the framework terminology table in `repo-website-guide-create`. Confirm that the UI library supports the framework before creating the guide. Register it under the same `## Integration guides` heading for that framework.
+
+The field contract is the same everywhere, but its spelling is not. Verify against `frameworks/{framework}/src/types/field.ts`, then use:
+
+| Framework    | Form and field                                | Native binding                                   | Programmatic setter          | Lifecycle props                         |
+| ------------ | --------------------------------------------- | ------------------------------------------------ | ---------------------------- | --------------------------------------- |
+| React        | `useForm`, `<Form>`, `<Field>` render prop    | `{...field.props}` + `value`                     | `field.onChange(value)`      | `onFocus`, `onBlur`, `autoFocus`        |
+| Preact       | `useForm`, `<Field>` render prop              | `{...field.props}` + `value={field.input.value}` | `field.onInput(value)`       | `onFocus`, `onBlur`, `autofocus`        |
+| Solid        | `createForm`, `<Field>` render prop           | `{...field.props}` + `value`                     | `field.onInput(value)`       | `onFocus`, `onBlur`, `autofocus`        |
+| Svelte       | `createForm`, `<Field>` snippet, `onsubmit`   | `{...field.props}` + `value`                     | `field.onInput(value)`       | `onfocus`, `onblur`, `autofocus`        |
+| Vue          | `useForm`, `<Field v-slot>`                   | `v-bind="field.props"` + `v-model="field.input"` | assign `field.input = ...`   | `onFocus`, `onBlur`, `autofocus`        |
+| Qwik         | `useForm$`, `<Field>` render prop             | `{...field.props}` + `value={field.input.value}` | `field.onInput(value)` (QRL) | `onFocus$`, `onBlur$` (QRLs)            |
+| React Native | `useForm`, `<Field>` render prop, no `<Form>` | `{...field.props}` + `value`                     | `field.onChange(value)`      | `onFocus`, `onBlur` (no name/autofocus) |
+| Angular      | `injectForm`, `*formischField`                | `[formischControl]="field"`                      | `field.setInput(value)`      | handled by the directive                |
+
+Two consequences worth checking before writing: Svelte spells every handler in lowercase and passes its ref as an attachment symbol, so a spread only registers the element when it lands on real DOM. Vue has no setter method and its `props.onChange` only triggers change-mode validation, so the value must flow through `v-model` or an explicit assignment.
+
+### React Native
+
+React Native has no DOM, so the skeleton changes:
+
+- There is no `<Form>` component. Wrap fields in a `View` and submit with a `Pressable` calling `handleSubmit(form, callback)`.
+- `field.props` is only `{ ref, onFocus, onBlur, onChangeText }`. Spread it onto `TextInput`; there is no `name` or `autofocus` to forward.
+- Controls that cannot receive focus, such as a checkbox, radio or select trigger, call `field.props.onFocus()` in their press handler to mark the field touched.
+- `FieldElement` is structural (`focus`, optional `blur` and `isFocused`). Expose it from a custom control with `useImperativeHandle` so `focus()` and submit-time error focusing work.
+- Import everything from `@formisch/react-native`, which bundles core and methods. Mixing it with `@formisch/methods/react-native` creates a second reactive graph, so state updates without re-rendering.
+- Accessibility uses `accessibilityLabel`, `aria-invalid` and the library's error component instead of `htmlFor`, `aria-errormessage` and ids.
+- Verify in a browser through `react-native-web` and drop the DOM-only checks from the browser checklist.
 
 ## Cross-Linking
 

--- a/website/src/routes/(docs)/react-native/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -93,6 +93,13 @@ import { ColorPicker } from 'some-component-library';
 
 The `field.onChange` method updates the field value and triggers validation, just like typing into a connected `TextInput` would.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/react-native/guides/gluestack-ui/">gluestack-ui</Link>
+- <Link href="/react-native/guides/react-native-paper/">
+    React Native Paper
+  </Link>
+
 ## Next steps
 
 Now that you understand controlled fields, you can explore more advanced topics like <Link href="/react-native/guides/nested-fields/">nested fields</Link> and <Link href="/react-native/guides/field-arrays/">field arrays</Link> to handle complex form structures.

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
@@ -298,7 +298,7 @@ Use `Textarea` with `TextareaInput` for a longer text field. The wiring is ident
 
 ### Select
 
-`Select` has no imperative API for opening its menu, so route the element reference to the trigger. `onOpen` is where the field becomes touched, since focusing the control alone does not count as an interaction:
+`Select` has no imperative API for opening its menu, so route the element reference to the trigger. `onOpen` is where the field becomes touched, since focusing the control alone does not count as an interaction, and `onClose` reports the blur that ends it:
 
 ```tsx
 <Field of={form} path={['framework']}>
@@ -318,6 +318,7 @@ Use `Textarea` with `TextareaInput` for a longer text field. The wiring is ident
         <Select
           selectedValue={field.input}
           onOpen={() => field.props.onFocus()}
+          onClose={() => field.props.onBlur()}
           onValueChange={(value) => field.onChange(value as 'angular' | 'vue')}
         >
           <SelectTrigger ref={setFieldRef as never}>

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
@@ -1,0 +1,433 @@
+---
+title: gluestack-ui
+description: >-
+  Learn how to connect Formisch fields to gluestack-ui inputs, selects, radio
+  groups, sliders and other form components.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# gluestack-ui
+
+[gluestack-ui](https://gluestack.io) generates universal components into your own project, where you can adapt them to your needs. This guide targets gluestack-ui v5. No adapter package is needed: the input components accept the whole `field.props` spread, while every other control reports its value through its own callback and marks the field as touched on press.
+
+## Installation
+
+Create the project, add the web dependencies, then initialize gluestack-ui and add the components used below:
+
+```bash
+npx create-expo-app@latest my-app --template blank-typescript
+npx expo install react-native-web react-dom @expo/metro-runtime react-native-safe-area-context
+npx gluestack-ui init --use-npm --uniwind
+npx gluestack-ui add input textarea select slider checkbox radio form-control button icon
+npm install @formisch/react-native valibot
+```
+
+Three things are worth knowing about that setup. The `init` command writes a Babel config that requires `babel-preset-expo` without adding it as a dependency, so install it yourself. Adding `checkbox`, `radio` or `select` does not pull in `icon`, which their documented usage needs, so add it explicitly. Finally, verify the app in a browser rather than trusting a successful `expo export`, since a bundle can build and still fail to boot.
+
+Import everything from `@formisch/react-native`. That package bundles the core and the methods, so importing from `@formisch/methods/react-native` alongside it would load a second copy of Formisch's reactive state and break updates in field arrays.
+
+## Wiring patterns
+
+React Native has no DOM, so `field.props` is only `{ ref, onFocus, onBlur, onChangeText }`. There is no `name` and no `autoFocus` to forward:
+
+- On `InputField` or `TextareaInput`, spread `field.props` and pass `field.input` as the value.
+- On any other control, pass `field.input` as the value, send the control's callback to `field.onChange`, and call `field.props.onFocus()` when the control is pressed or opened.
+
+That last point is the important one. A press does not raise a focus event in React Native, so without calling `field.props.onFocus()` yourself the field never becomes touched and touch validation never runs.
+
+### Spreading field.props
+
+`InputField` forwards the spread to the underlying native input. gluestack types its component refs against the props type rather than the element instance, so the reference needs a cast even though it is forwarded correctly at runtime:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <Input>
+      <InputField
+        {...field.props}
+        // gluestack types its component refs against the props type
+        // instead of the element instance, so the field ref, which is
+        // forwarded to a real element at runtime, needs a cast
+        ref={field.props.ref as never}
+        placeholder="example@email.com"
+        value={field.input ?? ''}
+      />
+    </Input>
+  )}
+</Field>
+```
+
+### Controlled components
+
+The checkbox reports its new state, so mark the field as touched in the same handler:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox
+      ref={field.props.ref as never}
+      value="rememberMe"
+      isChecked={!!field.input}
+      onChange={(isChecked: boolean) => {
+        // Press does not trigger focus, so mark the field as touched here
+        field.props.onFocus();
+        field.onChange(isChecked);
+      }}
+    >
+      <CheckboxIndicator>
+        <CheckboxIcon as={CheckIcon} />
+      </CheckboxIndicator>
+      <CheckboxLabel>Remember me</CheckboxLabel>
+    </Checkbox>
+  )}
+</Field>
+```
+
+Note that the programmatic setter is `field.onChange(value)`. In React Native, `field.props` carries only `onChangeText`, which is meant for text input.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Wrap a control in `FormControl` and pass `isInvalid`, then render the message in `FormControlError`. The wrapper also applies the invalid state to the nested control, so setting `aria-invalid` yourself has no effect:
+
+```tsx
+<FormControl isInvalid={!!field.errors}>
+  <FormControlLabel>
+    <FormControlLabelText>Email</FormControlLabelText>
+  </FormControlLabel>
+  <Input>
+    <InputField
+      {...field.props}
+      ref={field.props.ref as never}
+      value={field.input ?? ''}
+    />
+  </Input>
+  <FormControlError>
+    <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+  </FormControlError>
+</FormControl>
+```
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/react-native/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+React Native has no `Form` component. Wrap the fields in a `View` and pass `handleSubmit` straight to a button, since it returns a function that takes no arguments:
+
+```tsx
+import { Button, ButtonText } from '@/components/ui/button';
+import {
+  Checkbox,
+  CheckboxIcon,
+  CheckboxIndicator,
+  CheckboxLabel,
+} from '@/components/ui/checkbox';
+import {
+  FormControl,
+  FormControlError,
+  FormControlErrorText,
+  FormControlLabel,
+  FormControlLabelText,
+} from '@/components/ui/form-control';
+import { CheckIcon } from '@/components/ui/icon';
+import { Input, InputField } from '@/components/ui/input';
+import { Field, handleSubmit, useForm } from '@formisch/react-native';
+import { View } from 'react-native';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export function LoginForm() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: { email: '', password: '', rememberMe: false },
+  });
+
+  const submitForm = handleSubmit(loginForm, (output) => {
+    console.log(output);
+  });
+
+  return (
+    <View style={{ gap: 16 }}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <FormControl isInvalid={!!field.errors}>
+            <FormControlLabel>
+              <FormControlLabelText>Email</FormControlLabelText>
+            </FormControlLabel>
+            <Input>
+              <InputField
+                {...field.props}
+                // gluestack types its component refs against the props type
+                // instead of the element instance, so the field ref, which is
+                // forwarded to a real element at runtime, needs a cast
+                ref={field.props.ref as never}
+                placeholder="example@email.com"
+                value={field.input ?? ''}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoComplete="email"
+              />
+            </Input>
+            <FormControlError>
+              <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+            </FormControlError>
+          </FormControl>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <FormControl isInvalid={!!field.errors}>
+            <FormControlLabel>
+              <FormControlLabelText>Password</FormControlLabelText>
+            </FormControlLabel>
+            <Input>
+              <InputField
+                {...field.props}
+                ref={field.props.ref as never}
+                placeholder="********"
+                value={field.input ?? ''}
+                type="password"
+                autoComplete="current-password"
+              />
+            </Input>
+            <FormControlError>
+              <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+            </FormControlError>
+          </FormControl>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <Checkbox
+            ref={field.props.ref as never}
+            value="rememberMe"
+            isChecked={!!field.input}
+            onChange={(isChecked: boolean) => {
+              // Press does not trigger focus, so mark the field as touched here
+              field.props.onFocus();
+              field.onChange(isChecked);
+            }}
+          >
+            <CheckboxIndicator>
+              <CheckboxIcon as={CheckIcon} />
+            </CheckboxIndicator>
+            <CheckboxLabel>Remember me</CheckboxLabel>
+          </Checkbox>
+        )}
+      </Field>
+
+      <Button onPress={submitForm} isDisabled={loginForm.isSubmitting}>
+        <ButtonText>Login</ButtonText>
+      </Button>
+    </View>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. A failed submit moves focus to the first invalid field on its own, so no extra wiring is needed for that.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <FormControl isInvalid={!!field.errors}>
+      <FormControlLabel>
+        <FormControlLabelText>Email</FormControlLabelText>
+      </FormControlLabel>
+      <Input>
+        <InputField
+          {...field.props}
+          ref={field.props.ref as never}
+          value={field.input ?? ''}
+        />
+      </Input>
+      <FormControlError>
+        <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+      </FormControlError>
+    </FormControl>
+  )}
+</Field>
+```
+
+Use `Textarea` with `TextareaInput` for a longer text field. The wiring is identical.
+
+### Checkbox
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <Checkbox
+      ref={field.props.ref as never}
+      value="newsletter"
+      isChecked={!!field.input}
+      onChange={(isChecked: boolean) => {
+        field.props.onFocus();
+        field.onChange(isChecked);
+      }}
+    >
+      <CheckboxIndicator>
+        <CheckboxIcon as={CheckIcon} />
+      </CheckboxIndicator>
+      <CheckboxLabel>Newsletter</CheckboxLabel>
+    </Checkbox>
+  )}
+</Field>
+```
+
+### Select
+
+`Select` has no imperative API for opening its menu, so route the element reference to the trigger. `onOpen` is where the field becomes touched, since focusing the control alone does not count as an interaction:
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => {
+    // gluestack's `Select` has no imperative open API, so `focus(form, { path })`
+    // is routed to the trigger element. `isFocused` is deliberately omitted:
+    // Formisch treats an element without it as successfully focused instead
+    // of skipping on to the next errored field.
+    const setFieldRef = (element: { focus?: () => void } | null) =>
+      field.props.ref(element ? { focus: () => element.focus?.() } : null);
+
+    return (
+      <FormControl isInvalid={!!field.errors}>
+        <FormControlLabel>
+          <FormControlLabelText>Framework</FormControlLabelText>
+        </FormControlLabel>
+        <Select
+          selectedValue={field.input}
+          onOpen={() => field.props.onFocus()}
+          onValueChange={(value) => field.onChange(value as 'angular' | 'vue')}
+        >
+          <SelectTrigger ref={setFieldRef as never}>
+            <SelectInput placeholder="Select a framework" />
+            <SelectIcon as={ChevronDownIcon} />
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectBackdrop />
+            <SelectContent>
+              {FRAMEWORKS.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  label={option.label}
+                  value={option.value}
+                />
+              ))}
+            </SelectContent>
+          </SelectPortal>
+        </Select>
+        <FormControlError>
+          <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+        </FormControlError>
+      </FormControl>
+    );
+  }}
+</Field>
+```
+
+### Radio group
+
+`RadioGroup` reports the new value, so mark the field as touched there:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <FormControl isInvalid={!!field.errors}>
+      <FormControlLabel>
+        <FormControlLabelText>Plan</FormControlLabelText>
+      </FormControlLabel>
+      <RadioGroup
+        ref={field.props.ref as never}
+        value={field.input ?? ''}
+        onChange={(value: string) => {
+          field.props.onFocus();
+          field.onChange(value as 'hobby' | 'pro');
+        }}
+      >
+        <View style={{ flexDirection: 'row', gap: 24 }}>
+          <Radio value="hobby">
+            <RadioIndicator>
+              <RadioIcon as={CircleIcon} />
+            </RadioIndicator>
+            <RadioLabel>Hobby</RadioLabel>
+          </Radio>
+          <Radio value="pro">
+            <RadioIndicator>
+              <RadioIcon as={CircleIcon} />
+            </RadioIndicator>
+            <RadioLabel>Pro</RadioLabel>
+          </Radio>
+        </View>
+      </RadioGroup>
+      <FormControlError>
+        <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+      </FormControlError>
+    </FormControl>
+  )}
+</Field>
+```
+
+### Slider
+
+The slider works with numbers directly, so `field.onChange` can be passed as is. Its thumb is the focusable part, and `onChangeEnd` marks the end of an interaction:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <FormControl isInvalid={!!field.errors}>
+      <FormControlLabel>
+        <FormControlLabelText>Volume: {field.input}</FormControlLabelText>
+      </FormControlLabel>
+      <View ref={field.props.ref}>
+        <Slider
+          value={field.input}
+          minValue={0}
+          maxValue={100}
+          step={1}
+          onChange={field.onChange}
+          onChangeEnd={() => field.props.onBlur()}
+        >
+          <SliderTrack>
+            <SliderFilledTrack />
+          </SliderTrack>
+          <SliderThumb onFocus={() => field.props.onFocus()} />
+        </Slider>
+      </View>
+      <FormControlError>
+        <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+      </FormControlError>
+    </FormControl>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+When you write a custom control, only expose `isFocused` from its `FieldElement` if it reports the truth. Formisch treats an element without `isFocused` as focused, but one that returns `false` is treated as a failed focus, and it moves on to the next invalid field.
+
+The generated components do not typecheck cleanly under `strict` on a fresh scaffold. Those errors are in the generated source rather than in your field wiring, and you can fix them in place since the components live in your project.
+
+## Next steps
+
+Read the <Link href="/react-native/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react-native/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react-native/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
@@ -93,21 +93,25 @@ Note that the programmatic setter is `field.onChange(value)`. In React Native, `
 Formisch exposes errors as `[string, ...string[]] | null`. Wrap a control in `FormControl` and pass `isInvalid`, then render the message in `FormControlError`. The wrapper also applies the invalid state to the nested control, so setting `aria-invalid` yourself has no effect:
 
 ```tsx
-<FormControl isInvalid={!!field.errors}>
-  <FormControlLabel>
-    <FormControlLabelText>Email</FormControlLabelText>
-  </FormControlLabel>
-  <Input>
-    <InputField
-      {...field.props}
-      ref={field.props.ref as never}
-      value={field.input ?? ''}
-    />
-  </Input>
-  <FormControlError>
-    <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
-  </FormControlError>
-</FormControl>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <FormControl isInvalid={!!field.errors}>
+      <FormControlLabel>
+        <FormControlLabelText>Email</FormControlLabelText>
+      </FormControlLabel>
+      <Input>
+        <InputField
+          {...field.props}
+          ref={field.props.ref as never}
+          value={field.input ?? ''}
+        />
+      </Input>
+      <FormControlError>
+        <FormControlErrorText>{field.errors?.[0]}</FormControlErrorText>
+      </FormControlError>
+    </FormControl>
+  )}
+</Field>
 ```
 
 By default, Formisch validates on submit and revalidates on input. The <Link href="/react-native/guides/validation/">validation guide</Link> explains how to change that timing.

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/gluestack-ui/index.mdx
@@ -390,7 +390,7 @@ Use `Textarea` with `TextareaInput` for a longer text field. The wiring is ident
 
 ### Slider
 
-The slider works with numbers directly, so `field.onChange` can be passed as is. Its thumb is the focusable part, and `onChangeEnd` marks the end of an interaction:
+The slider works with numbers directly, so `field.onChange` can be passed as is. Its thumb is the focusable part, and `onChangeEnd` marks the end of an interaction. There is no native input to register, so `focus` cannot reach this field; do not register the surrounding `View` instead, because React Native cannot verify whether an element took focus and Formisch would treat the failed attempt as successful:
 
 ```tsx
 <Field of={form} path={['volume']}>
@@ -399,7 +399,7 @@ The slider works with numbers directly, so `field.onChange` can be passed as is.
       <FormControlLabel>
         <FormControlLabelText>Volume: {field.input}</FormControlLabelText>
       </FormControlLabel>
-      <View ref={field.props.ref}>
+      <View>
         <Slider
           value={field.input}
           minValue={0}

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
@@ -1,0 +1,392 @@
+---
+title: React Native Paper
+description: >-
+  Learn how to connect Formisch fields to React Native Paper text inputs,
+  checkboxes, radio buttons and other form components.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# React Native Paper
+
+[React Native Paper](https://callstack.github.io/react-native-paper/) is a Material Design component library for React Native. This guide targets Paper v5. No adapter package is needed: `TextInput` accepts the whole `field.props` spread, while every other control reports its value through its own callback and marks the field as touched on press.
+
+## Installation
+
+Install Formisch, Valibot and React Native Paper, then wrap your app in `PaperProvider` as described in the [Paper getting started guide](https://callstack.github.io/react-native-paper/docs/guides/getting-started):
+
+```bash
+npx expo install @formisch/react-native valibot react-native-paper react-native-safe-area-context
+```
+
+Import everything from `@formisch/react-native`. That package bundles the core and the methods, so importing from `@formisch/methods/react-native` alongside it would load a second copy of Formisch's reactive state and break updates in field arrays.
+
+## Wiring patterns
+
+React Native has no DOM, so `field.props` is only `{ ref, onFocus, onBlur, onChangeText }`. There is no `name` and no `autoFocus` to forward:
+
+- On a text input, spread `field.props` and pass `field.input` as the value.
+- On any other control, pass `field.input` as the value, send the control's callback to `field.onChange`, and call `field.props.onFocus()` in the press handler.
+
+That last point is the important one. A press does not raise a focus event in React Native, so without calling `field.props.onFocus()` yourself the field never becomes touched and touch validation never runs.
+
+### Spreading field.props
+
+Paper's `TextInput` forwards the spread to the underlying native input:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextInput
+      {...field.props}
+      mode="outlined"
+      label="Email"
+      value={field.input ?? ''}
+      error={!!field.errors}
+      aria-invalid={!!field.errors}
+    />
+  )}
+</Field>
+```
+
+Paper's `error` prop only changes the styling, so set `aria-invalid` as well to expose the state to assistive technology.
+
+### Controlled components
+
+`Checkbox.Item` accepts no `ref`, so register a wrapping `View` to keep the field reachable for <Link href="/methods/api/focus/">`focus`</Link>, and mark the field as touched in the press handler:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <View ref={field.props.ref}>
+      <Checkbox.Item
+        label="Remember me"
+        status={field.input ? 'checked' : 'unchecked'}
+        onPress={() => {
+          field.props.onFocus();
+          field.onChange(!field.input);
+        }}
+      />
+    </View>
+  )}
+</Field>
+```
+
+Note that the programmatic setter is `field.onChange(value)`. In React Native, `field.props` carries only `onChangeText`, which is meant for text input.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Paper's `HelperText` renders the message and unmounts it when the field becomes valid again:
+
+```tsx
+<TextInput
+  {...field.props}
+  label="Email"
+  value={field.input ?? ''}
+  error={!!field.errors}
+  aria-invalid={!!field.errors}
+/>
+<HelperText type="error" visible={!!field.errors}>
+  {field.errors?.[0]}
+</HelperText>
+```
+
+Paper does not associate the helper text with the input, so there is no equivalent of `aria-errormessage` here.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/react-native/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+React Native has no `Form` component. Wrap the fields in a `View` and pass `handleSubmit` straight to a button, since it returns a function that takes no arguments:
+
+```tsx
+import { Field, handleSubmit, useForm } from '@formisch/react-native';
+import { View } from 'react-native';
+import { Button, Checkbox, HelperText, TextInput } from 'react-native-paper';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export function LoginForm() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: { email: '', password: '', rememberMe: false },
+  });
+
+  const submitForm = handleSubmit(loginForm, (output) => {
+    console.log(output);
+  });
+
+  return (
+    <View style={{ gap: 8 }}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <View>
+            <TextInput
+              {...field.props}
+              mode="outlined"
+              label="Email"
+              placeholder="example@email.com"
+              value={field.input ?? ''}
+              error={!!field.errors}
+              aria-invalid={!!field.errors}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoComplete="email"
+            />
+            <HelperText type="error" visible={!!field.errors}>
+              {field.errors?.[0]}
+            </HelperText>
+          </View>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <View>
+            <TextInput
+              {...field.props}
+              mode="outlined"
+              label="Password"
+              value={field.input ?? ''}
+              error={!!field.errors}
+              aria-invalid={!!field.errors}
+              secureTextEntry
+              autoComplete="current-password"
+            />
+            <HelperText type="error" visible={!!field.errors}>
+              {field.errors?.[0]}
+            </HelperText>
+          </View>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          // `Checkbox.Item` accepts no ref, so the field ref goes on a wrapping
+          // `View` to keep the field reachable for `focus(form, { path })`
+          <View ref={field.props.ref}>
+            <Checkbox.Item
+              label="Remember me"
+              status={field.input ? 'checked' : 'unchecked'}
+              onPress={() => {
+                // Press does not trigger focus, so mark the field as touched here
+                field.props.onFocus();
+                field.onChange(!field.input);
+              }}
+            />
+          </View>
+        )}
+      </Field>
+
+      <Button
+        mode="contained"
+        onPress={submitForm}
+        loading={loginForm.isSubmitting}
+        disabled={loginForm.isSubmitting}
+      >
+        Login
+      </Button>
+    </View>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. A failed submit moves focus to the first invalid field on its own, so no extra wiring is needed for that.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <View>
+      <TextInput
+        {...field.props}
+        mode="outlined"
+        label="Email"
+        value={field.input ?? ''}
+        error={!!field.errors}
+        aria-invalid={!!field.errors}
+      />
+      <HelperText type="error" visible={!!field.errors}>
+        {field.errors?.[0]}
+      </HelperText>
+    </View>
+  )}
+</Field>
+```
+
+Add `multiline` for a longer text field. The wiring stays the same.
+
+### Checkbox
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <View ref={field.props.ref}>
+      <Checkbox.Item
+        label="Newsletter"
+        status={field.input ? 'checked' : 'unchecked'}
+        onPress={() => {
+          field.props.onFocus();
+          field.onChange(!field.input);
+        }}
+      />
+    </View>
+  )}
+</Field>
+```
+
+### Select
+
+Paper has no select component. Build one from `Menu` with a pressable anchor, and expose a `FieldElement` through `useImperativeHandle` so `focus` can open it:
+
+```tsx
+function MenuSelect<TValue extends string>({
+  ref,
+  onFocus,
+  label,
+  value,
+  options,
+  onValueChange,
+}: Pick<FieldElementProps, 'ref' | 'onFocus'> & {
+  label: string;
+  value: TValue | undefined;
+  options: readonly { label: string; value: TValue }[];
+  onValueChange: (value: TValue) => void;
+}) {
+  const [visible, setVisible] = useState(false);
+
+  // Expose a `FieldElement` so `focus(form, { path })` can reach this control.
+  // `isFocused` is deliberately omitted: Formisch treats an element without it
+  // as successfully focused, instead of skipping to the next errored field.
+  useImperativeHandle(ref, () => ({
+    focus: () => setVisible(true),
+    blur: () => setVisible(false),
+  }));
+
+  return (
+    <Menu
+      visible={visible}
+      onDismiss={() => setVisible(false)}
+      anchor={
+        <Button
+          mode="outlined"
+          onPress={() => {
+            onFocus();
+            setVisible(true);
+          }}
+        >
+          {options.find((option) => option.value === value)?.label ?? label}
+        </Button>
+      }
+    >
+      {options.map((option) => (
+        <Menu.Item
+          key={option.value}
+          title={option.label}
+          onPress={() => {
+            onValueChange(option.value);
+            setVisible(false);
+          }}
+        />
+      ))}
+    </Menu>
+  );
+}
+```
+
+Making the component generic over `TValue` keeps it assignable to `field.onChange`, which expects the schema's union rather than a plain string:
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <MenuSelect
+      ref={field.props.ref}
+      onFocus={field.props.onFocus}
+      label="Select a framework"
+      value={field.input}
+      options={FRAMEWORKS}
+      onValueChange={field.onChange}
+    />
+  )}
+</Field>
+```
+
+For a small set of options, `SegmentedButtons` is a simpler alternative.
+
+### Radio group
+
+`RadioButton.Group` reports the new value, so mark the field as touched there:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <View ref={field.props.ref} role="radiogroup">
+      <RadioButton.Group
+        value={field.input ?? ''}
+        onValueChange={(value) => {
+          field.props.onFocus();
+          field.onChange(value as 'hobby' | 'pro');
+        }}
+      >
+        <RadioButton.Item label="Hobby" value="hobby" />
+        <RadioButton.Item label="Pro" value="pro" />
+      </RadioButton.Group>
+      <HelperText type="error" visible={!!field.errors}>
+        {field.errors?.[0]}
+      </HelperText>
+    </View>
+  )}
+</Field>
+```
+
+### Slider
+
+Paper has no slider. The community package `@react-native-community/slider` works with numbers directly, so `field.onChange` can be passed as is, and its drag events map onto the focus and blur handlers:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <View ref={field.props.ref}>
+      <Text>Volume: {field.input}</Text>
+      <Slider
+        style={{ width: '100%', height: 40 }}
+        value={field.input}
+        minimumValue={0}
+        maximumValue={100}
+        step={1}
+        onSlidingStart={() => field.props.onFocus()}
+        onSlidingComplete={() => field.props.onBlur()}
+        onValueChange={field.onChange}
+      />
+    </View>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+When you write a custom control, only expose `isFocused` from its `FieldElement` if it reports the truth. Formisch treats an element without `isFocused` as focused, but one that returns `false` is treated as a failed focus, and it moves on to the next invalid field.
+
+## Next steps
+
+Read the <Link href="/react-native/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react-native/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react-native/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
@@ -85,15 +85,19 @@ Note that the programmatic setter is `field.onChange(value)`. In React Native, `
 Formisch exposes errors as `[string, ...string[]] | null`. Paper's `HelperText` renders the message and unmounts it when the field becomes valid again:
 
 ```tsx
-<TextInput
-  {...field.props}
-  label="Email"
-  value={field.input ?? ''}
-  error={!!field.errors}
-/>
-<HelperText type="error" visible={!!field.errors}>
-  {field.errors?.[0]}
-</HelperText>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextInput
+      {...field.props}
+      label="Email"
+      value={field.input ?? ''}
+      error={!!field.errors}
+    />
+    <HelperText type="error" visible={!!field.errors}>
+      {field.errors?.[0]}
+    </HelperText>
+  )}
+</Field>
 ```
 
 Paper does not associate the helper text with the input, so there is no equivalent of `aria-errormessage` here.

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
@@ -21,6 +21,12 @@ Install Formisch, Valibot and React Native Paper, then wrap your app in `PaperPr
 npx expo install @formisch/react-native valibot react-native-paper react-native-safe-area-context
 ```
 
+The slider section below additionally uses `@react-native-community/slider`, which is a separate package rather than part of Paper:
+
+```bash
+npx expo install @react-native-community/slider
+```
+
 Import everything from `@formisch/react-native`. That package bundles the core and the methods, so importing from `@formisch/methods/react-native` alongside it would load a second copy of Formisch's reactive state and break updates in field arrays.
 
 ## Wiring patterns
@@ -45,31 +51,29 @@ Paper's `TextInput` forwards the spread to the underlying native input:
       label="Email"
       value={field.input ?? ''}
       error={!!field.errors}
-      aria-invalid={!!field.errors}
     />
   )}
 </Field>
 ```
 
-Paper's `error` prop only changes the styling, so set `aria-invalid` as well to expose the state to assistive technology.
+Paper's `error` prop switches the input to its error styling. React Native has no equivalent of the `aria-invalid` attribute, so the visible `HelperText` below the input is what conveys the error.
 
 ### Controlled components
 
-`Checkbox.Item` accepts no `ref`, so register a wrapping `View` to keep the field reachable for <Link href="/methods/api/focus/">`focus`</Link>, and mark the field as touched in the press handler:
+`Checkbox.Item` accepts no `ref`, so there is no element to register and <Link href="/methods/api/focus/">`focus`</Link> cannot reach this field. Do not register a wrapping `View` to work around it: React Native cannot verify whether an element took focus, so Formisch trusts any registered element that cannot report its focus state and stops there, which makes a failed focus look successful. Mark the field as touched in the press handler instead:
 
 ```tsx
 <Field of={loginForm} path={['rememberMe']}>
   {(field) => (
-    <View ref={field.props.ref}>
-      <Checkbox.Item
-        label="Remember me"
-        status={field.input ? 'checked' : 'unchecked'}
-        onPress={() => {
-          field.props.onFocus();
-          field.onChange(!field.input);
-        }}
-      />
-    </View>
+    <Checkbox.Item
+      label="Remember me"
+      status={field.input ? 'checked' : 'unchecked'}
+      onPress={() => {
+        // Press does not trigger focus, so mark the field as touched here
+        field.props.onFocus();
+        field.onChange(!field.input);
+      }}
+    />
   )}
 </Field>
 ```
@@ -86,7 +90,6 @@ Formisch exposes errors as `[string, ...string[]] | null`. Paper's `HelperText` 
   label="Email"
   value={field.input ?? ''}
   error={!!field.errors}
-  aria-invalid={!!field.errors}
 />
 <HelperText type="error" visible={!!field.errors}>
   {field.errors?.[0]}
@@ -143,7 +146,6 @@ export function LoginForm() {
               placeholder="example@email.com"
               value={field.input ?? ''}
               error={!!field.errors}
-              aria-invalid={!!field.errors}
               keyboardType="email-address"
               autoCapitalize="none"
               autoComplete="email"
@@ -164,7 +166,6 @@ export function LoginForm() {
               label="Password"
               value={field.input ?? ''}
               error={!!field.errors}
-              aria-invalid={!!field.errors}
               secureTextEntry
               autoComplete="current-password"
             />
@@ -177,19 +178,16 @@ export function LoginForm() {
 
       <Field of={loginForm} path={['rememberMe']}>
         {(field) => (
-          // `Checkbox.Item` accepts no ref, so the field ref goes on a wrapping
-          // `View` to keep the field reachable for `focus(form, { path })`
-          <View ref={field.props.ref}>
-            <Checkbox.Item
-              label="Remember me"
-              status={field.input ? 'checked' : 'unchecked'}
-              onPress={() => {
-                // Press does not trigger focus, so mark the field as touched here
-                field.props.onFocus();
-                field.onChange(!field.input);
-              }}
-            />
-          </View>
+          // `Checkbox.Item` accepts no ref, so `focus` cannot reach this field
+          <Checkbox.Item
+            label="Remember me"
+            status={field.input ? 'checked' : 'unchecked'}
+            onPress={() => {
+              // Press does not trigger focus, so mark the field as touched here
+              field.props.onFocus();
+              field.onChange(!field.input);
+            }}
+          />
         )}
       </Field>
 
@@ -224,7 +222,6 @@ The following snippets assume a form store named `form` and initialized values t
         label="Email"
         value={field.input ?? ''}
         error={!!field.errors}
-        aria-invalid={!!field.errors}
       />
       <HelperText type="error" visible={!!field.errors}>
         {field.errors?.[0]}
@@ -241,33 +238,32 @@ Add `multiline` for a longer text field. The wiring stays the same.
 ```tsx
 <Field of={form} path={['newsletter']}>
   {(field) => (
-    <View ref={field.props.ref}>
-      <Checkbox.Item
-        label="Newsletter"
-        status={field.input ? 'checked' : 'unchecked'}
-        onPress={() => {
-          field.props.onFocus();
-          field.onChange(!field.input);
-        }}
-      />
-    </View>
+    <Checkbox.Item
+      label="Newsletter"
+      status={field.input ? 'checked' : 'unchecked'}
+      onPress={() => {
+        field.props.onFocus();
+        field.onChange(!field.input);
+      }}
+    />
   )}
 </Field>
 ```
 
 ### Select
 
-Paper has no select component. Build one from `Menu` with a pressable anchor, and expose a `FieldElement` through `useImperativeHandle` so `focus` can open it:
+Paper has no select component. Build one from `Menu` with a pressable anchor, and expose a `FieldElement` through `useImperativeHandle` so `focus` can open it. The component below reads `ref` from its props, which requires React 19; on React 18 wrap it in `forwardRef` instead:
 
 ```tsx
 function MenuSelect<TValue extends string>({
   ref,
   onFocus,
+  onBlur,
   label,
   value,
   options,
   onValueChange,
-}: Pick<FieldElementProps, 'ref' | 'onFocus'> & {
+}: Pick<FieldElementProps, 'ref' | 'onFocus' | 'onBlur'> & {
   label: string;
   value: TValue | undefined;
   options: readonly { label: string; value: TValue }[];
@@ -275,18 +271,24 @@ function MenuSelect<TValue extends string>({
 }) {
   const [visible, setVisible] = useState(false);
 
+  // The menu closing ends the interaction, so report it as a blur
+  const close = () => {
+    setVisible(false);
+    onBlur();
+  };
+
   // Expose a `FieldElement` so `focus(form, { path })` can reach this control.
   // `isFocused` is deliberately omitted: Formisch treats an element without it
   // as successfully focused, instead of skipping to the next errored field.
   useImperativeHandle(ref, () => ({
     focus: () => setVisible(true),
-    blur: () => setVisible(false),
+    blur: close,
   }));
 
   return (
     <Menu
       visible={visible}
-      onDismiss={() => setVisible(false)}
+      onDismiss={close}
       anchor={
         <Button
           mode="outlined"
@@ -305,7 +307,7 @@ function MenuSelect<TValue extends string>({
           title={option.label}
           onPress={() => {
             onValueChange(option.value);
-            setVisible(false);
+            close();
           }}
         />
       ))}
@@ -322,6 +324,7 @@ Making the component generic over `TValue` keeps it assignable to `field.onChang
     <MenuSelect
       ref={field.props.ref}
       onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
       label="Select a framework"
       value={field.input}
       options={FRAMEWORKS}
@@ -340,7 +343,7 @@ For a small set of options, `SegmentedButtons` is a simpler alternative.
 ```tsx
 <Field of={form} path={['plan']}>
   {(field) => (
-    <View ref={field.props.ref} role="radiogroup">
+    <View role="radiogroup">
       <RadioButton.Group
         value={field.input ?? ''}
         onValueChange={(value) => {
@@ -366,7 +369,7 @@ Paper has no slider. The community package `@react-native-community/slider` work
 ```tsx
 <Field of={form} path={['volume']}>
   {(field) => (
-    <View ref={field.props.ref}>
+    <View>
       <Text>Volume: {field.input}</Text>
       <Slider
         style={{ width: '100%', height: 40 }}

--- a/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(integration-guides)/react-native-paper/index.mdx
@@ -338,12 +338,12 @@ For a small set of options, `SegmentedButtons` is a simpler alternative.
 
 ### Radio group
 
-`RadioButton.Group` reports the new value, so mark the field as touched there:
+`RadioButton.Group` reports the new value, so mark the field as touched there. The group needs its own accessible name, since the individual options only announce their own labels:
 
 ```tsx
 <Field of={form} path={['plan']}>
   {(field) => (
-    <View role="radiogroup">
+    <View role="radiogroup" accessibilityLabel="Plan">
       <RadioButton.Group
         value={field.input ?? ''}
         onValueChange={(value) => {

--- a/website/src/routes/(docs)/react-native/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(main-concepts)/input-components/index.mdx
@@ -227,6 +227,13 @@ import { Switch } from 'react-native';
 
 The `field.onChange` method updates the field value and triggers validation. Your own components can still extend `FieldElementProps` as shown above: forward the `ref` to the pressable part of the component and call the `onFocus` and `onBlur` handlers when the interaction starts and ends, so that <Link href="/methods/api/focus/">`focus`</Link>, `isTouched` and blur validation keep working. For more details, see the <Link href="/react-native/guides/controlled-fields/">controlled fields</Link> guide.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/react-native/guides/gluestack-ui/">gluestack-ui</Link>
+- <Link href="/react-native/guides/react-native-paper/">
+    React Native Paper
+  </Link>
+
 ## Next steps
 
 Now that you know how to create reusable input components, continue to the <Link href="/react-native/guides/handle-submission/">handle submission</Link> guide to learn how to process form data when the user submits the form.

--- a/website/src/routes/(docs)/react-native/guides/menu.md
+++ b/website/src/routes/(docs)/react-native/guides/menu.md
@@ -32,3 +32,8 @@
 - [From React Hook Form](/react-native/guides/migrate-from-react-hook-form/)
 - [From TanStack Form](/react-native/guides/migrate-from-tanstack-form/)
 - [From Formik](/react-native/guides/migrate-from-formik/)
+
+## Integration guides
+
+- [gluestack-ui](/react-native/guides/gluestack-ui/)
+- [React Native Paper](/react-native/guides/react-native-paper/)

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -215,6 +215,10 @@ The `field.onChange` method updates the field value and triggers validation, jus
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/react/guides/shadcn-ui/">shadcn/ui</Link>
+- <Link href="/react/guides/base-ui/">Base UI</Link>
+- <Link href="/react/guides/chakra-ui/">Chakra UI</Link>
+- <Link href="/react/guides/mantine/">Mantine</Link>
+- <Link href="/react/guides/react-aria/">React Aria</Link>
 
 ## Next steps
 

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -215,6 +215,7 @@ The `field.onChange` method updates the field value and triggers validation, jus
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/react/guides/shadcn-ui/">shadcn/ui</Link>
+- <Link href="/react/guides/ark-ui/">Ark UI</Link>
 - <Link href="/react/guides/base-ui/">Base UI</Link>
 - <Link href="/react/guides/chakra-ui/">Chakra UI</Link>
 - <Link href="/react/guides/mantine/">Mantine</Link>

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
@@ -86,15 +86,19 @@ Every Ark root accepts an `ids` object, which is the supported way to give a hid
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires `aria-errormessage` to that element for you, and the error text only renders while the field is invalid:
 
 ```tsx
-<ArkField.Root
-  id="login-email"
-  ids={{ errorText: 'login-email-error' }}
-  invalid={field.errors !== null}
->
-  <ArkField.Label>Email</ArkField.Label>
-  <ArkField.Input {...field.props} value={field.input ?? ''} />
-  <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
-</ArkField.Root>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <ArkField.Root
+      id="login-email"
+      ids={{ errorText: 'login-email-error' }}
+      invalid={field.errors !== null}
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} value={field.input ?? ''} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  )}
+</Field>
 ```
 
 Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
@@ -391,6 +391,7 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
         </Slider.Track>
         <Slider.Thumb
           index={0}
+          autoFocus={field.props.autoFocus}
           onFocus={field.props.onFocus}
           onBlur={field.props.onBlur}
           aria-errormessage="settings-volume-error"

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
@@ -293,24 +293,26 @@ const frameworkCollection = createListCollection({
       name={field.props.name}
       value={field.input ? [field.input] : []}
       onValueChange={(details) =>
-        field.onChange(details.value[0] as 'angular' | 'react')
+        field.onChange(details.value[0] as typeof field.input)
       }
       invalid={field.errors !== null}
     >
       <Select.Label>Framework</Select.Label>
       <Select.Control>
-        <Select.Trigger aria-errormessage="project-framework-error">
+        <Select.Trigger
+          autoFocus={field.props.autoFocus}
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
+          aria-errormessage="project-framework-error"
+        >
           <Select.ValueText placeholder="Select a framework" />
           <Select.Indicator>▾</Select.Indicator>
         </Select.Trigger>
       </Select.Control>
-      <Select.HiddenSelect
-        ref={field.props.ref}
-        autoFocus={field.props.autoFocus}
-        onFocus={field.props.onFocus}
-        onBlur={field.props.onBlur}
-      />
-      <span id="project-framework-error">{field.errors?.[0]}</span>
+      <Select.HiddenSelect ref={field.props.ref} />
+      {field.errors && (
+        <span id="project-framework-error">{field.errors[0]}</span>
+      )}
       <Portal>
         <Select.Positioner>
           <Select.Content>
@@ -327,7 +329,7 @@ const frameworkCollection = createListCollection({
 </Field>
 ```
 
-The hidden select forwards focus to the visible trigger on its own, so `focus` lands on the button the user sees.
+Put the focus handlers on the trigger rather than on the hidden select, because that is the element a keyboard user lands on. `focus` still works, since Ark forwards focus from the hidden select to the visible trigger.
 
 ### Radio group
 
@@ -359,7 +361,7 @@ Register every item's hidden input. Formisch keeps a list of registered elements
           <RadioGroup.ItemText>{PLAN_LABELS[plan]}</RadioGroup.ItemText>
         </RadioGroup.Item>
       ))}
-      <span id="plan-error">{field.errors?.[0]}</span>
+      {field.errors && <span id="plan-error">{field.errors[0]}</span>}
     </RadioGroup.Root>
   )}
 </Field>
@@ -387,15 +389,18 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
         <Slider.Track>
           <Slider.Range />
         </Slider.Track>
-        <Slider.Thumb index={0} aria-errormessage="settings-volume-error">
-          <Slider.HiddenInput
-            ref={field.props.ref}
-            onFocus={field.props.onFocus}
-            onBlur={field.props.onBlur}
-          />
+        <Slider.Thumb
+          index={0}
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
+          aria-errormessage="settings-volume-error"
+        >
+          <Slider.HiddenInput ref={field.props.ref} />
         </Slider.Thumb>
       </Slider.Control>
-      <span id="settings-volume-error">{field.errors?.[0]}</span>
+      {field.errors && (
+        <span id="settings-volume-error">{field.errors[0]}</span>
+      )}
     </Slider.Root>
   )}
 </Field>

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/ark-ui/index.mdx
@@ -2,7 +2,7 @@
 title: Ark UI
 description: >-
   Learn how to connect Formisch fields to Ark UI inputs, checkboxes, selects,
-  radio groups and sliders in Solid.
+  radio groups and sliders in React.
 contributors:
   - fabian-hiller
 ---
@@ -11,14 +11,14 @@ import { Link } from '~/components';
 
 # Ark UI
 
-[Ark UI](https://ark-ui.com) is a headless component library built on state machines, available for Solid among other frameworks. This guide targets Ark UI v5 for Solid. No adapter package is needed: each component exposes the native element as one of its parts, so you spread `field.props` onto that part and let the component root handle the value.
+[Ark UI](https://ark-ui.com) is a headless component library built on state machines, available for React among other frameworks. This guide targets Ark UI v5 for React. No adapter package is needed: each component exposes the native element as one of its parts, so you spread `field.props` onto that part and let the component root handle the value.
 
 ## Installation
 
 Install Formisch, Valibot and Ark UI:
 
 ```bash
-npm install @formisch/solid valibot @ark-ui/solid
+npm install @formisch/react valibot @ark-ui/react
 ```
 
 Ark UI ships unstyled, so every example below leaves styling to you.
@@ -28,9 +28,9 @@ Ark UI ships unstyled, so every example below leaves styling to you.
 Choose the wiring from the part you are rendering:
 
 - If the part is a native `<input>`, `<textarea>` or `<select>`, spread `field.props` onto it and pass `field.input` as the value.
-- If the component owns the value, pass `field.input` to the root and send the root's value callback to `field.onInput`, then forward the lifecycle props to the component's hidden native part.
+- If the component owns the value, pass `field.input` to the root and send the root's value callback to `field.onChange`, then forward the lifecycle props to the component's hidden native part.
 
-`field.onInput` and `field.props.onInput` are different functions and mixing them up is the easiest mistake to make here. `field.onInput(value)` stores a value, while `field.props.onInput(event)` reads the value from a DOM element. Because it reads from the element, it always produces a string, so a number, boolean or enum field must go through the component's own callback rather than the spread.
+Both of those are named `onChange`, which makes them easy to confuse. `field.onChange(value)` stores a value, while `field.props.onChange(event)` reads the value from a DOM element. Because it reads from the element, it always produces a string, so a number, boolean or enum field must go through the component's own callback rather than the spread.
 
 ### Spreading field.props
 
@@ -39,7 +39,7 @@ Choose the wiring from the part you are rendering:
 ```tsx
 <Field of={loginForm} path={['email']}>
   {(field) => (
-    <ArkField.Root id="login-email" invalid={!!field.errors}>
+    <ArkField.Root id="login-email" invalid={field.errors !== null}>
       <ArkField.Label>Email</ArkField.Label>
       <ArkField.Input {...field.props} type="email" value={field.input ?? ''} />
       <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
@@ -48,7 +48,7 @@ Choose the wiring from the part you are rendering:
 </Field>
 ```
 
-Set the `id` on `ArkField.Root` rather than on the input. Ark derives the control id and the label's `for` attribute from it, so overriding the part's own `id` would break that association.
+Set the `id` on `ArkField.Root` rather than on the input. Ark derives the control id and the label's `htmlFor` from it, so overriding the part's own `id` would break that association. Passing `value={field.input ?? ''}` next to the spread keeps the input controlled from its first render.
 
 ### Controlled components
 
@@ -61,12 +61,12 @@ A checkbox owns its value, so the root takes `checked` and `onCheckedChange`, wh
       ids={{ hiddenInput: 'login-remember-me' }}
       name={field.props.name}
       checked={field.input ?? false}
-      onCheckedChange={(details) => field.onInput(details.checked === true)}
-      invalid={!!field.errors}
+      onCheckedChange={(details) => field.onChange(details.checked === true)}
+      invalid={field.errors !== null}
     >
       <Checkbox.HiddenInput
         ref={field.props.ref}
-        autofocus={field.props.autofocus}
+        autoFocus={field.props.autoFocus}
         onFocus={field.props.onFocus}
         onBlur={field.props.onBlur}
       />
@@ -89,7 +89,7 @@ Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root
 <ArkField.Root
   id="login-email"
   ids={{ errorText: 'login-email-error' }}
-  invalid={!!field.errors}
+  invalid={field.errors !== null}
 >
   <ArkField.Label>Email</ArkField.Label>
   <ArkField.Input {...field.props} value={field.input ?? ''} />
@@ -99,16 +99,16 @@ Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root
 
 Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
 
-By default, Formisch validates on submit and revalidates on input. The <Link href="/solid/guides/validation/">validation guide</Link> explains how to change that timing.
+By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.
 
 ## Login form example
 
 This complete example combines two text fields, a controlled checkbox and accessible errors:
 
 ```tsx
-import { Checkbox } from '@ark-ui/solid/checkbox';
-import { Field as ArkField } from '@ark-ui/solid/field';
-import { createForm, Field, Form, type SubmitHandler } from '@formisch/solid';
+import { Checkbox } from '@ark-ui/react/checkbox';
+import { Field as ArkField } from '@ark-ui/react/field';
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
 import * as v from 'valibot';
 
 const LoginSchema = v.object({
@@ -126,7 +126,7 @@ const LoginSchema = v.object({
 });
 
 export default function LoginPage() {
-  const loginForm = createForm({
+  const loginForm = useForm({
     schema: LoginSchema,
     initialInput: {
       email: '',
@@ -146,13 +146,13 @@ export default function LoginPage() {
           <ArkField.Root
             id="login-email"
             ids={{ errorText: 'login-email-error' }}
-            invalid={!!field.errors}
+            invalid={field.errors !== null}
           >
             <ArkField.Label>Email</ArkField.Label>
             <ArkField.Input
               {...field.props}
               type="email"
-              autocomplete="email"
+              autoComplete="email"
               placeholder="jane@example.com"
               value={field.input ?? ''}
             />
@@ -166,13 +166,13 @@ export default function LoginPage() {
           <ArkField.Root
             id="login-password"
             ids={{ errorText: 'login-password-error' }}
-            invalid={!!field.errors}
+            invalid={field.errors !== null}
           >
             <ArkField.Label>Password</ArkField.Label>
             <ArkField.Input
               {...field.props}
               type="password"
-              autocomplete="current-password"
+              autoComplete="current-password"
               value={field.input ?? ''}
             />
             <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
@@ -187,13 +187,13 @@ export default function LoginPage() {
             name={field.props.name}
             checked={field.input ?? false}
             onCheckedChange={(details) =>
-              field.onInput(details.checked === true)
+              field.onChange(details.checked === true)
             }
-            invalid={!!field.errors}
+            invalid={field.errors !== null}
           >
             <Checkbox.HiddenInput
               ref={field.props.ref}
-              autofocus={field.props.autofocus}
+              autoFocus={field.props.autoFocus}
               onFocus={field.props.onFocus}
               onBlur={field.props.onBlur}
             />
@@ -217,7 +217,7 @@ The initial input keeps every control defined from its first render. The two tex
 
 ## Component reference
 
-The following snippets assume a form store named `form` and initialized values that match the schema. Never destructure the field store, and read `field.input` and `field.errors` inside JSX so Solid tracks them.
+The following snippets assume a form store named `form` and initialized values that match the schema.
 
 ### Text input
 
@@ -227,7 +227,7 @@ The following snippets assume a form store named `form` and initialized values t
     <ArkField.Root
       id="profile-email"
       ids={{ errorText: 'profile-email-error' }}
-      invalid={!!field.errors}
+      invalid={field.errors !== null}
     >
       <ArkField.Label>Email</ArkField.Label>
       <ArkField.Input {...field.props} type="email" value={field.input ?? ''} />
@@ -248,12 +248,12 @@ Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the 
       ids={{ hiddenInput: 'settings-newsletter' }}
       name={field.props.name}
       checked={field.input ?? false}
-      onCheckedChange={(details) => field.onInput(details.checked === true)}
-      invalid={!!field.errors}
+      onCheckedChange={(details) => field.onChange(details.checked === true)}
+      invalid={field.errors !== null}
     >
       <Checkbox.HiddenInput
         ref={field.props.ref}
-        autofocus={field.props.autofocus}
+        autoFocus={field.props.autoFocus}
         onFocus={field.props.onFocus}
         onBlur={field.props.onBlur}
       />
@@ -268,7 +268,7 @@ Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the 
 
 ### Select
 
-Ark's select is array based even for a single selection, so wrap the value and unwrap the callback. Items come from a collection:
+Ark's select is array based even for a single selection, so wrap the value and unwrap the callback. Items come from a collection, and `Portal` is imported from Ark UI rather than from React:
 
 ```tsx
 const frameworkCollection = createListCollection({
@@ -293,9 +293,9 @@ const frameworkCollection = createListCollection({
       name={field.props.name}
       value={field.input ? [field.input] : []}
       onValueChange={(details) =>
-        field.onInput(details.value[0] as 'angular' | 'react')
+        field.onChange(details.value[0] as 'angular' | 'react')
       }
-      invalid={!!field.errors}
+      invalid={field.errors !== null}
     >
       <Select.Label>Framework</Select.Label>
       <Select.Control>
@@ -306,7 +306,7 @@ const frameworkCollection = createListCollection({
       </Select.Control>
       <Select.HiddenSelect
         ref={field.props.ref}
-        autofocus={field.props.autofocus}
+        autoFocus={field.props.autoFocus}
         onFocus={field.props.onFocus}
         onBlur={field.props.onBlur}
       />
@@ -314,13 +314,11 @@ const frameworkCollection = createListCollection({
       <Portal>
         <Select.Positioner>
           <Select.Content>
-            <For each={frameworkCollection.items}>
-              {(item) => (
-                <Select.Item item={item}>
-                  <Select.ItemText>{item.label}</Select.ItemText>
-                </Select.Item>
-              )}
-            </For>
+            {frameworkCollection.items.map((item) => (
+              <Select.Item key={item.value} item={item}>
+                <Select.ItemText>{item.label}</Select.ItemText>
+              </Select.Item>
+            ))}
           </Select.Content>
         </Select.Positioner>
       </Portal>
@@ -333,7 +331,7 @@ The hidden select forwards focus to the visible trigger on its own, so `focus` l
 
 ### Radio group
 
-Register every item's hidden input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autofocus` on the first item only, otherwise every radio competes for focus:
+Register every item's hidden input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autoFocus` on the first item only, otherwise every radio competes for focus:
 
 ```tsx
 <Field of={form} path={['plan']}>
@@ -343,26 +341,24 @@ Register every item's hidden input. Formisch keeps a list of registered elements
       name={field.props.name}
       value={field.input ?? null}
       onValueChange={(details) =>
-        field.onInput(details.value as 'hobby' | 'pro')
+        field.onChange(details.value as 'hobby' | 'pro')
       }
       aria-errormessage="plan-error"
     >
       <RadioGroup.Label>Plan</RadioGroup.Label>
-      <For each={PLANS}>
-        {(plan, index) => (
-          <RadioGroup.Item value={plan}>
-            <RadioGroup.ItemHiddenInput
-              ref={field.props.ref}
-              autofocus={index() === 0 && field.props.autofocus}
-              onFocus={field.props.onFocus}
-              onBlur={field.props.onBlur}
-              aria-invalid={field.errors ? true : undefined}
-            />
-            <RadioGroup.ItemControl />
-            <RadioGroup.ItemText>{PLAN_LABELS[plan]}</RadioGroup.ItemText>
-          </RadioGroup.Item>
-        )}
-      </For>
+      {PLANS.map((plan, index) => (
+        <RadioGroup.Item key={plan} value={plan}>
+          <RadioGroup.ItemHiddenInput
+            ref={field.props.ref}
+            autoFocus={index === 0 && field.props.autoFocus}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+            aria-invalid={field.errors !== null ? true : undefined}
+          />
+          <RadioGroup.ItemControl />
+          <RadioGroup.ItemText>{PLAN_LABELS[plan]}</RadioGroup.ItemText>
+        </RadioGroup.Item>
+      ))}
       <span id="plan-error">{field.errors?.[0]}</span>
     </RadioGroup.Root>
   )}
@@ -382,8 +378,8 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
       min={0}
       max={100}
       value={[field.input ?? 50]}
-      onValueChange={(details) => field.onInput(details.value[0])}
-      invalid={!!field.errors}
+      onValueChange={(details) => field.onChange(details.value[0])}
+      invalid={field.errors !== null}
     >
       <Slider.Label>Volume</Slider.Label>
       <Slider.ValueText />
@@ -409,10 +405,10 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
 
 ## Library-specific notes
 
-`field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.
+`field.props.autoFocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.
 
-Ark UI is also available for other frameworks. The part names and the `ids` and `invalid` props are identical there, so this wiring ports with only the framework API changing. See our <Link href="/react/guides/ark-ui/">React</Link>, <Link href="/vue/guides/ark-ui/">Vue</Link> and <Link href="/svelte/guides/ark-ui/">Svelte</Link> guides.
+Ark UI is also available for other frameworks. The part names and the `ids` and `invalid` props are identical there, so this wiring ports with only the framework API changing. See our <Link href="/solid/guides/ark-ui/">Solid</Link>, <Link href="/vue/guides/ark-ui/">Vue</Link> and <Link href="/svelte/guides/ark-ui/">Svelte</Link> guides.
 
 ## Next steps
 
-Read the <Link href="/solid/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/solid/guides/validation/">validation</Link> guide for validation timing.
+Read the <Link href="/react/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/base-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/base-ui/index.mdx
@@ -79,13 +79,17 @@ These examples wire fields directly so you can see the complete integration. Onc
 Formisch exposes errors as `[string, ...string[]] | null`. Base UI's `Field.Error` normally displays messages from its own validity tracking, so pass `match` to force it whenever Formisch reports errors, and set `invalid` on `Field.Root` for the visual and `aria` invalid state:
 
 ```tsx
-<BaseField.Root invalid={field.errors !== null}>
-  <BaseField.Label>Email</BaseField.Label>
-  <Input {...field.props} value={field.input ?? ''} />
-  <BaseField.Error match={field.errors !== null}>
-    {field.errors?.[0]}
-  </BaseField.Error>
-</BaseField.Root>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <BaseField.Root invalid={field.errors !== null}>
+      <BaseField.Label>Email</BaseField.Label>
+      <Input {...field.props} value={field.input ?? ''} />
+      <BaseField.Error match={field.errors !== null}>
+        {field.errors?.[0]}
+      </BaseField.Error>
+    </BaseField.Root>
+  )}
+</Field>
 ```
 
 By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/base-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/base-ui/index.mdx
@@ -1,0 +1,393 @@
+---
+title: Base UI
+description: >-
+  Learn how to connect Formisch fields to Base UI inputs, selects, radio
+  groups, sliders and other form controls.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Base UI
+
+[Base UI](https://base-ui.com) is an unstyled component library from the creators of Radix, Floating UI and Material UI. This guide targets `@base-ui/react` v1. No adapter package is needed: native controls receive `field.props`, while composite components map Formisch's value and lifecycle APIs to their parts. Base UI's `Field` parts handle label and error accessibility for both kinds.
+
+## Installation
+
+Install Formisch, Valibot and Base UI:
+
+```bash
+npm install @formisch/react valibot @base-ui/react
+```
+
+## Wiring patterns
+
+Choose the wiring from the component's public API:
+
+- If it forwards props and a ref to a native form element, spread `field.props` and pass `field.input` as its value.
+- If it exposes a custom callback such as `onCheckedChange` or `onValueChange`, control it with `field.input` and `field.onChange`, then forward the remaining lifecycle props separately.
+
+### Spreading field.props
+
+`Input` renders a native `<input>`, so its wiring is the same as a plain HTML input. Base UI's `Field.Root` wires the label, error and `aria` attributes automatically. Since both Formisch and Base UI export a component named `Field`, the Base UI one is imported as `BaseField`:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <BaseField.Root invalid={field.errors !== null}>
+      <BaseField.Label>Email</BaseField.Label>
+      <Input {...field.props} value={field.input ?? ''} type="email" />
+      <BaseField.Error match={field.errors !== null}>
+        {field.errors?.[0]}
+      </BaseField.Error>
+    </BaseField.Root>
+  )}
+</Field>
+```
+
+For a textarea, use `BaseField.Control render={<textarea />}` with the same spread.
+
+### Controlled components
+
+Composite components expose their value through custom callbacks and render a hidden native element that accepts `inputRef`. Registering that hidden element with `field.props.ref` keeps Formisch's `focus()` working, because Base UI redirects focus from the hidden element to the visible control:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox.Root
+      name={field.props.name}
+      inputRef={field.props.ref}
+      autoFocus={field.props.autoFocus}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      checked={field.input ?? false}
+      onCheckedChange={(checked) => field.onChange(checked)}
+    >
+      <Checkbox.Indicator />
+    </Checkbox.Root>
+  )}
+</Field>
+```
+
+Formisch's focus and blur handlers are parameterless because they only update field lifecycle state, so you can pass them directly even when the component supplies an event argument.
+
+These examples wire fields directly so you can see the complete integration. Once a pattern repeats, wrap the parts in your own input component. The <Link href="/react/guides/input-components/">input components guide</Link> shows how.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Base UI's `Field.Error` normally displays messages from its own validity tracking, so pass `match` to force it whenever Formisch reports errors, and set `invalid` on `Field.Root` for the visual and `aria` invalid state:
+
+```tsx
+<BaseField.Root invalid={field.errors !== null}>
+  <BaseField.Label>Email</BaseField.Label>
+  <Input {...field.props} value={field.input ?? ''} />
+  <BaseField.Error match={field.errors !== null}>
+    {field.errors?.[0]}
+  </BaseField.Error>
+</BaseField.Root>
+```
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs, a controlled checkbox and accessible errors:
+
+```tsx
+import { Checkbox } from '@base-ui/react/checkbox';
+import { Field as BaseField } from '@base-ui/react/field';
+import { Input } from '@base-ui/react/input';
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <BaseField.Root invalid={field.errors !== null}>
+            <BaseField.Label>Email</BaseField.Label>
+            <Input
+              {...field.props}
+              value={field.input ?? ''}
+              type="email"
+              placeholder="jane@example.com"
+              autoComplete="email"
+            />
+            <BaseField.Error match={field.errors !== null}>
+              {field.errors?.[0]}
+            </BaseField.Error>
+          </BaseField.Root>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <BaseField.Root invalid={field.errors !== null}>
+            <BaseField.Label>Password</BaseField.Label>
+            <Input
+              {...field.props}
+              value={field.input ?? ''}
+              type="password"
+              autoComplete="current-password"
+            />
+            <BaseField.Error match={field.errors !== null}>
+              {field.errors?.[0]}
+            </BaseField.Error>
+          </BaseField.Root>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <BaseField.Root>
+            <BaseField.Label>
+              <Checkbox.Root
+                name={field.props.name}
+                inputRef={field.props.ref}
+                autoFocus={field.props.autoFocus}
+                onFocus={field.props.onFocus}
+                onBlur={field.props.onBlur}
+                checked={field.input ?? false}
+                onCheckedChange={(checked) => field.onChange(checked)}
+              >
+                <Checkbox.Indicator />
+              </Checkbox.Root>
+              Remember me
+            </BaseField.Label>
+          </BaseField.Root>
+        )}
+      </Field>
+
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. The native inputs use the `field.props` spread, while the checkbox maps Base UI's value callback and hidden input explicitly.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+`Input` forwards to a native `<input>`, so spread `field.props` directly:
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <BaseField.Root invalid={field.errors !== null}>
+      <BaseField.Label>Email</BaseField.Label>
+      <Input {...field.props} value={field.input ?? ''} type="email" />
+      <BaseField.Error match={field.errors !== null}>
+        {field.errors?.[0]}
+      </BaseField.Error>
+    </BaseField.Root>
+  )}
+</Field>
+```
+
+For a textarea, use `BaseField.Control render={<textarea />}` with the same spread.
+
+### Checkbox
+
+For a boolean field, control `checked` and register the hidden input:
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <BaseField.Root>
+      <BaseField.Label>
+        <Checkbox.Root
+          name={field.props.name}
+          inputRef={field.props.ref}
+          autoFocus={field.props.autoFocus}
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
+          checked={field.input ?? false}
+          onCheckedChange={(checked) => field.onChange(checked)}
+        >
+          <Checkbox.Indicator />
+        </Checkbox.Root>
+        Newsletter
+      </BaseField.Label>
+    </BaseField.Root>
+  )}
+</Field>
+```
+
+### Select
+
+`Select` represents no selection as `null`, while an optional Formisch value is `undefined`. Convert between them and narrow the value back to the schema union. The `items` prop lets `Select.Value` display the selected item's label, and the registered hidden select redirects focus to the visible trigger:
+
+```tsx
+const frameworks = [
+  { label: 'Angular', value: 'angular' },
+  { label: 'React', value: 'react' },
+  { label: 'Solid', value: 'solid' },
+  { label: 'Vue', value: 'vue' },
+];
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <BaseField.Root invalid={field.errors !== null}>
+      <BaseField.Label id="project-framework-label">Framework</BaseField.Label>
+      <Select.Root
+        items={frameworks}
+        name={field.props.name}
+        inputRef={field.props.ref}
+        value={field.input ?? null}
+        onValueChange={(value) =>
+          field.onChange((value ?? undefined) as typeof field.input)
+        }
+      >
+        <Select.Trigger
+          aria-labelledby="project-framework-label"
+          autoFocus={field.props.autoFocus}
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
+        >
+          <Select.Value placeholder="Select a framework" />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.List>
+                {frameworks.map((item) => (
+                  <Select.Item key={item.value} value={item.value}>
+                    <Select.ItemText>{item.label}</Select.ItemText>
+                  </Select.Item>
+                ))}
+              </Select.List>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>
+      <BaseField.Error match={field.errors !== null}>
+        {field.errors?.[0]}
+      </BaseField.Error>
+    </BaseField.Root>
+  )}
+</Field>
+```
+
+### Radio group
+
+`RadioGroup` is controlled through `onValueChange` and accepts the field name, input ref and lifecycle props directly on the group:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <BaseField.Root invalid={field.errors !== null}>
+      <BaseField.Label id="plan-label">Plan</BaseField.Label>
+      <RadioGroup
+        aria-labelledby="plan-label"
+        name={field.props.name}
+        inputRef={field.props.ref}
+        value={field.input ?? null}
+        onValueChange={(value) =>
+          field.onChange((value ?? undefined) as typeof field.input)
+        }
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      >
+        <label>
+          <Radio.Root value="hobby" autoFocus={field.props.autoFocus}>
+            <Radio.Indicator />
+          </Radio.Root>
+          Hobby
+        </label>
+        <label>
+          <Radio.Root value="pro">
+            <Radio.Indicator />
+          </Radio.Root>
+          Pro
+        </label>
+      </RadioGroup>
+      <BaseField.Error match={field.errors !== null}>
+        {field.errors?.[0]}
+      </BaseField.Error>
+    </BaseField.Root>
+  )}
+</Field>
+```
+
+### Slider
+
+`Slider.Root` accepts a single number, and the thumb count follows the number of `Slider.Thumb` parts you render, so no array conversion is needed. The callback is still typed as `number | readonly number[]`, so normalize it explicitly. Connect the label with `aria-labelledby`, which Base UI forwards to the thumb's hidden range input:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <BaseField.Root invalid={field.errors !== null}>
+      <BaseField.Label id="volume-label">Volume</BaseField.Label>
+      <Slider.Root
+        aria-labelledby="volume-label"
+        name={field.props.name}
+        value={field.input ?? 50}
+        onValueChange={(value) =>
+          field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
+        }
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+        min={0}
+        max={100}
+      >
+        <Slider.Control>
+          <Slider.Track>
+            <Slider.Indicator />
+            <Slider.Thumb inputRef={field.props.ref} />
+          </Slider.Track>
+        </Slider.Control>
+      </Slider.Root>
+      <BaseField.Error match={field.errors !== null}>
+        {field.errors?.[0]}
+      </BaseField.Error>
+    </BaseField.Root>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+Base UI also ships its own `Form` component and `Field.Root` validation through the `validate` prop. You do not need either with Formisch: use Formisch's <Link href="/react/api/Form/">`Form`</Link> component and let your Valibot schema drive validation, with `Field.Root` reduced to layout and accessibility wiring as shown above.
+
+If you use shadcn/ui, note that its current registry generates styled components on top of these Base UI primitives; see our <Link href="/react/guides/shadcn-ui/">shadcn/ui guide</Link> for the generated-component wiring.
+
+## Next steps
+
+Read the <Link href="/react/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/chakra-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/chakra-ui/index.mdx
@@ -344,7 +344,9 @@ const frameworks = createListCollection({
 
 ### Slider
 
-Pass `field.input` wrapped in a one-element array for a single thumb and unwrap the details value in the callback. `Slider.Label` gives the slider its accessible name, and the lifecycle handlers go on the thumb, which is the keyboard focus target:
+Pass `field.input` wrapped in a one-element array for a single thumb and unwrap the details value in the callback. `Slider.Label` gives the slider its accessible name, and the lifecycle handlers go on the thumb, which is the keyboard focus target.
+
+Chakra's slider keeps its focusable thumb as a `div` and renders its hidden input with `display: none`, so there is no element Formisch can register and focus. That means `focus` and submit-time error focusing cannot reach this field, while its value, validation and blur handling work normally:
 
 ```tsx
 <Field of={form} path={['volume']}>

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/chakra-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/chakra-ui/index.mdx
@@ -1,0 +1,386 @@
+---
+title: Chakra UI
+description: >-
+  Learn how to connect Formisch fields to Chakra UI inputs, selects, radio
+  groups, sliders and other form controls.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Chakra UI
+
+[Chakra UI](https://chakra-ui.com) is a component system for building accessible React applications. This guide targets Chakra UI v3, whose composition-based API differs fundamentally from v2. No adapter package is needed: native controls receive `field.props`, while the Ark UI based composite components map Formisch's value and lifecycle APIs to their parts.
+
+## Installation
+
+Install Formisch, Valibot and Chakra UI, and follow the [Chakra UI installation guide](https://chakra-ui.com/docs/get-started/installation) to set up the provider:
+
+```bash
+npm install @formisch/react valibot @chakra-ui/react @emotion/react
+```
+
+## Wiring patterns
+
+Choose the wiring from the component's public API:
+
+- If it forwards props and a ref to a native form element, spread `field.props` and pass `field.input` as its value.
+- If it exposes a details callback such as `onCheckedChange` or `onValueChange`, control it with `field.input` and `field.onChange`, then forward the remaining lifecycle props to the component's native parts.
+
+### Spreading field.props
+
+`Input` and `Textarea` render native elements, so their wiring is the same as a plain HTML input. Chakra's `Field.Root` wires the label, error and `aria` attributes to the nested input automatically. Since both Formisch and Chakra UI export a component named `Field`, the Chakra one is imported as `ChakraField`:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <ChakraField.Root invalid={field.errors !== null}>
+      <ChakraField.Label>Email</ChakraField.Label>
+      <Input {...field.props} value={field.input ?? ''} type="email" />
+      <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+    </ChakraField.Root>
+  )}
+</Field>
+```
+
+### Controlled components
+
+Chakra's composite components expose their state through a details object and render a hidden native element for form integration. Control the value on the root, and pass the field name, ref and lifecycle props to the hidden native part:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox.Root
+      checked={field.input ?? false}
+      onCheckedChange={(details) => field.onChange(!!details.checked)}
+    >
+      <Checkbox.HiddenInput
+        name={field.props.name}
+        ref={field.props.ref}
+        autoFocus={field.props.autoFocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator />
+      </Checkbox.Control>
+      <Checkbox.Label>Remember me</Checkbox.Label>
+    </Checkbox.Root>
+  )}
+</Field>
+```
+
+The hidden input is the component's real focus target, so registering it with `field.props.ref` keeps Formisch's `focus()` working. The `details.checked` value can be `'indeterminate'`, so `!!details.checked` normalizes it to a boolean. Formisch's focus and blur handlers are parameterless because they only update field lifecycle state, so you can pass them directly even when the component supplies an event argument.
+
+These examples wire fields directly so you can see the complete integration. Once a pattern repeats, wrap the parts in your own input component. The <Link href="/react/guides/input-components/">input components guide</Link> shows how.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Wrap any control in `ChakraField.Root` and pass its `invalid` prop; `ChakraField.ErrorText` then renders the message, and nested native inputs receive `aria-invalid` and `aria-describedby` automatically:
+
+```tsx
+<ChakraField.Root invalid={field.errors !== null}>
+  <ChakraField.Label>Email</ChakraField.Label>
+  <Input {...field.props} value={field.input ?? ''} />
+  <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+</ChakraField.Root>
+```
+
+Composite components such as `Select.Root` and `Slider.Root` additionally accept their own `invalid` prop to mark the visible trigger. By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs, a controlled checkbox and accessible errors:
+
+```tsx
+import {
+  Button,
+  Field as ChakraField,
+  Checkbox,
+  Input,
+} from '@chakra-ui/react';
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <ChakraField.Root invalid={field.errors !== null}>
+            <ChakraField.Label>Email</ChakraField.Label>
+            <Input
+              {...field.props}
+              value={field.input ?? ''}
+              type="email"
+              placeholder="jane@example.com"
+              autoComplete="email"
+            />
+            <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+          </ChakraField.Root>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <ChakraField.Root invalid={field.errors !== null}>
+            <ChakraField.Label>Password</ChakraField.Label>
+            <Input
+              {...field.props}
+              value={field.input ?? ''}
+              type="password"
+              autoComplete="current-password"
+            />
+            <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+          </ChakraField.Root>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <Checkbox.Root
+            checked={field.input ?? false}
+            onCheckedChange={(details) => field.onChange(!!details.checked)}
+          >
+            <Checkbox.HiddenInput
+              name={field.props.name}
+              ref={field.props.ref}
+              autoFocus={field.props.autoFocus}
+              onFocus={field.props.onFocus}
+              onBlur={field.props.onBlur}
+            />
+            <Checkbox.Control>
+              <Checkbox.Indicator />
+            </Checkbox.Control>
+            <Checkbox.Label>Remember me</Checkbox.Label>
+          </Checkbox.Root>
+        )}
+      </Field>
+
+      <Button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </Button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. The native inputs use the `field.props` spread, while the checkbox maps Chakra's details callback and hidden input explicitly.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+`Input` forwards to a native `<input>`, so spread `field.props` directly:
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <ChakraField.Root invalid={field.errors !== null}>
+      <ChakraField.Label>Email</ChakraField.Label>
+      <Input {...field.props} value={field.input ?? ''} type="email" />
+      <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+    </ChakraField.Root>
+  )}
+</Field>
+```
+
+`Textarea` works the same way because it also renders a native element.
+
+### Checkbox
+
+For a boolean field, control `checked` on the root and register the hidden input:
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <Checkbox.Root
+      checked={field.input ?? false}
+      onCheckedChange={(details) => field.onChange(!!details.checked)}
+    >
+      <Checkbox.HiddenInput
+        name={field.props.name}
+        ref={field.props.ref}
+        autoFocus={field.props.autoFocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator />
+      </Checkbox.Control>
+      <Checkbox.Label>Newsletter</Checkbox.Label>
+    </Checkbox.Root>
+  )}
+</Field>
+```
+
+### Select
+
+`Select` works with a collection created by `createListCollection` and represents its value as a `string[]`. Convert between the array and Formisch's single value, and narrow the plain string back to the schema union. The hidden select redirects focus to the visible trigger, so registering it with `field.props.ref` keeps `focus()` working:
+
+```tsx
+const frameworks = createListCollection({
+  items: [
+    { label: 'Angular', value: 'angular' },
+    { label: 'React', value: 'react' },
+    { label: 'Solid', value: 'solid' },
+    { label: 'Vue', value: 'vue' },
+  ],
+});
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <ChakraField.Root invalid={field.errors !== null}>
+      <Select.Root
+        collection={frameworks}
+        invalid={field.errors !== null}
+        value={field.input ? [field.input] : []}
+        onValueChange={(details) =>
+          field.onChange((details.value[0] ?? undefined) as typeof field.input)
+        }
+      >
+        <Select.HiddenSelect name={field.props.name} ref={field.props.ref} />
+        <Select.Label>Framework</Select.Label>
+        <Select.Control>
+          <Select.Trigger
+            autoFocus={field.props.autoFocus}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+          >
+            <Select.ValueText placeholder="Select a framework" />
+          </Select.Trigger>
+          <Select.IndicatorGroup>
+            <Select.Indicator />
+          </Select.IndicatorGroup>
+        </Select.Control>
+        <Portal>
+          <Select.Positioner>
+            <Select.Content>
+              {frameworks.items.map((item) => (
+                <Select.Item item={item} key={item.value}>
+                  {item.label}
+                  <Select.ItemIndicator />
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Positioner>
+        </Portal>
+      </Select.Root>
+      <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+    </ChakraField.Root>
+  )}
+</Field>
+```
+
+### Radio group
+
+`RadioGroup` is controlled through its details callback, and each item renders a hidden native radio input. Register the first item's hidden input so Formisch can move focus into the group:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <ChakraField.Root invalid={field.errors !== null}>
+      <ChakraField.Label>Plan</ChakraField.Label>
+      <RadioGroup.Root
+        name={field.props.name}
+        value={field.input ?? null}
+        onValueChange={(details) =>
+          field.onChange((details.value ?? undefined) as typeof field.input)
+        }
+      >
+        <RadioGroup.Item value="hobby">
+          <RadioGroup.ItemHiddenInput
+            ref={field.props.ref}
+            autoFocus={field.props.autoFocus}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+          />
+          <RadioGroup.ItemIndicator />
+          <RadioGroup.ItemText>Hobby</RadioGroup.ItemText>
+        </RadioGroup.Item>
+        <RadioGroup.Item value="pro">
+          <RadioGroup.ItemHiddenInput />
+          <RadioGroup.ItemIndicator />
+          <RadioGroup.ItemText>Pro</RadioGroup.ItemText>
+        </RadioGroup.Item>
+      </RadioGroup.Root>
+      <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+    </ChakraField.Root>
+  )}
+</Field>
+```
+
+### Slider
+
+Pass `field.input` wrapped in a one-element array for a single thumb and unwrap the details value in the callback. `Slider.Label` gives the slider its accessible name, and the lifecycle handlers go on the thumb, which is the keyboard focus target:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <ChakraField.Root invalid={field.errors !== null}>
+      <Slider.Root
+        invalid={field.errors !== null}
+        value={[field.input ?? 50]}
+        onValueChange={(details) => field.onChange(details.value[0] ?? 50)}
+        min={0}
+        max={100}
+      >
+        <Slider.Label>Volume</Slider.Label>
+        <Slider.Control>
+          <Slider.Track>
+            <Slider.Range />
+          </Slider.Track>
+          <Slider.Thumb
+            index={0}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+          >
+            <Slider.HiddenInput name={field.props.name} />
+          </Slider.Thumb>
+        </Slider.Control>
+      </Slider.Root>
+      <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+    </ChakraField.Root>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+This guide covers Chakra UI v3 only. The v2 API (`FormControl`, `isInvalid`, plain `onChange` callbacks) is entirely different; consult the [Chakra migration guide](https://chakra-ui.com/docs/get-started/migration) if you are upgrading.
+
+## Next steps
+
+Read the <Link href="/react/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/chakra-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/chakra-ui/index.mdx
@@ -80,11 +80,15 @@ These examples wire fields directly so you can see the complete integration. Onc
 Formisch exposes errors as `[string, ...string[]] | null`. Wrap any control in `ChakraField.Root` and pass its `invalid` prop; `ChakraField.ErrorText` then renders the message, and nested native inputs receive `aria-invalid` and `aria-describedby` automatically:
 
 ```tsx
-<ChakraField.Root invalid={field.errors !== null}>
-  <ChakraField.Label>Email</ChakraField.Label>
-  <Input {...field.props} value={field.input ?? ''} />
-  <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
-</ChakraField.Root>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <ChakraField.Root invalid={field.errors !== null}>
+      <ChakraField.Label>Email</ChakraField.Label>
+      <Input {...field.props} value={field.input ?? ''} />
+      <ChakraField.ErrorText>{field.errors?.[0]}</ChakraField.ErrorText>
+    </ChakraField.Root>
+  )}
+</Field>
 ```
 
 Composite components such as `Select.Root` and `Slider.Root` additionally accept their own `invalid` prop to mark the visible trigger. By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
@@ -290,7 +290,9 @@ const frameworks = [
 
 ### Slider
 
-`Slider` works with a single number, so `field.onChange` can be passed directly. It has no `error` prop, so wrap it in `Input.Wrapper`, and use `thumbLabel` for the accessible name because the visible wrapper label is not associated with the thumb:
+`Slider` works with a single number, so `field.onChange` can be passed directly. It has no `error` prop, so wrap it in `Input.Wrapper`, and use `thumbLabel` for the accessible name because the visible wrapper label is not associated with the thumb.
+
+Mantine's slider keeps its focusable thumb as a `div` and only renders a hidden input of type `hidden`, so there is no element Formisch can register. That means `focus` and submit-time error focusing cannot reach this field, while its value, validation and blur handling work normally:
 
 ```tsx
 <Field of={form} path={['volume']}>

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
@@ -292,7 +292,7 @@ const frameworks = [
 
 `Slider` works with a single number, so `field.onChange` can be passed directly. It has no `error` prop, so wrap it in `Input.Wrapper`, and use `thumbLabel` for the accessible name because the visible wrapper label is not associated with the thumb.
 
-Mantine's slider keeps its focusable thumb as a `div` and only renders a hidden input of type `hidden`, so there is no element Formisch can register. That means `focus` and submit-time error focusing cannot reach this field, while its value, validation and blur handling work normally:
+Mantine's slider keeps its focusable thumb as a `div` and only renders a hidden input of type `hidden`, so there is no element Formisch can register. That means `focus` and submit-time error focusing cannot reach this field, while its value, validation and blur handling work normally. The thumb also carries only its accessible name: `thumbProps` is typed but not forwarded to the DOM, so the error text cannot be associated with it either:
 
 ```tsx
 <Field of={form} path={['volume']}>

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
@@ -1,0 +1,320 @@
+---
+title: Mantine
+description: >-
+  Learn how to connect Formisch fields to Mantine inputs, selects, radio
+  groups, sliders and other form controls.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Mantine
+
+[Mantine](https://mantine.dev) is a fully featured React components library with more than 100 customizable components. This guide targets Mantine v9. No adapter package is needed: most Mantine inputs forward their props to a native element, so they receive `field.props` directly, and every input handles labels and error accessibility through its built-in `label` and `error` props.
+
+## Installation
+
+Install Formisch, Valibot and Mantine, and follow the [Mantine getting started guide](https://mantine.dev/getting-started/) to set up `MantineProvider` and the core styles:
+
+```bash
+npm install @formisch/react valibot @mantine/core @mantine/hooks
+```
+
+## Wiring patterns
+
+Choose the wiring from the component's public API:
+
+- If it forwards props and a ref to a native form element, spread `field.props` and pass `field.input` as its value.
+- If it exposes a value callback such as `onChange(value)`, control it with `field.input` and `field.onChange`, then forward the remaining lifecycle props separately.
+
+### Spreading field.props
+
+`TextInput`, `PasswordInput`, `Textarea` and `Checkbox` render native elements and forward their ref to them, so the `field.props` spread works directly. The `label` prop associates the label for you:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextInput
+      {...field.props}
+      value={field.input ?? ''}
+      type="email"
+      label="Email"
+      error={field.errors?.[0]}
+    />
+  )}
+</Field>
+```
+
+### Controlled components
+
+`Select` hides the native element behind a readonly combobox input, but its public props still cover the complete field contract. Pass the field name and ref, forward focus, blur and autofocus behavior, and normalize the value in both directions, since Mantine represents no selection as `null` and types every value as a plain string:
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <Select
+      name={field.props.name}
+      ref={field.props.ref}
+      autoFocus={field.props.autoFocus}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      value={field.input ?? null}
+      onChange={(value) =>
+        field.onChange((value ?? undefined) as typeof field.input)
+      }
+      label="Framework"
+      placeholder="Select a framework"
+      data={frameworks}
+      error={field.errors?.[0]}
+    />
+  )}
+</Field>
+```
+
+`ref` registers the combobox input so Formisch can focus the field, and the cast narrows Mantine's `string` value back to the schema's union type. Formisch's focus and blur handlers are parameterless because they only update field lifecycle state, so you can pass them directly even when the component supplies an event argument.
+
+These examples wire fields directly so you can see the complete integration. Once a pattern repeats, wrap the control, lifecycle props and errors in your own input component. The <Link href="/react/guides/input-components/">input components guide</Link> shows how.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Mantine inputs display an error message through their `error` prop and set `aria-invalid` and `aria-describedby` on the input automatically, so a single expression covers the visual and accessible error state:
+
+```tsx
+<TextInput
+  {...field.props}
+  value={field.input ?? ''}
+  error={field.errors?.[0]}
+/>
+```
+
+For widgets without an `error` prop, such as `Slider`, wrap the control in `Input.Wrapper`, which renders the same label and error markup:
+
+```tsx
+<Input.Wrapper label="Volume" error={field.errors?.[0]}>
+  <Slider {/* ... */} />
+</Input.Wrapper>
+```
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs and a checkbox with accessible errors:
+
+```tsx
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
+import { Button, Checkbox, PasswordInput, TextInput } from '@mantine/core';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <TextInput
+            {...field.props}
+            value={field.input ?? ''}
+            type="email"
+            label="Email"
+            placeholder="jane@example.com"
+            autoComplete="email"
+            error={field.errors?.[0]}
+          />
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <PasswordInput
+            {...field.props}
+            value={field.input ?? ''}
+            label="Password"
+            autoComplete="current-password"
+            error={field.errors?.[0]}
+          />
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <Checkbox
+            {...field.props}
+            checked={field.input ?? false}
+            label="Remember me"
+            error={field.errors?.[0]}
+          />
+        )}
+      </Field>
+
+      <Button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </Button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. All three fields use the `field.props` spread because Mantine forwards their props and refs to native elements, including the checkbox.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+`TextInput` forwards to a native `<input>`, so spread `field.props` directly:
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <TextInput
+      {...field.props}
+      value={field.input ?? ''}
+      type="email"
+      label="Email"
+      error={field.errors?.[0]}
+    />
+  )}
+</Field>
+```
+
+`Textarea` works the same way because it also renders a native element.
+
+### Checkbox
+
+`Checkbox` also wraps a native input, so a boolean field only adds `checked`:
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <Checkbox
+      {...field.props}
+      checked={field.input ?? false}
+      label="Newsletter"
+      error={field.errors?.[0]}
+    />
+  )}
+</Field>
+```
+
+### Select
+
+`Select` is controlled. Convert between Mantine's `null` and Formisch's `undefined`, and narrow the plain string value back to the schema union:
+
+```tsx
+const frameworks = [
+  { value: 'angular', label: 'Angular' },
+  { value: 'react', label: 'React' },
+  { value: 'solid', label: 'Solid' },
+  { value: 'vue', label: 'Vue' },
+];
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <Select
+      name={field.props.name}
+      ref={field.props.ref}
+      autoFocus={field.props.autoFocus}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      value={field.input ?? null}
+      onChange={(value) =>
+        field.onChange((value ?? undefined) as typeof field.input)
+      }
+      label="Framework"
+      placeholder="Select a framework"
+      data={frameworks}
+      error={field.errors?.[0]}
+    />
+  )}
+</Field>
+```
+
+### Radio group
+
+`Radio.Group` is controlled through `onChange(value)`. Its `label` and `error` props handle the group accessibility, while the individual `Radio` components wrap native inputs. Register the first radio so Formisch can move focus into the group:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <Radio.Group
+      name={field.props.name}
+      value={field.input}
+      onChange={(value) => field.onChange(value as 'hobby' | 'pro')}
+      label="Plan"
+      error={field.errors?.[0]}
+    >
+      <Radio
+        value="hobby"
+        label="Hobby"
+        ref={field.props.ref}
+        autoFocus={field.props.autoFocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Radio value="pro" label="Pro" />
+    </Radio.Group>
+  )}
+</Field>
+```
+
+### Slider
+
+`Slider` works with a single number, so `field.onChange` can be passed directly. It has no `error` prop, so wrap it in `Input.Wrapper`, and use `thumbLabel` for the accessible name because the visible wrapper label is not associated with the thumb:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <Input.Wrapper label="Volume" error={field.errors?.[0]}>
+      <Slider
+        name={field.props.name}
+        value={field.input ?? 50}
+        onChange={field.onChange}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+        thumbLabel="Volume"
+        min={0}
+        max={100}
+      />
+    </Input.Wrapper>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+Mantine's own `use-form` hook and its `getInputProps` helper are not needed with Formisch. The <Link href="/react/api/Field/">`Field`</Link> component provides the same wiring through its render prop, with validation coming from your Valibot schema.
+
+## Next steps
+
+Read the <Link href="/react/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/mantine/index.mdx
@@ -81,19 +81,27 @@ These examples wire fields directly so you can see the complete integration. Onc
 Formisch exposes errors as `[string, ...string[]] | null`. Mantine inputs display an error message through their `error` prop and set `aria-invalid` and `aria-describedby` on the input automatically, so a single expression covers the visual and accessible error state:
 
 ```tsx
-<TextInput
-  {...field.props}
-  value={field.input ?? ''}
-  error={field.errors?.[0]}
-/>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextInput
+      {...field.props}
+      value={field.input ?? ''}
+      error={field.errors?.[0]}
+    />
+  )}
+</Field>
 ```
 
 For widgets without an `error` prop, such as `Slider`, wrap the control in `Input.Wrapper`, which renders the same label and error markup:
 
 ```tsx
-<Input.Wrapper label="Volume" error={field.errors?.[0]}>
-  <Slider {/* ... */} />
-</Input.Wrapper>
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <Input.Wrapper label="Volume" error={field.errors?.[0]}>
+      <Slider {/* ... */} />
+    </Input.Wrapper>
+  )}
+</Field>
 ```
 
 By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/react-aria/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/react-aria/index.mdx
@@ -1,0 +1,408 @@
+---
+title: React Aria
+description: >-
+  Learn how to connect Formisch fields to React Aria Components text fields,
+  selects, radio groups, sliders and other form controls.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# React Aria
+
+[React Aria Components](https://react-aria.adobe.com) is Adobe's library of unstyled, accessible components with built-in behavior and internationalization. This guide targets react-aria-components v1. No adapter package is needed: every component is value-controlled, so fields are wired with `field.input` and `field.onChange`, plus Formisch's lifecycle props. Set `validationBehavior="aria"` on each form component so your Valibot schema controls validation instead of the browser.
+
+## Installation
+
+Install Formisch, Valibot and React Aria Components:
+
+```bash
+npm install @formisch/react valibot react-aria-components
+```
+
+## Wiring patterns
+
+React Aria Components never expose their native element for a props spread. Instead, every form component is controlled through a value callback, and labels, errors and `aria` attributes are wired automatically from the composition:
+
+- Pass `field.input` as `value` (or `isSelected` for checkboxes) and `field.onChange` as the change handler. The callbacks receive plain values, so `field.onChange` often works directly.
+- Forward `field.props` individually: `name` on the component, `ref` on the nested native element, and the focus, blur and autofocus props on the component.
+
+### Text field
+
+`TextField` manages a nested native `<Input>`. Control the value on the root and register the native element through the `Input` ref:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextField
+      name={field.props.name}
+      value={field.input ?? ''}
+      onChange={field.onChange}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      autoFocus={field.props.autoFocus}
+      type="email"
+      validationBehavior="aria"
+      isInvalid={field.errors !== null}
+    >
+      <Label>Email</Label>
+      <Input ref={field.props.ref} />
+      <FieldError>{field.errors?.[0]}</FieldError>
+    </TextField>
+  )}
+</Field>
+```
+
+Formisch's focus and blur handlers are parameterless because they only update field lifecycle state, so you can pass them directly even when the component supplies an event argument.
+
+### Ref objects
+
+Components that hide their native input, such as `Checkbox`, `Radio` and `SliderThumb`, expose it through an `inputRef` prop instead. That prop only accepts ref objects, while `field.props.ref` is a ref callback, so bridge the two with a small utility that you define once:
+
+```ts
+import type { RefObject } from 'react';
+
+export function toRefObject<T>(
+  callback: (element: T | null) => void
+): RefObject<T | null> {
+  let element: T | null = null;
+  return {
+    get current() {
+      return element;
+    },
+    set current(value) {
+      element = value;
+      callback(value);
+    },
+  };
+}
+```
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox
+      name={field.props.name}
+      inputRef={toRefObject<HTMLInputElement>(field.props.ref)}
+      autoFocus={field.props.autoFocus}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      isSelected={field.input ?? false}
+      onChange={field.onChange}
+      validationBehavior="aria"
+    >
+      Remember me
+    </Checkbox>
+  )}
+</Field>
+```
+
+These examples wire fields directly so you can see the complete integration. Once a pattern repeats, wrap the composition in your own input component. The <Link href="/react/guides/input-components/">input components guide</Link> shows how.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Pass `isInvalid` to the form component and render the first message inside `FieldError`, which only appears while the field is invalid and is associated with the control automatically:
+
+```tsx
+<TextField
+  /* ... */
+  validationBehavior="aria"
+  isInvalid={field.errors !== null}
+>
+  <Label>Email</Label>
+  <Input ref={field.props.ref} />
+  <FieldError>{field.errors?.[0]}</FieldError>
+</TextField>
+```
+
+`validationBehavior="aria"` matters: without it, React Aria defaults to native browser validation, which would compete with your schema. By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines two text fields and a checkbox with accessible errors:
+
+```tsx
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/react';
+import {
+  Button,
+  Checkbox,
+  FieldError,
+  Input,
+  Label,
+  TextField,
+} from 'react-aria-components';
+import * as v from 'valibot';
+import { toRefObject } from './toRefObject';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = useForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <TextField
+            name={field.props.name}
+            value={field.input ?? ''}
+            onChange={field.onChange}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+            autoFocus={field.props.autoFocus}
+            type="email"
+            autoComplete="email"
+            validationBehavior="aria"
+            isInvalid={field.errors !== null}
+          >
+            <Label>Email</Label>
+            <Input ref={field.props.ref} placeholder="jane@example.com" />
+            <FieldError>{field.errors?.[0]}</FieldError>
+          </TextField>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <TextField
+            name={field.props.name}
+            value={field.input ?? ''}
+            onChange={field.onChange}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+            autoFocus={field.props.autoFocus}
+            type="password"
+            autoComplete="current-password"
+            validationBehavior="aria"
+            isInvalid={field.errors !== null}
+          >
+            <Label>Password</Label>
+            <Input ref={field.props.ref} />
+            <FieldError>{field.errors?.[0]}</FieldError>
+          </TextField>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <Checkbox
+            name={field.props.name}
+            inputRef={toRefObject<HTMLInputElement>(field.props.ref)}
+            autoFocus={field.props.autoFocus}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+            isSelected={field.input ?? false}
+            onChange={field.onChange}
+            validationBehavior="aria"
+          >
+            Remember me
+          </Checkbox>
+        )}
+      </Field>
+
+      <Button type="submit" isDisabled={loginForm.isSubmitting}>
+        Login
+      </Button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. Both patterns appear here: the text fields register the nested `Input` directly, while the checkbox bridges its `inputRef` prop with `toRefObject`.
+
+## Component reference
+
+The following snippets assume a form store named `form`, initialized values that match the schema, and the `toRefObject` utility from above.
+
+### Text input
+
+`TextField` with a nested `Input`, controlled on the root:
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <TextField
+      name={field.props.name}
+      value={field.input ?? ''}
+      onChange={field.onChange}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      autoFocus={field.props.autoFocus}
+      type="email"
+      validationBehavior="aria"
+      isInvalid={field.errors !== null}
+    >
+      <Label>Email</Label>
+      <Input ref={field.props.ref} />
+      <FieldError>{field.errors?.[0]}</FieldError>
+    </TextField>
+  )}
+</Field>
+```
+
+For multiline text, replace `Input` with `TextArea` inside the same `TextField` composition.
+
+### Checkbox
+
+For a boolean field, use `isSelected` and bridge the input ref:
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <Checkbox
+      name={field.props.name}
+      inputRef={toRefObject<HTMLInputElement>(field.props.ref)}
+      autoFocus={field.props.autoFocus}
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      isSelected={field.input ?? false}
+      onChange={field.onChange}
+      validationBehavior="aria"
+    >
+      Newsletter
+    </Checkbox>
+  )}
+</Field>
+```
+
+### Select
+
+`Select` is controlled through `selectedKey` and `onSelectionChange`. Convert between React Aria's `null` and Formisch's `undefined`, and narrow the key back to the schema union:
+
+```tsx
+const frameworks = [
+  { id: 'angular', label: 'Angular' },
+  { id: 'react', label: 'React' },
+  { id: 'solid', label: 'Solid' },
+  { id: 'vue', label: 'Vue' },
+];
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <Select
+      name={field.props.name}
+      selectedKey={field.input ?? null}
+      onSelectionChange={(key) =>
+        field.onChange((key ?? undefined) as typeof field.input)
+      }
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      autoFocus={field.props.autoFocus}
+      validationBehavior="aria"
+      isInvalid={field.errors !== null}
+      placeholder="Select a framework"
+    >
+      <Label>Framework</Label>
+      <Button>
+        <SelectValue />
+      </Button>
+      <FieldError>{field.errors?.[0]}</FieldError>
+      <Popover>
+        <ListBox items={frameworks}>
+          {(item) => <ListBoxItem>{item.label}</ListBoxItem>}
+        </ListBox>
+      </Popover>
+    </Select>
+  )}
+</Field>
+```
+
+`Select` does not expose its hidden native element, so Formisch's `focus()` method cannot target this field. Focus, touched state and blur validation still work through the visible trigger's lifecycle props.
+
+### Radio group
+
+`RadioGroup` is controlled through `onChange(value)`. Bridge the first radio's `inputRef` so Formisch can move focus into the group:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <RadioGroup
+      name={field.props.name}
+      value={field.input ?? null}
+      onChange={(value) =>
+        field.onChange((value ?? undefined) as typeof field.input)
+      }
+      onFocus={field.props.onFocus}
+      onBlur={field.props.onBlur}
+      validationBehavior="aria"
+      isInvalid={field.errors !== null}
+    >
+      <Label>Plan</Label>
+      <Radio
+        value="hobby"
+        inputRef={toRefObject<HTMLInputElement>(field.props.ref)}
+        autoFocus={field.props.autoFocus}
+      >
+        Hobby
+      </Radio>
+      <Radio value="pro">Pro</Radio>
+      <FieldError>{field.errors?.[0]}</FieldError>
+    </RadioGroup>
+  )}
+</Field>
+```
+
+### Slider
+
+`Slider` supports single number values directly, so no array conversion is needed. The lifecycle props and the input ref bridge go on `SliderThumb`:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <Slider
+      value={field.input ?? 50}
+      onChange={(value) =>
+        field.onChange(Array.isArray(value) ? (value[0] ?? 50) : value)
+      }
+      minValue={0}
+      maxValue={100}
+    >
+      <Label>Volume</Label>
+      <SliderOutput />
+      <SliderTrack>
+        <SliderThumb
+          name={field.props.name}
+          inputRef={toRefObject<HTMLInputElement>(field.props.ref)}
+          autoFocus={field.props.autoFocus}
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
+        />
+      </SliderTrack>
+    </Slider>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+React Aria's own form documentation demonstrates integration through React Hook Form's `Controller`. You do not need it with Formisch: the <Link href="/react/api/Field/">`Field`</Link> component provides the same render-prop wiring. React Aria Components ship unstyled, so all examples assume you style them following the [React Aria styling guide](https://react-aria.adobe.com/styling).
+
+## Next steps
+
+Read the <Link href="/react/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/react/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/react/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/react-aria/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/react-aria/index.mdx
@@ -105,15 +105,19 @@ These examples wire fields directly so you can see the complete integration. Onc
 Formisch exposes errors as `[string, ...string[]] | null`. Pass `isInvalid` to the form component and render the first message inside `FieldError`, which only appears while the field is invalid and is associated with the control automatically:
 
 ```tsx
-<TextField
-  /* ... */
-  validationBehavior="aria"
-  isInvalid={field.errors !== null}
->
-  <Label>Email</Label>
-  <Input ref={field.props.ref} />
-  <FieldError>{field.errors?.[0]}</FieldError>
-</TextField>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextField
+      /* ... */
+      validationBehavior="aria"
+      isInvalid={field.errors !== null}
+    >
+      <Label>Email</Label>
+      <Input ref={field.props.ref} />
+      <FieldError>{field.errors?.[0]}</FieldError>
+    </TextField>
+  )}
+</Field>
 ```
 
 `validationBehavior="aria"` matters: without it, React Aria defaults to native browser validation, which would compete with your schema. By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.

--- a/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(integration-guides)/shadcn-ui/index.mdx
@@ -72,20 +72,24 @@ These examples wire fields directly so you can see the complete integration. Onc
 Formisch exposes errors as `[string, ...string[]] | null`. shadcn's `FieldError` expects objects with a `message` property, so map the strings before passing them. Give the error a stable ID and reference it from the input when an error is present:
 
 ```tsx
-<UIField data-invalid={field.errors !== null}>
-  <FieldLabel htmlFor="login-email">Email</FieldLabel>
-  <Input
-    {...field.props}
-    id="login-email"
-    value={field.input ?? ''}
-    aria-invalid={field.errors !== null}
-    aria-errormessage={field.errors ? 'login-email-error' : undefined}
-  />
-  <FieldError
-    id="login-email-error"
-    errors={field.errors?.map((message) => ({ message }))}
-  />
-</UIField>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <UIField data-invalid={field.errors !== null}>
+      <FieldLabel htmlFor="login-email">Email</FieldLabel>
+      <Input
+        {...field.props}
+        id="login-email"
+        value={field.input ?? ''}
+        aria-invalid={field.errors !== null}
+        aria-errormessage={field.errors ? 'login-email-error' : undefined}
+      />
+      <FieldError
+        id="login-email-error"
+        errors={field.errors?.map((message) => ({ message }))}
+      />
+    </UIField>
+  )}
+</Field>
 ```
 
 Use page-unique IDs for labels and errors instead of assuming that a field name is unique in the DOM. By default, Formisch validates on submit and revalidates on input. The <Link href="/react/guides/validation/">validation guide</Link> explains how to change that timing.

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/input-components/index.mdx
@@ -190,6 +190,7 @@ The `field.onChange` method updates the field value and triggers validation. For
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/react/guides/shadcn-ui/">shadcn/ui</Link>
+- <Link href="/react/guides/ark-ui/">Ark UI</Link>
 - <Link href="/react/guides/base-ui/">Base UI</Link>
 - <Link href="/react/guides/chakra-ui/">Chakra UI</Link>
 - <Link href="/react/guides/mantine/">Mantine</Link>

--- a/website/src/routes/(docs)/react/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(main-concepts)/input-components/index.mdx
@@ -190,6 +190,10 @@ The `field.onChange` method updates the field value and triggers validation. For
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/react/guides/shadcn-ui/">shadcn/ui</Link>
+- <Link href="/react/guides/base-ui/">Base UI</Link>
+- <Link href="/react/guides/chakra-ui/">Chakra UI</Link>
+- <Link href="/react/guides/mantine/">Mantine</Link>
+- <Link href="/react/guides/react-aria/">React Aria</Link>
 
 ## Next steps
 

--- a/website/src/routes/(docs)/react/guides/menu.md
+++ b/website/src/routes/(docs)/react/guides/menu.md
@@ -36,6 +36,7 @@
 ## Integration guides
 
 - [shadcn/ui](/react/guides/shadcn-ui/)
+- [Ark UI](/react/guides/ark-ui/)
 - [Base UI](/react/guides/base-ui/)
 - [Chakra UI](/react/guides/chakra-ui/)
 - [Mantine](/react/guides/mantine/)

--- a/website/src/routes/(docs)/react/guides/menu.md
+++ b/website/src/routes/(docs)/react/guides/menu.md
@@ -36,3 +36,7 @@
 ## Integration guides
 
 - [shadcn/ui](/react/guides/shadcn-ui/)
+- [Base UI](/react/guides/base-ui/)
+- [Chakra UI](/react/guides/chakra-ui/)
+- [Mantine](/react/guides/mantine/)
+- [React Aria](/react/guides/react-aria/)

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -212,6 +212,11 @@ This is useful for:
 
 The `field.onInput` method updates the field value and triggers validation, just like a native input would.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/solid/guides/kobalte/">Kobalte</Link>
+- <Link href="/solid/guides/ark-ui/">Ark UI</Link>
+
 ## Next steps
 
 Now that you understand controlled fields, you can explore more advanced topics like <Link href="/solid/guides/nested-fields/">nested fields</Link> and <Link href="/solid/guides/field-arrays/">field arrays</Link> to handle complex form structures.

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/ark-ui/index.mdx
@@ -1,0 +1,418 @@
+---
+title: Ark UI
+description: >-
+  Learn how to connect Formisch fields to Ark UI inputs, checkboxes, selects,
+  radio groups and sliders in Solid.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Ark UI
+
+[Ark UI](https://ark-ui.com) is a headless component library built on state machines, available for Solid among other frameworks. This guide targets Ark UI v5 for Solid. No adapter package is needed: each component exposes the native element as one of its parts, so you spread `field.props` onto that part and let the component root handle the value.
+
+## Installation
+
+Install Formisch, Valibot and Ark UI:
+
+```bash
+npm install @formisch/solid valibot @ark-ui/solid
+```
+
+Ark UI ships unstyled, so every example below leaves styling to you.
+
+## Wiring patterns
+
+Choose the wiring from the part you are rendering:
+
+- If the part is a native `<input>`, `<textarea>` or `<select>`, spread `field.props` onto it and pass `field.input` as the value.
+- If the component owns the value, pass `field.input` to the root and send the root's value callback to `field.onInput`, then forward the lifecycle props to the component's hidden native part.
+
+`field.onInput` and `field.props.onInput` are different functions and mixing them up is the easiest mistake to make here. `field.onInput(value)` stores a value, while `field.props.onInput(event)` reads the value from a DOM element. Because it reads from the element, it always produces a string, so a number, boolean or enum field must go through the component's own callback rather than the spread.
+
+### Spreading field.props
+
+`Field.Input` renders a native input and merges its handlers with yours, so the whole spread works. Since Formisch and Ark UI both export a `Field`, the Ark one is imported as `ArkField`:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <ArkField.Root id="login-email" invalid={!!field.errors}>
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} type="email" value={field.input ?? ''} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  )}
+</Field>
+```
+
+Set the `id` on `ArkField.Root` rather than on the input. Ark derives the control id and the label's `for` attribute from it, so overriding the part's own `id` would break that association.
+
+### Controlled components
+
+A checkbox owns its value, so the root takes `checked` and `onCheckedChange`, while `Checkbox.HiddenInput` takes the element reference and the lifecycle handlers. Registering that input is what keeps <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing working. The callback reports `boolean | 'indeterminate'`, so normalize it before storing:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox.Root
+      ids={{ hiddenInput: 'login-remember-me' }}
+      name={field.props.name}
+      checked={field.input ?? false}
+      onCheckedChange={(details) => field.onInput(details.checked === true)}
+      invalid={!!field.errors}
+    >
+      <Checkbox.HiddenInput
+        ref={field.props.ref}
+        autofocus={field.props.autofocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Remember me</Checkbox.Label>
+    </Checkbox.Root>
+  )}
+</Field>
+```
+
+Every Ark root accepts an `ids` object, which is the supported way to give a hidden part a stable id. Setting `id` directly on a hidden part instead leaves the generated label pointing at the old value.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires `aria-errormessage` to that element for you, and the error text only renders while the field is invalid:
+
+```tsx
+<ArkField.Root
+  id="login-email"
+  ids={{ errorText: 'login-email-error' }}
+  invalid={!!field.errors}
+>
+  <ArkField.Label>Email</ArkField.Label>
+  <ArkField.Input {...field.props} value={field.input ?? ''} />
+  <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+</ArkField.Root>
+```
+
+Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/solid/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines two text fields, a controlled checkbox and accessible errors:
+
+```tsx
+import { Checkbox } from '@ark-ui/solid/checkbox';
+import { Field as ArkField } from '@ark-ui/solid/field';
+import { createForm, Field, Form, type SubmitHandler } from '@formisch/solid';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = createForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <ArkField.Root
+            id="login-email"
+            ids={{ errorText: 'login-email-error' }}
+            invalid={!!field.errors}
+          >
+            <ArkField.Label>Email</ArkField.Label>
+            <ArkField.Input
+              {...field.props}
+              type="email"
+              autocomplete="email"
+              placeholder="jane@example.com"
+              value={field.input ?? ''}
+            />
+            <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+          </ArkField.Root>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <ArkField.Root
+            id="login-password"
+            ids={{ errorText: 'login-password-error' }}
+            invalid={!!field.errors}
+          >
+            <ArkField.Label>Password</ArkField.Label>
+            <ArkField.Input
+              {...field.props}
+              type="password"
+              autocomplete="current-password"
+              value={field.input ?? ''}
+            />
+            <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+          </ArkField.Root>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <Checkbox.Root
+            ids={{ hiddenInput: 'login-remember-me' }}
+            name={field.props.name}
+            checked={field.input ?? false}
+            onCheckedChange={(details) =>
+              field.onInput(details.checked === true)
+            }
+            invalid={!!field.errors}
+          >
+            <Checkbox.HiddenInput
+              ref={field.props.ref}
+              autofocus={field.props.autofocus}
+              onFocus={field.props.onFocus}
+              onBlur={field.props.onBlur}
+            />
+            <Checkbox.Control>
+              <Checkbox.Indicator>✓</Checkbox.Indicator>
+            </Checkbox.Control>
+            <Checkbox.Label>Remember me</Checkbox.Label>
+          </Checkbox.Root>
+        )}
+      </Field>
+
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. The two text fields use the spread, while the checkbox routes its value through the root and its lifecycle props through the hidden input.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema. Never destructure the field store, and read `field.input` and `field.errors` inside JSX so Solid tracks them.
+
+### Text input
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <ArkField.Root
+      id="profile-email"
+      ids={{ errorText: 'profile-email-error' }}
+      invalid={!!field.errors}
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} type="email" value={field.input ?? ''} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  )}
+</Field>
+```
+
+Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the same wiring.
+
+### Checkbox
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <Checkbox.Root
+      ids={{ hiddenInput: 'settings-newsletter' }}
+      name={field.props.name}
+      checked={field.input ?? false}
+      onCheckedChange={(details) => field.onInput(details.checked === true)}
+      invalid={!!field.errors}
+    >
+      <Checkbox.HiddenInput
+        ref={field.props.ref}
+        autofocus={field.props.autofocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Newsletter</Checkbox.Label>
+    </Checkbox.Root>
+  )}
+</Field>
+```
+
+### Select
+
+Ark's select is array based even for a single selection, so wrap the value and unwrap the callback. Items come from a collection:
+
+```tsx
+const frameworkCollection = createListCollection({
+  items: [
+    { label: 'Angular', value: 'angular' },
+    { label: 'React', value: 'react' },
+    { label: 'Solid', value: 'solid' },
+    { label: 'Vue', value: 'vue' },
+  ],
+});
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <Select.Root
+      ids={{
+        trigger: 'project-framework',
+        hiddenSelect: 'project-framework-select',
+      }}
+      collection={frameworkCollection}
+      name={field.props.name}
+      value={field.input ? [field.input] : []}
+      onValueChange={(details) =>
+        field.onInput(details.value[0] as 'angular' | 'react')
+      }
+      invalid={!!field.errors}
+    >
+      <Select.Label>Framework</Select.Label>
+      <Select.Control>
+        <Select.Trigger aria-errormessage="project-framework-error">
+          <Select.ValueText placeholder="Select a framework" />
+          <Select.Indicator>▾</Select.Indicator>
+        </Select.Trigger>
+      </Select.Control>
+      <Select.HiddenSelect
+        ref={field.props.ref}
+        autofocus={field.props.autofocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <span id="project-framework-error">{field.errors?.[0]}</span>
+      <Portal>
+        <Select.Positioner>
+          <Select.Content>
+            <For each={frameworkCollection.items}>
+              {(item) => (
+                <Select.Item item={item}>
+                  <Select.ItemText>{item.label}</Select.ItemText>
+                </Select.Item>
+              )}
+            </For>
+          </Select.Content>
+        </Select.Positioner>
+      </Portal>
+    </Select.Root>
+  )}
+</Field>
+```
+
+The hidden select forwards focus to the visible trigger on its own, so `focus` lands on the button the user sees.
+
+### Radio group
+
+Register every item's hidden input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autofocus` on the first item only, otherwise every radio competes for focus:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <RadioGroup.Root
+      ids={{ itemHiddenInput: (value) => `plan-${value}` }}
+      name={field.props.name}
+      value={field.input ?? null}
+      onValueChange={(details) =>
+        field.onInput(details.value as 'hobby' | 'pro')
+      }
+      aria-errormessage="plan-error"
+    >
+      <RadioGroup.Label>Plan</RadioGroup.Label>
+      <For each={PLANS}>
+        {(plan, index) => (
+          <RadioGroup.Item value={plan}>
+            <RadioGroup.ItemHiddenInput
+              ref={field.props.ref}
+              autofocus={index() === 0 && field.props.autofocus}
+              onFocus={field.props.onFocus}
+              onBlur={field.props.onBlur}
+              aria-invalid={field.errors ? true : undefined}
+            />
+            <RadioGroup.ItemControl />
+            <RadioGroup.ItemText>{PLAN_LABELS[plan]}</RadioGroup.ItemText>
+          </RadioGroup.Item>
+        )}
+      </For>
+      <span id="plan-error">{field.errors?.[0]}</span>
+    </RadioGroup.Root>
+  )}
+</Field>
+```
+
+### Slider
+
+Ark's slider is array based like its select, and it uses `min` and `max` rather than `minValue` and `maxValue`. One `Slider.Thumb` renders exactly one thumb:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <Slider.Root
+      ids={{ thumb: () => 'settings-volume-thumb' }}
+      name={field.props.name}
+      min={0}
+      max={100}
+      value={[field.input ?? 50]}
+      onValueChange={(details) => field.onInput(details.value[0])}
+      invalid={!!field.errors}
+    >
+      <Slider.Label>Volume</Slider.Label>
+      <Slider.ValueText />
+      <Slider.Control>
+        <Slider.Track>
+          <Slider.Range />
+        </Slider.Track>
+        <Slider.Thumb index={0} aria-errormessage="settings-volume-error">
+          <Slider.HiddenInput
+            ref={field.props.ref}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+          />
+        </Slider.Thumb>
+      </Slider.Control>
+      <span id="settings-volume-error">{field.errors?.[0]}</span>
+    </Slider.Root>
+  )}
+</Field>
+```
+
+`Slider.HiddenInput` renders with the `hidden` attribute, which makes it unfocusable, so `focus` cannot move focus to this field. Keyboard users still reach the thumb normally, and validation, `isTouched` and blur validation are unaffected.
+
+## Library-specific notes
+
+`field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.
+
+Ark UI is also available for other frameworks. If you use its React version, the same part names apply, and our <Link href="/react/guides/base-ui/">Base UI guide</Link> covers a comparable composition style.
+
+## Next steps
+
+Read the <Link href="/solid/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/solid/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/ark-ui/index.mdx
@@ -88,15 +88,19 @@ The setter runs input-mode validation, so a form configured with `validate: 'cha
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires `aria-errormessage` to that element for you, and the error text only renders while the field is invalid:
 
 ```tsx
-<ArkField.Root
-  id="login-email"
-  ids={{ errorText: 'login-email-error' }}
-  invalid={!!field.errors}
->
-  <ArkField.Label>Email</ArkField.Label>
-  <ArkField.Input {...field.props} value={field.input ?? ''} />
-  <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
-</ArkField.Root>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <ArkField.Root
+      id="login-email"
+      ids={{ errorText: 'login-email-error' }}
+      invalid={!!field.errors}
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} value={field.input ?? ''} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  )}
+</Field>
 ```
 
 Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/ark-ui/index.mdx
@@ -81,6 +81,8 @@ A checkbox owns its value, so the root takes `checked` and `onCheckedChange`, wh
 
 Every Ark root accepts an `ids` object, which is the supported way to give a hidden part a stable id. Setting `id` directly on a hidden part instead leaves the generated label pointing at the old value.
 
+The setter runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit. Use `validate: 'input'` if you want them validated as the value changes.
+
 ## Displaying errors
 
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires `aria-errormessage` to that element for you, and the error text only renders while the field is invalid:

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
@@ -1,0 +1,444 @@
+---
+title: Kobalte
+description: >-
+  Learn how to connect Formisch fields to Kobalte text fields, checkboxes,
+  selects, radio groups and sliders.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Kobalte
+
+[Kobalte](https://kobalte.dev) is a headless, accessible UI toolkit for Solid. This guide targets Kobalte v0.13. No adapter package is needed: each component exposes the native element as one of its parts, so you spread `field.props` onto that part and let the component root handle the value.
+
+## Installation
+
+Install Formisch, Valibot and Kobalte:
+
+```bash
+npm install @formisch/solid valibot @kobalte/core
+```
+
+Kobalte ships unstyled, so every example below leaves styling to you.
+
+## Wiring patterns
+
+Choose the wiring from the part you are rendering:
+
+- If the part is a native `<input>`, `<textarea>` or `<select>`, spread `field.props` onto it and pass `field.input` as the value.
+- If the component owns the value, such as a checkbox or select, pass `field.input` to the root and send the root's `onChange` to `field.onInput`, then forward the lifecycle props to the component's hidden native part.
+
+`field.onInput` and `field.props.onInput` are different functions and mixing them up is the easiest mistake to make here. `field.onInput(value)` stores a value, while `field.props.onInput(event)` reads the value from a DOM element. Because it reads from the element, it always produces a string, so a number, boolean or enum field must go through the component's own callback rather than the spread.
+
+### Spreading field.props
+
+`TextField.Input` renders a native input and composes its handlers with the ones you pass, so the whole spread works. Kobalte applies its own value first and yours second, which is why the explicit `value` wins:
+
+```tsx
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextField validationState={field.errors ? 'invalid' : 'valid'}>
+      <TextField.Label>Email</TextField.Label>
+      <TextField.Input
+        {...field.props}
+        id="login-email"
+        type="email"
+        value={field.input ?? ''}
+      />
+    </TextField>
+  )}
+</Field>
+```
+
+### Controlled components
+
+A checkbox owns its value, so the root takes `checked` and `onChange`, while the hidden `Checkbox.Input` takes the element reference and the lifecycle handlers. Registering that input is what keeps <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing working:
+
+```tsx
+<Field of={loginForm} path={['rememberMe']}>
+  {(field) => (
+    <Checkbox
+      name={field.props.name}
+      checked={field.input ?? false}
+      onChange={field.onInput}
+      validationState={field.errors ? 'invalid' : 'valid'}
+    >
+      <Checkbox.Input
+        id="login-remember-me"
+        ref={field.props.ref}
+        autofocus={field.props.autofocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Remember me</Checkbox.Label>
+    </Checkbox>
+  )}
+</Field>
+```
+
+Note that the compound components are the root themselves. There is no `Checkbox.Root` or `TextField.Root` in Kobalte v0.13.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Pass `validationState` to the root and render the message in the component's `ErrorMessage` part, which only appears while the state is invalid:
+
+```tsx
+<TextField validationState={field.errors ? 'invalid' : 'valid'}>
+  <TextField.Label>Email</TextField.Label>
+  <TextField.Input
+    {...field.props}
+    id="login-email"
+    value={field.input ?? ''}
+    aria-errormessage="login-email-error"
+  />
+  <TextField.ErrorMessage id="login-email-error">
+    {field.errors?.[0]}
+  </TextField.ErrorMessage>
+</TextField>
+```
+
+Kobalte sets `aria-invalid` on the native parts, but not on a select trigger or a slider thumb, so add it yourself on those two. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/solid/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines two text fields, a controlled checkbox and accessible errors:
+
+```tsx
+import { createForm, Field, Form, type SubmitHandler } from '@formisch/solid';
+import { Checkbox } from '@kobalte/core/checkbox';
+import { TextField } from '@kobalte/core/text-field';
+import * as v from 'valibot';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+export default function LoginPage() {
+  const loginForm = createForm({
+    schema: LoginSchema,
+    initialInput: {
+      email: '',
+      password: '',
+      rememberMe: false,
+    },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+
+  return (
+    <Form of={loginForm} onSubmit={handleSubmit}>
+      <Field of={loginForm} path={['email']}>
+        {(field) => (
+          <TextField validationState={field.errors ? 'invalid' : 'valid'}>
+            <TextField.Label>Email</TextField.Label>
+            <TextField.Input
+              {...field.props}
+              id="login-email"
+              type="email"
+              autocomplete="email"
+              placeholder="jane@example.com"
+              value={field.input ?? ''}
+              aria-errormessage="login-email-error"
+            />
+            <TextField.ErrorMessage id="login-email-error">
+              {field.errors?.[0]}
+            </TextField.ErrorMessage>
+          </TextField>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['password']}>
+        {(field) => (
+          <TextField validationState={field.errors ? 'invalid' : 'valid'}>
+            <TextField.Label>Password</TextField.Label>
+            <TextField.Input
+              {...field.props}
+              id="login-password"
+              type="password"
+              autocomplete="current-password"
+              value={field.input ?? ''}
+              aria-errormessage="login-password-error"
+            />
+            <TextField.ErrorMessage id="login-password-error">
+              {field.errors?.[0]}
+            </TextField.ErrorMessage>
+          </TextField>
+        )}
+      </Field>
+
+      <Field of={loginForm} path={['rememberMe']}>
+        {(field) => (
+          <Checkbox
+            name={field.props.name}
+            checked={field.input ?? false}
+            onChange={field.onInput}
+            validationState={field.errors ? 'invalid' : 'valid'}
+          >
+            <Checkbox.Input
+              id="login-remember-me"
+              ref={field.props.ref}
+              autofocus={field.props.autofocus}
+              onFocus={field.props.onFocus}
+              onBlur={field.props.onBlur}
+            />
+            <Checkbox.Control>
+              <Checkbox.Indicator>✓</Checkbox.Indicator>
+            </Checkbox.Control>
+            <Checkbox.Label>Remember me</Checkbox.Label>
+          </Checkbox>
+        )}
+      </Field>
+
+      <button type="submit" disabled={loginForm.isSubmitting}>
+        Login
+      </button>
+    </Form>
+  );
+}
+```
+
+The initial input keeps every control defined from its first render. The two text fields use the spread, while the checkbox routes its value through the root and its lifecycle props through the hidden input.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema. Never destructure the field store, and read `field.input` and `field.errors` inside JSX so Solid tracks them.
+
+### Text input
+
+```tsx
+<Field of={form} path={['email']}>
+  {(field) => (
+    <TextField validationState={field.errors ? 'invalid' : 'valid'}>
+      <TextField.Label>Email</TextField.Label>
+      <TextField.Input
+        {...field.props}
+        id="profile-email"
+        type="email"
+        value={field.input ?? ''}
+        aria-errormessage="profile-email-error"
+      />
+      <TextField.ErrorMessage id="profile-email-error">
+        {field.errors?.[0]}
+      </TextField.ErrorMessage>
+    </TextField>
+  )}
+</Field>
+```
+
+Swap `TextField.Input` for `TextField.TextArea` to get a multiline field with the same wiring.
+
+### Checkbox
+
+```tsx
+<Field of={form} path={['newsletter']}>
+  {(field) => (
+    <Checkbox
+      name={field.props.name}
+      checked={field.input ?? false}
+      onChange={field.onInput}
+      validationState={field.errors ? 'invalid' : 'valid'}
+    >
+      <Checkbox.Input
+        id="settings-newsletter"
+        ref={field.props.ref}
+        autofocus={field.props.autofocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Newsletter</Checkbox.Label>
+    </Checkbox>
+  )}
+</Field>
+```
+
+### Select
+
+Kobalte represents no selection as `null`, while an optional Formisch value is `undefined`, so convert in both directions. Passing `undefined` to a controlled `value` would silently turn the component uncontrolled. Using plain string options with a label map avoids option identity problems, and `Select.Value` needs its own type argument:
+
+```tsx
+const FRAMEWORKS = ['angular', 'react', 'solid', 'vue'] as const;
+type Framework = (typeof FRAMEWORKS)[number];
+const FRAMEWORK_LABELS: Record<Framework, string> = {
+  angular: 'Angular',
+  react: 'React',
+  solid: 'Solid',
+  vue: 'Vue',
+};
+```
+
+```tsx
+<Field of={form} path={['framework']}>
+  {(field) => (
+    <Select<Framework>
+      name={field.props.name}
+      options={[...FRAMEWORKS]}
+      value={field.input ?? null}
+      onChange={(value) => field.onInput(value ?? undefined)}
+      validationState={field.errors ? 'invalid' : 'valid'}
+      placeholder="Select a framework"
+      itemComponent={(props) => (
+        <Select.Item item={props.item}>
+          <Select.ItemLabel>
+            {FRAMEWORK_LABELS[props.item.rawValue]}
+          </Select.ItemLabel>
+        </Select.Item>
+      )}
+    >
+      <Select.Label>Framework</Select.Label>
+      <Select.HiddenSelect
+        id="project-framework-select"
+        ref={field.props.ref}
+        autofocus={field.props.autofocus}
+        onFocus={field.props.onFocus}
+        onBlur={field.props.onBlur}
+      />
+      <Select.Trigger
+        id="project-framework"
+        aria-invalid={field.errors ? true : undefined}
+        aria-errormessage="project-framework-error"
+      >
+        <Select.Value<Framework>>
+          {(state) => FRAMEWORK_LABELS[state.selectedOption()]}
+        </Select.Value>
+      </Select.Trigger>
+      <Select.ErrorMessage id="project-framework-error">
+        {field.errors?.[0]}
+      </Select.ErrorMessage>
+      <Select.Portal>
+        <Select.Content>
+          <Select.Listbox />
+        </Select.Content>
+      </Select.Portal>
+    </Select>
+  )}
+</Field>
+```
+
+### Radio group
+
+Register every item's input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autofocus` on the first item only, otherwise every radio competes for focus:
+
+```tsx
+<Field of={form} path={['plan']}>
+  {(field) => (
+    <RadioGroup
+      name={field.props.name}
+      value={field.input}
+      onChange={(value) => field.onInput(value as 'hobby' | 'pro')}
+      validationState={field.errors ? 'invalid' : 'valid'}
+      aria-errormessage="plan-error"
+    >
+      <RadioGroup.Label>Plan</RadioGroup.Label>
+      <For each={PLANS}>
+        {(plan, index) => (
+          <RadioGroup.Item value={plan}>
+            <RadioGroup.ItemInput
+              id={`plan-${plan}`}
+              ref={field.props.ref}
+              autofocus={index() === 0 && field.props.autofocus}
+              onFocus={field.props.onFocus}
+              onBlur={field.props.onBlur}
+            />
+            <RadioGroup.ItemControl>
+              <RadioGroup.ItemIndicator />
+            </RadioGroup.ItemControl>
+            <RadioGroup.ItemLabel>{PLAN_LABELS[plan]}</RadioGroup.ItemLabel>
+          </RadioGroup.Item>
+        )}
+      </For>
+      <RadioGroup.ErrorMessage id="plan-error">
+        {field.errors?.[0]}
+      </RadioGroup.ErrorMessage>
+    </RadioGroup>
+  )}
+</Field>
+```
+
+### Slider
+
+Kobalte's slider works with an array of values, so wrap the number for the single thumb and unwrap it in the callback. `Slider.Input` is a real range input that is only visually hidden, so mark it `aria-hidden` to keep a single `slider` role in the accessibility tree. The thumb is the element assistive technology should see:
+
+```tsx
+<Field of={form} path={['volume']}>
+  {(field) => (
+    <Slider
+      name={field.props.name}
+      minValue={0}
+      maxValue={100}
+      value={[field.input ?? 50]}
+      onChange={(values) => field.onInput(values[0])}
+      validationState={field.errors ? 'invalid' : 'valid'}
+    >
+      <Slider.Label>Volume</Slider.Label>
+      <Slider.ValueLabel />
+      <Slider.Track>
+        <Slider.Fill />
+        <Slider.Thumb
+          aria-invalid={field.errors ? true : undefined}
+          aria-errormessage="settings-volume-error"
+        >
+          <Slider.Input
+            id="settings-volume"
+            aria-hidden="true"
+            ref={field.props.ref}
+            autofocus={field.props.autofocus}
+            onFocus={field.props.onFocus}
+            onBlur={field.props.onBlur}
+          />
+        </Slider.Thumb>
+      </Slider.Track>
+      <Slider.ErrorMessage id="settings-volume-error">
+        {field.errors?.[0]}
+      </Slider.ErrorMessage>
+    </Slider>
+  )}
+</Field>
+```
+
+## Library-specific notes
+
+`Select.HiddenSelect` renders its native select inside an `aria-hidden` wrapper and does not forward focus to the visible trigger, so `focus` moves focus into that hidden element rather than to the button the user sees. Validation, `isTouched` and blur validation are unaffected. If you want the visible affordance, keep a reference to the trigger and forward focus yourself:
+
+```tsx
+let triggerElement: HTMLButtonElement | undefined;
+```
+
+```tsx
+<Select.HiddenSelect
+  ref={field.props.ref}
+  onFocus={() => {
+    field.props.onFocus();
+    triggerElement?.focus();
+  }}
+  onBlur={field.props.onBlur}
+/>
+<Select.Trigger ref={triggerElement}>{/* ... */}</Select.Trigger>
+```
+
+`field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.
+
+## Next steps
+
+Read the <Link href="/solid/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/solid/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
@@ -83,6 +83,8 @@ A checkbox owns its value, so the root takes `checked` and `onChange`, while the
 
 Note that the compound components are the root themselves. There is no `Checkbox.Root` or `TextField.Root` in Kobalte v0.13.
 
+The setter runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit. Use `validate: 'input'` if you want them validated as the value changes.
+
 ## Displaying errors
 
 Formisch exposes errors as `[string, ...string[]] | null`. Pass `validationState` to the root and render the message in the component's `ErrorMessage` part, which only appears while the state is invalid:

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
@@ -378,7 +378,7 @@ Register every item's input. Formisch keeps a list of registered elements, so ea
 
 ### Slider
 
-Kobalte's slider works with an array of values, so wrap the number for the single thumb and unwrap it in the callback. `Slider.Input` is a real range input that is only visually hidden, so mark it `aria-hidden` to keep a single `slider` role in the accessibility tree. The thumb is the element assistive technology should see:
+Kobalte's slider works with an array of values, so wrap the number for the single thumb and unwrap it in the callback. `Slider.Input` is a real range input that is only visually hidden, so mark it `aria-hidden` to keep a single `slider` role in the accessibility tree. The thumb is the element assistive technology should see. Kobalte already gives that input `tabindex="-1"`, so hiding it does not leave a focusable element out of the accessibility tree, and it stays available as the target for `focus`:
 
 ```tsx
 <Field of={form} path={['volume']}>

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
@@ -378,7 +378,7 @@ Register every item's input. Formisch keeps a list of registered elements, so ea
 
 ### Slider
 
-Kobalte's slider works with an array of values, so wrap the number for the single thumb and unwrap it in the callback. `Slider.Input` is a real range input that is only visually hidden, so mark it `aria-hidden` to keep a single `slider` role in the accessibility tree. The thumb is the element assistive technology should see. Kobalte already gives that input `tabindex="-1"`, so hiding it does not leave a focusable element out of the accessibility tree, and it stays available as the target for `focus`:
+Kobalte's slider works with an array of values, so wrap the number for the single thumb and unwrap it in the callback. `Slider.Input` is a real range input that is only visually hidden, so mark it `aria-hidden` to keep a single `slider` role in the accessibility tree. The thumb is the element assistive technology should see, so the focus handlers belong there rather than on the hidden input:
 
 ```tsx
 <Field of={form} path={['volume']}>
@@ -396,17 +396,12 @@ Kobalte's slider works with an array of values, so wrap the number for the singl
       <Slider.Track>
         <Slider.Fill />
         <Slider.Thumb
+          onFocus={field.props.onFocus}
+          onBlur={field.props.onBlur}
           aria-invalid={field.errors ? true : undefined}
           aria-errormessage="settings-volume-error"
         >
-          <Slider.Input
-            id="settings-volume"
-            aria-hidden="true"
-            ref={field.props.ref}
-            autofocus={field.props.autofocus}
-            onFocus={field.props.onFocus}
-            onBlur={field.props.onBlur}
-          />
+          <Slider.Input id="settings-volume" aria-hidden="true" />
         </Slider.Thumb>
       </Slider.Track>
       <Slider.ErrorMessage id="settings-volume-error">
@@ -416,6 +411,8 @@ Kobalte's slider works with an array of values, so wrap the number for the singl
   )}
 </Field>
 ```
+
+Do not register the hidden input as the field element. It is a one pixel, `aria-hidden` element, so `focus` would move focus somewhere the user cannot see and assistive technology cannot describe. Leaving it unregistered means `focus` and submit-time error focusing skip this field, while its value, validation and blur handling work normally.
 
 ## Library-specific notes
 

--- a/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(integration-guides)/kobalte/index.mdx
@@ -90,18 +90,22 @@ The setter runs input-mode validation, so a form configured with `validate: 'cha
 Formisch exposes errors as `[string, ...string[]] | null`. Pass `validationState` to the root and render the message in the component's `ErrorMessage` part, which only appears while the state is invalid:
 
 ```tsx
-<TextField validationState={field.errors ? 'invalid' : 'valid'}>
-  <TextField.Label>Email</TextField.Label>
-  <TextField.Input
-    {...field.props}
-    id="login-email"
-    value={field.input ?? ''}
-    aria-errormessage="login-email-error"
-  />
-  <TextField.ErrorMessage id="login-email-error">
-    {field.errors?.[0]}
-  </TextField.ErrorMessage>
-</TextField>
+<Field of={loginForm} path={['email']}>
+  {(field) => (
+    <TextField validationState={field.errors ? 'invalid' : 'valid'}>
+      <TextField.Label>Email</TextField.Label>
+      <TextField.Input
+        {...field.props}
+        id="login-email"
+        value={field.input ?? ''}
+        aria-errormessage="login-email-error"
+      />
+      <TextField.ErrorMessage id="login-email-error">
+        {field.errors?.[0]}
+      </TextField.ErrorMessage>
+    </TextField>
+  )}
+</Field>
 ```
 
 Kobalte sets `aria-invalid` on the native parts, but not on a select trigger or a slider thumb, so add it yourself on those two. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
@@ -425,15 +429,22 @@ let triggerElement: HTMLButtonElement | undefined;
 ```
 
 ```tsx
-<Select.HiddenSelect
-  ref={field.props.ref}
-  onFocus={() => {
-    field.props.onFocus();
-    triggerElement?.focus();
-  }}
-  onBlur={field.props.onBlur}
-/>
-<Select.Trigger ref={triggerElement}>{/* ... */}</Select.Trigger>
+<Field of={form} path={['framework']}>
+  {(field) => (
+    // The remaining Select props are the same as in the reference above
+    <Select<Framework>>
+      <Select.HiddenSelect
+        ref={field.props.ref}
+        onFocus={() => {
+          field.props.onFocus();
+          triggerElement?.focus();
+        }}
+        onBlur={field.props.onBlur}
+      />
+      <Select.Trigger ref={triggerElement}>{/* ... */}</Select.Trigger>
+    </Select>
+  )}
+</Field>
 ```
 
 `field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.

--- a/website/src/routes/(docs)/solid/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(main-concepts)/input-components/index.mdx
@@ -187,6 +187,11 @@ import { DatePicker } from 'some-component-library';
 
 The `field.onInput` method updates the field value and triggers validation. For more details, see the <Link href="/solid/guides/controlled-fields/">controlled fields</Link> guide.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/solid/guides/kobalte/">Kobalte</Link>
+- <Link href="/solid/guides/ark-ui/">Ark UI</Link>
+
 ## Next steps
 
 Now that you know how to create reusable input components, continue to the <Link href="/solid/guides/handle-submission/">handle submission</Link> guide to learn how to process form data when the user submits the form.

--- a/website/src/routes/(docs)/solid/guides/menu.md
+++ b/website/src/routes/(docs)/solid/guides/menu.md
@@ -31,3 +31,8 @@
 
 - [From Felte](/solid/guides/migrate-from-felte/)
 - [From TanStack Form](/solid/guides/migrate-from-tanstack-form/)
+
+## Integration guides
+
+- [Kobalte](/solid/guides/kobalte/)
+- [Ark UI](/solid/guides/ark-ui/)

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -223,6 +223,7 @@ The `field.onInput` method updates the field value and triggers validation, just
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/svelte/guides/shadcn-svelte/">shadcn-svelte</Link>
+- <Link href="/svelte/guides/ark-ui/">Ark UI</Link>
 - <Link href="/svelte/guides/bits-ui/">Bits UI</Link>
 
 ## Next steps

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -220,6 +220,11 @@ This is useful for:
 
 The `field.onInput` method updates the field value and triggers validation, just like a native input would.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/svelte/guides/shadcn-svelte/">shadcn-svelte</Link>
+- <Link href="/svelte/guides/bits-ui/">Bits UI</Link>
+
 ## Next steps
 
 Now that you understand controlled fields, you can explore more advanced topics like <Link href="/svelte/guides/nested-fields/">nested fields</Link> and <Link href="/svelte/guides/field-arrays/">field arrays</Link> to handle complex form structures.

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
@@ -88,8 +88,13 @@ The setter runs input-mode validation, so a form configured with `validate: 'cha
 For the select and the slider, put `onfocus` and `onblur` on the visible part rather than on the hidden one. Their hidden inputs are not what a keyboard user lands on, so handlers placed there never fire during real interaction and the field would stay untouched:
 
 ```svelte
-{@const { name, oninput, onchange, onfocus, onblur, ...fieldProps } =
-  field.props}
+<Field of={form} path={['framework']}>
+  {#snippet children(field)}
+    {@const { name, oninput, onchange, onfocus, onblur, ...fieldProps } =
+      field.props}
+    <!-- ... -->
+  {/snippet}
+</Field>
 ```
 
 The attachment stays on the hidden part, while `onfocus` and `onblur` move to `Select.Trigger` or `Slider.Thumb`. `focus` keeps working for the select, because Ark forwards focus from the hidden select to the visible trigger, and `autofocus` can stay in the spread there for the same reason. The slider is the exception: its hidden input carries the `hidden` attribute and cannot be focused at all, so pass `autofocus` to the thumb as well.
@@ -99,15 +104,19 @@ The attachment stays on the hidden part, while `onfocus` and `onblur` move to `S
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires the error reference for you, and the text only renders while the field is invalid:
 
 ```svelte
-<ArkField.Root
-  id="login-email"
-  ids={{ errorText: 'login-email-error' }}
-  invalid={!!field.errors}
->
-  <ArkField.Label>Email</ArkField.Label>
-  <ArkField.Input {...field.props} value={field.input} />
-  <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
-</ArkField.Root>
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <ArkField.Root
+      id="login-email"
+      ids={{ errorText: 'login-email-error' }}
+      invalid={!!field.errors}
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} value={field.input} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  {/snippet}
+</Field>
 ```
 
 Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. The select, checkbox and radio group derive `aria-invalid` from their root's `invalid` prop, but the slider does not, so set it on the thumb yourself.

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
@@ -1,0 +1,421 @@
+---
+title: Ark UI
+description: >-
+  Learn how to connect Formisch fields to Ark UI inputs, checkboxes, selects,
+  radio groups and sliders in Svelte.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Ark UI
+
+[Ark UI](https://ark-ui.com) is a headless component library built on state machines, available for Svelte among other frameworks. This guide targets Ark UI v5 for Svelte. No adapter package is needed, and Ark handles more of the accessibility wiring than most libraries: inside its `Field`, the label association, `aria-invalid` and the error message reference are derived for you.
+
+## Installation
+
+Install Formisch, Valibot and Ark UI:
+
+```bash
+npm install @formisch/svelte valibot @ark-ui/svelte
+```
+
+Ark UI ships unstyled, so every example below leaves styling to you.
+
+## Wiring patterns
+
+Choose the wiring from the part you are rendering:
+
+- If the part wraps a native `<input>`, `<textarea>` or `<select>`, spread `field.props` onto it.
+- If the component owns the value, pass `field.input` to the root and send the root's value callback to `field.onInput`, then distribute the remaining props across its parts.
+
+In Svelte, Formisch passes the element reference as an attachment under a symbol key, so it can only travel by spreading. There is no `ref` prop to place by hand, which makes the spread the backbone of every binding here. Ark merges symbol keys through all of its parts, so the reference reaches the element even through several component layers.
+
+### Spreading field.props
+
+`Field.Input` wraps a native input, so it takes the whole spread. Since Formisch and Ark UI both export a `Field`, the Ark one is imported as `ArkField`:
+
+```svelte
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <ArkField.Root id="login-email" invalid={!!field.errors}>
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} type="email" value={field.input} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  {/snippet}
+</Field>
+```
+
+Set the `id` on `ArkField.Root` rather than on the input. Ark derives the control id and the label's `for` from it, and the root requires an `id` anyway.
+
+Do not reach for `bind:value={field.input}` here. On an Ark part it passes `svelte-check` and even mounts cleanly, then throws on the first keystroke because `field.input` is a getter rather than a `$state` reference. Pass `value={field.input}` as above.
+
+### Controlled components
+
+A composite component owns its value, so the root takes the value and the change callback while the remaining props are split across its parts. Pull `name` out for the root, drop `oninput` and `onchange` so the value flows only through the component's own callback, and keep the focus handlers for the part the user actually interacts with:
+
+```svelte
+<Field of={loginForm} path={['rememberMe']}>
+  {#snippet children(field)}
+    {@const { name, oninput, onchange, ...fieldProps } = field.props}
+    <Checkbox.Root
+      ids={{ hiddenInput: 'login-remember-me' }}
+      {name}
+      checked={field.input ?? false}
+      onCheckedChange={(details) => field.onInput(details.checked === true)}
+      invalid={!!field.errors}
+    >
+      <Checkbox.HiddenInput {...fieldProps} />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Remember me</Checkbox.Label>
+    </Checkbox.Root>
+  {/snippet}
+</Field>
+```
+
+The checkbox and the radio group hide a real focusable input, so the whole rest object belongs on that hidden part, and <Link href="/methods/api/focus/">`focus`</Link> reaches it directly. The select and the slider are different, as the next section shows. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+
+Every Ark root also accepts an `ids` object, which is the supported way to give a hidden part a stable id.
+
+## Where the focus handlers belong
+
+For the select and the slider, put `onfocus` and `onblur` on the visible part rather than on the hidden one. Their hidden inputs are not what a keyboard user lands on, so handlers placed there never fire during real interaction and the field would stay untouched:
+
+```svelte
+{@const { name, oninput, onchange, onfocus, onblur, ...fieldProps } =
+  field.props}
+```
+
+The attachment and `autofocus` stay on the hidden part, while `onfocus` and `onblur` move to `Select.Trigger` or `Slider.Thumb`. `focus` keeps working for the select, because Ark forwards focus from the hidden select to the visible trigger.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires the error reference for you, and the text only renders while the field is invalid:
+
+```svelte
+<ArkField.Root
+  id="login-email"
+  ids={{ errorText: 'login-email-error' }}
+  invalid={!!field.errors}
+>
+  <ArkField.Label>Email</ArkField.Label>
+  <ArkField.Input {...field.props} value={field.input} />
+  <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+</ArkField.Root>
+```
+
+Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. The select, checkbox and radio group derive `aria-invalid` from their root's `invalid` prop, but the slider does not, so set it on the thumb yourself.
+
+Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/svelte/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines two text fields, a controlled checkbox and accessible errors:
+
+```svelte
+<script lang="ts">
+  import { Checkbox } from '@ark-ui/svelte/checkbox';
+  import { Field as ArkField } from '@ark-ui/svelte/field';
+  import {
+    createForm,
+    Field,
+    Form,
+    type SubmitHandler,
+  } from '@formisch/svelte';
+  import * as v from 'valibot';
+
+  const LoginSchema = v.object({
+    email: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your email.'),
+      v.email('The email address is badly formatted.')
+    ),
+    password: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your password.'),
+      v.minLength(8, 'Your password must have 8 characters or more.')
+    ),
+    rememberMe: v.optional(v.boolean(), false),
+  });
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    initialInput: { email: '', password: '', rememberMe: false },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+</script>
+
+<Form of={loginForm} onsubmit={handleSubmit}>
+  <Field of={loginForm} path={['email']}>
+    {#snippet children(field)}
+      <ArkField.Root
+        id="login-email"
+        ids={{ errorText: 'login-email-error' }}
+        invalid={!!field.errors}
+      >
+        <ArkField.Label>Email</ArkField.Label>
+        <ArkField.Input
+          {...field.props}
+          type="email"
+          autocomplete="email"
+          placeholder="jane@example.com"
+          value={field.input}
+        />
+        <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+      </ArkField.Root>
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['password']}>
+    {#snippet children(field)}
+      <ArkField.Root
+        id="login-password"
+        ids={{ errorText: 'login-password-error' }}
+        invalid={!!field.errors}
+      >
+        <ArkField.Label>Password</ArkField.Label>
+        <ArkField.Input
+          {...field.props}
+          type="password"
+          autocomplete="current-password"
+          value={field.input}
+        />
+        <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+      </ArkField.Root>
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['rememberMe']}>
+    {#snippet children(field)}
+      {@const { name, oninput, onchange, ...fieldProps } = field.props}
+      <Checkbox.Root
+        ids={{ hiddenInput: 'login-remember-me' }}
+        {name}
+        checked={field.input ?? false}
+        onCheckedChange={(details) => field.onInput(details.checked === true)}
+        invalid={!!field.errors}
+      >
+        <Checkbox.HiddenInput {...fieldProps} />
+        <Checkbox.Control>
+          <Checkbox.Indicator>✓</Checkbox.Indicator>
+        </Checkbox.Control>
+        <Checkbox.Label>Remember me</Checkbox.Label>
+      </Checkbox.Root>
+    {/snippet}
+  </Field>
+
+  <button type="submit" disabled={loginForm.isSubmitting}>Login</button>
+</Form>
+```
+
+The initial input keeps every control defined from its first render. The two text fields take the whole spread, while the checkbox splits it between the root and its hidden input.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+```svelte
+<Field of={form} path={['email']}>
+  {#snippet children(field)}
+    <ArkField.Root
+      id="profile-email"
+      ids={{ errorText: 'profile-email-error' }}
+      invalid={!!field.errors}
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input {...field.props} type="email" value={field.input} />
+      <ArkField.ErrorText>{field.errors?.[0]}</ArkField.ErrorText>
+    </ArkField.Root>
+  {/snippet}
+</Field>
+```
+
+Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the same wiring.
+
+### Checkbox
+
+```svelte
+<Field of={form} path={['newsletter']}>
+  {#snippet children(field)}
+    {@const { name, oninput, onchange, ...fieldProps } = field.props}
+    <Checkbox.Root
+      ids={{ hiddenInput: 'settings-newsletter' }}
+      {name}
+      checked={field.input ?? false}
+      onCheckedChange={(details) => field.onInput(details.checked === true)}
+      invalid={!!field.errors}
+    >
+      <Checkbox.HiddenInput {...fieldProps} />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Newsletter</Checkbox.Label>
+    </Checkbox.Root>
+  {/snippet}
+</Field>
+```
+
+### Select
+
+Ark's select is array based even for a single selection, so wrap the value and unwrap the payload, narrowing it to the schema union. The focus handlers go on the trigger, while the attachment stays on the hidden select:
+
+```ts
+const frameworkCollection = createListCollection({
+  items: [
+    { label: 'Angular', value: 'angular' },
+    { label: 'React', value: 'react' },
+    { label: 'Solid', value: 'solid' },
+    { label: 'Vue', value: 'vue' },
+  ],
+});
+```
+
+```svelte
+<Field of={form} path={['framework']}>
+  {#snippet children(field)}
+    {@const { name, oninput, onchange, onfocus, onblur, ...fieldProps } =
+      field.props}
+    <Select.Root
+      ids={{
+        trigger: 'project-framework',
+        hiddenSelect: 'project-framework-select',
+      }}
+      collection={frameworkCollection}
+      {name}
+      value={field.input ? [field.input] : []}
+      onValueChange={(details) =>
+        field.onInput(details.value[0] as 'angular' | 'vue')}
+      invalid={!!field.errors}
+    >
+      <Select.Label>Framework</Select.Label>
+      <Select.Control>
+        <Select.Trigger
+          {onfocus}
+          {onblur}
+          aria-errormessage="project-framework-error"
+        >
+          <Select.ValueText placeholder="Select a framework" />
+          <Select.Indicator>▾</Select.Indicator>
+        </Select.Trigger>
+      </Select.Control>
+      <Select.HiddenSelect {...fieldProps} />
+      {#if field.errors}
+        <span id="project-framework-error">{field.errors[0]}</span>
+      {/if}
+      <Portal>
+        <Select.Positioner>
+          <Select.Content>
+            {#each frameworkCollection.items as item (item.value)}
+              <Select.Item {item}>
+                <Select.ItemText>{item.label}</Select.ItemText>
+              </Select.Item>
+            {/each}
+          </Select.Content>
+        </Select.Positioner>
+      </Portal>
+    </Select.Root>
+  {/snippet}
+</Field>
+```
+
+### Radio group
+
+Spread the rest object onto every item's hidden input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autofocus` on the first item only, otherwise every radio competes for focus. The root's `invalid` prop already marks each item, so no per-item `aria-invalid` is needed:
+
+```svelte
+<Field of={form} path={['plan']}>
+  {#snippet children(field)}
+    {@const { name, oninput, onchange, ...fieldProps } = field.props}
+    <RadioGroup.Root
+      ids={{ itemHiddenInput: (value) => `plan-${value}` }}
+      {name}
+      value={field.input ?? null}
+      onValueChange={(details) => field.onInput(details.value as 'hobby' | 'pro')}
+      invalid={!!field.errors}
+      aria-errormessage="plan-error"
+    >
+      <RadioGroup.Label>Plan</RadioGroup.Label>
+      {#each plans as plan, index (plan.value)}
+        <RadioGroup.Item value={plan.value}>
+          <RadioGroup.ItemHiddenInput
+            {...fieldProps}
+            autofocus={index === 0 && fieldProps.autofocus}
+          />
+          <RadioGroup.ItemControl />
+          <RadioGroup.ItemText>{plan.label}</RadioGroup.ItemText>
+        </RadioGroup.Item>
+      {/each}
+      {#if field.errors}
+        <span id="plan-error">{field.errors[0]}</span>
+      {/if}
+    </RadioGroup.Root>
+  {/snippet}
+</Field>
+```
+
+### Slider
+
+Ark's slider is array based like its select, and it uses `min` and `max` rather than `minValue` and `maxValue`. One `Slider.Thumb` renders exactly one thumb, and since Ark does not derive `aria-invalid` here, set it on the thumb along with the focus handlers:
+
+```svelte
+<Field of={form} path={['volume']}>
+  {#snippet children(field)}
+    {@const { name, oninput, onchange, onfocus, onblur, ...fieldProps } =
+      field.props}
+    <Slider.Root
+      ids={{ thumb: () => 'settings-volume-thumb' }}
+      {name}
+      min={0}
+      max={100}
+      value={[field.input ?? 50]}
+      onValueChange={(details) => field.onInput(details.value[0])}
+      invalid={!!field.errors}
+    >
+      <Slider.Label>Volume</Slider.Label>
+      <Slider.ValueText />
+      <Slider.Control>
+        <Slider.Track>
+          <Slider.Range />
+        </Slider.Track>
+        <Slider.Thumb
+          index={0}
+          {onfocus}
+          {onblur}
+          aria-invalid={!!field.errors}
+          aria-errormessage="settings-volume-error"
+        >
+          <Slider.HiddenInput {...fieldProps} />
+        </Slider.Thumb>
+      </Slider.Control>
+      {#if field.errors}
+        <span id="settings-volume-error">{field.errors[0]}</span>
+      {/if}
+    </Slider.Root>
+  {/snippet}
+</Field>
+```
+
+`Slider.HiddenInput` renders with the `hidden` attribute, which makes it unfocusable, so `focus` cannot move focus to this field. Keyboard users still reach the thumb normally, and validation, `isTouched` and blur validation are unaffected.
+
+## Library-specific notes
+
+Spreading the rest object onto a part that is not a native form element, such as `Select.Trigger` or `Slider.Thumb`, fails `svelte-check`, because `oninput` and `onchange` are typed against Formisch's field elements. Destructuring them out, as every snippet above does, is the fix and is also semantically right: those handlers read a value from the event target, which only a native form element has.
+
+`field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
+
+Ark UI is also available for other frameworks. The part names and the `ids` and `invalid` props are identical there, so this wiring ports with only the framework API changing. See our <Link href="/react/guides/ark-ui/">React</Link>, <Link href="/solid/guides/ark-ui/">Solid</Link> and <Link href="/vue/guides/ark-ui/">Vue</Link> guides.
+
+## Next steps
+
+Read the <Link href="/svelte/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/svelte/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
@@ -81,6 +81,8 @@ The checkbox and the radio group hide a real focusable input, so the whole rest 
 
 Every Ark root also accepts an `ids` object, which is the supported way to give a hidden part a stable id.
 
+The setter runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit. Use `validate: 'input'` if you want them validated as the value changes.
+
 ## Where the focus handlers belong
 
 For the select and the slider, put `onfocus` and `onblur` on the visible part rather than on the hidden one. Their hidden inputs are not what a keyboard user lands on, so handlers placed there never fire during real interaction and the field would stay untouched:
@@ -90,7 +92,7 @@ For the select and the slider, put `onfocus` and `onblur` on the visible part ra
   field.props}
 ```
 
-The attachment and `autofocus` stay on the hidden part, while `onfocus` and `onblur` move to `Select.Trigger` or `Slider.Thumb`. `focus` keeps working for the select, because Ark forwards focus from the hidden select to the visible trigger.
+The attachment stays on the hidden part, while `onfocus` and `onblur` move to `Select.Trigger` or `Slider.Thumb`. `focus` keeps working for the select, because Ark forwards focus from the hidden select to the visible trigger, and `autofocus` can stay in the spread there for the same reason. The slider is the exception: its hidden input carries the `hidden` attribute and cannot be focused at all, so pass `autofocus` to the thumb as well.
 
 ## Displaying errors
 

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
@@ -392,6 +392,7 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
           index={0}
           {onfocus}
           {onblur}
+          autofocus={fieldProps.autofocus}
           aria-invalid={!!field.errors}
           aria-errormessage="settings-volume-error"
         >

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/ark-ui/index.mdx
@@ -295,7 +295,7 @@ const frameworkCollection = createListCollection({
       {name}
       value={field.input ? [field.input] : []}
       onValueChange={(details) =>
-        field.onInput(details.value[0] as 'angular' | 'vue')}
+        field.onInput(details.value[0] as typeof field.input)}
       invalid={!!field.errors}
     >
       <Select.Label>Framework</Select.Label>

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
@@ -1,0 +1,375 @@
+---
+title: Bits UI
+description: >-
+  Learn how to connect Formisch fields to Bits UI checkboxes, selects, radio
+  groups, sliders and other form primitives.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Bits UI
+
+[Bits UI](https://bits-ui.com) is a collection of headless, accessible primitives for Svelte 5. This guide targets Bits UI v2. No adapter package is needed: native elements take the whole `field.props` spread, while a primitive built on a button or span receives the value plus the lifecycle props it can forward.
+
+## Installation
+
+Install Formisch, Valibot and Bits UI:
+
+```bash
+npm install @formisch/svelte valibot bits-ui
+```
+
+Bits UI ships primitives only, so text inputs, textareas and buttons stay native elements that you style yourself.
+
+## Wiring patterns
+
+Choose the wiring from the element the primitive renders:
+
+- If it is a native `<input>`, `<textarea>` or `<select>`, spread `field.props` and pass `field.input` as the value.
+- If it renders a button or span, pass `field.input` as the value, forward the remaining props, and send the primitive's value callback to `field.onInput`.
+
+### Spreading field.props
+
+An `<input>` accepts every entry of `field.props`, including the element reference, which Formisch passes as a Svelte attachment:
+
+```svelte
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <input {...field.props} id="login-email" type="email" value={field.input} />
+  {/snippet}
+</Field>
+```
+
+Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte-check`, then throws at runtime because `field.input` is a getter rather than a `$state` reference, and the input silently drifts out of sync with the form. Use `value={field.input}` as above, or a function binding if you prefer that shape:
+
+```svelte
+<input
+  {...field.props}
+  bind:value={() => field.input ?? '', (value) => field.onInput(value)}
+/>
+```
+
+### Controlled components
+
+`Checkbox.Root` renders a button, so drop `oninput` and `onchange` from the spread and let the primitive report its value instead. Those two handlers read the value from the event target, which only exists on a native form element, and `svelte-check` rejects them on a button for the same reason:
+
+```svelte
+<Field of={loginForm} path={['rememberMe']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <Checkbox.Root
+      {...fieldProps}
+      id="login-remember"
+      aria-labelledby="login-remember-label"
+      checked={field.input ?? false}
+      onCheckedChange={(checked) => field.onInput(checked)}
+    >
+      {#snippet children({ checked })}
+        <span aria-hidden="true">{checked ? '✔' : ''}</span>
+      {/snippet}
+    </Checkbox.Root>
+    <label id="login-remember-label" for="login-remember">Remember me</label>
+  {/snippet}
+</Field>
+```
+
+The rest of the spread still carries its weight: the attachment reaches the visible button through Bits UI's prop merging, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Bits UI has no error primitive, so render the message yourself, give it a stable id and point the control at it while errors exist:
+
+```svelte
+<input
+  {...field.props}
+  id="login-email"
+  value={field.input}
+  aria-invalid={!!field.errors}
+  aria-errormessage="login-email-error"
+/>
+{#if field.errors}
+  <div id="login-email-error">{field.errors[0]}</div>
+{/if}
+```
+
+Use page-unique ids rather than the field name. `field.props.name` is the JSON encoded path, such as `["email"]`, which is meant for form submission and not for `for` and `id` attributes.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/svelte/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs, a controlled checkbox and accessible errors:
+
+```svelte
+<script lang="ts">
+  import {
+    createForm,
+    Field,
+    Form,
+    type SubmitHandler,
+  } from '@formisch/svelte';
+  import { Checkbox } from 'bits-ui';
+  import * as v from 'valibot';
+
+  const LoginSchema = v.object({
+    email: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your email.'),
+      v.email('The email address is badly formatted.')
+    ),
+    password: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your password.'),
+      v.minLength(8, 'Your password must have 8 characters or more.')
+    ),
+    rememberMe: v.optional(v.boolean(), false),
+  });
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    initialInput: { email: '', password: '', rememberMe: false },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+</script>
+
+<Form of={loginForm} onsubmit={handleSubmit}>
+  <Field of={loginForm} path={['email']}>
+    {#snippet children(field)}
+      <div>
+        <label for="login-email">Email</label>
+        <input
+          {...field.props}
+          id="login-email"
+          type="email"
+          value={field.input}
+          aria-invalid={!!field.errors}
+          aria-errormessage="login-email-error"
+        />
+        {#if field.errors}
+          <div id="login-email-error">{field.errors[0]}</div>
+        {/if}
+      </div>
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['password']}>
+    {#snippet children(field)}
+      <div>
+        <label for="login-password">Password</label>
+        <input
+          {...field.props}
+          id="login-password"
+          type="password"
+          value={field.input}
+          aria-invalid={!!field.errors}
+          aria-errormessage="login-password-error"
+        />
+        {#if field.errors}
+          <div id="login-password-error">{field.errors[0]}</div>
+        {/if}
+      </div>
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['rememberMe']}>
+    {#snippet children(field)}
+      {@const { oninput, onchange, ...fieldProps } = field.props}
+      <div>
+        <Checkbox.Root
+          {...fieldProps}
+          id="login-remember"
+          aria-labelledby="login-remember-label"
+          checked={field.input ?? false}
+          onCheckedChange={(checked) => field.onInput(checked)}
+        >
+          {#snippet children({ checked })}
+            <span aria-hidden="true">{checked ? '✔' : ''}</span>
+          {/snippet}
+        </Checkbox.Root>
+        <label id="login-remember-label" for="login-remember">
+          Remember me
+        </label>
+      </div>
+    {/snippet}
+  </Field>
+
+  <button type="submit" disabled={loginForm.isSubmitting}>Login</button>
+</Form>
+```
+
+The initial input keeps every control defined from its first render. The two text inputs use the full spread, while the checkbox maps Bits UI's value callback and forwards the remaining props.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+Native elements take the whole spread:
+
+```svelte
+<Field of={form} path={['email']}>
+  {#snippet children(field)}
+    <label for="profile-email">Email</label>
+    <input
+      {...field.props}
+      id="profile-email"
+      type="email"
+      value={field.input}
+      aria-invalid={!!field.errors}
+      aria-errormessage="profile-email-error"
+    />
+    {#if field.errors}
+      <div id="profile-email-error">{field.errors[0]}</div>
+    {/if}
+  {/snippet}
+</Field>
+```
+
+A `<textarea>` works the same way.
+
+### Checkbox
+
+Since `Checkbox.Root` renders a button, name it with `aria-labelledby` in addition to the label's `for` attribute. A button is labelable, but not every browser derives its accessible name from a `<label>`:
+
+```svelte
+<Field of={form} path={['newsletter']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <Checkbox.Root
+      {...fieldProps}
+      id="settings-newsletter"
+      aria-labelledby="settings-newsletter-label"
+      checked={field.input ?? false}
+      onCheckedChange={(checked) => field.onInput(checked)}
+    >
+      {#snippet children({ checked })}
+        <span aria-hidden="true">{checked ? '✔' : ''}</span>
+      {/snippet}
+    </Checkbox.Root>
+    <label id="settings-newsletter-label" for="settings-newsletter">
+      Newsletter
+    </label>
+  {/snippet}
+</Field>
+```
+
+Bits UI declares `name` as its own prop and renders a hidden native checkbox with it, so the button itself carries no `name` attribute.
+
+### Select
+
+Use `type="single"` so the value is a plain string, and normalize the empty value in both directions, since `onValueChange` hands you a bare `string` while an unselected Formisch field is `undefined`:
+
+```svelte
+<Field of={form} path={['framework']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <span id="project-framework-label">Framework</span>
+    <Select.Root
+      type="single"
+      value={field.input ?? ''}
+      onValueChange={(value) => field.onInput(value as 'angular' | 'react')}
+    >
+      <Select.Trigger
+        {...fieldProps}
+        id="project-framework"
+        aria-labelledby="project-framework-label"
+        aria-invalid={!!field.errors}
+      >
+        {frameworks.find((item) => item.value === field.input)?.label ??
+          'Select a framework'}
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content>
+          {#each frameworks as framework (framework.value)}
+            <Select.Item value={framework.value} label={framework.label}>
+              {framework.label}
+            </Select.Item>
+          {/each}
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  {/snippet}
+</Field>
+```
+
+The trigger is a button without a `combobox` role, so name it with `aria-labelledby` rather than a `<label>` element.
+
+### Radio group
+
+Spread the remaining props onto every item. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group, and the first one becomes the focus target:
+
+```svelte
+<Field of={form} path={['plan']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <span id="plan-label">Plan</span>
+    <RadioGroup.Root
+      aria-labelledby="plan-label"
+      aria-invalid={!!field.errors}
+      value={field.input ?? 'hobby'}
+      onValueChange={(value) => field.onInput(value as 'hobby' | 'pro')}
+    >
+      {#each plans as plan (plan.value)}
+        <RadioGroup.Item
+          {...fieldProps}
+          id="plan-{plan.value}"
+          value={plan.value}
+          aria-labelledby="plan-{plan.value}-label"
+        >
+          {#snippet children({ checked })}
+            <span aria-hidden="true">{checked ? '●' : ''}</span>
+          {/snippet}
+        </RadioGroup.Item>
+        <label id="plan-{plan.value}-label" for="plan-{plan.value}">
+          {plan.label}
+        </label>
+      {/each}
+    </RadioGroup.Root>
+  {/snippet}
+</Field>
+```
+
+### Slider
+
+`type="single"` keeps the value a number and renders exactly one thumb. The thumb carries the `slider` role, so the remaining props and the accessible name belong there rather than on the root:
+
+```svelte
+<Field of={form} path={['volume']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <Slider.Root
+      type="single"
+      min={0}
+      max={100}
+      step={1}
+      value={field.input ?? 50}
+      onValueChange={(value) => field.onInput(value)}
+    >
+      {#snippet children()}
+        <Slider.Range />
+        <Slider.Thumb
+          {...fieldProps}
+          index={0}
+          id="settings-volume"
+          aria-label="Volume"
+          aria-invalid={!!field.errors}
+        />
+      {/snippet}
+    </Slider.Root>
+  {/snippet}
+</Field>
+```
+
+## Library-specific notes
+
+`field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.
+
+## Next steps
+
+Read the <Link href="/svelte/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/svelte/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
@@ -45,10 +45,14 @@ An `<input>` accepts every entry of `field.props`, including the element referen
 Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte-check`, then throws at runtime because `field.input` is a getter rather than a `$state` reference, and the input silently drifts out of sync with the form. Use `value={field.input}` as above, or a function binding if you prefer that shape:
 
 ```svelte
-<input
-  {...field.props}
-  bind:value={() => field.input ?? '', (value) => field.onInput(value)}
-/>
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <input
+      {...field.props}
+      bind:value={() => field.input ?? '', (value) => field.onInput(value)}
+    />
+  {/snippet}
+</Field>
 ```
 
 ### Controlled components
@@ -84,16 +88,20 @@ Dropping `onchange` also means change-mode validation never fires for this contr
 Formisch exposes errors as `[string, ...string[]] | null`. Bits UI has no error primitive, so render the message yourself, give it a stable id and point the control at it while errors exist:
 
 ```svelte
-<input
-  {...field.props}
-  id="login-email"
-  value={field.input}
-  aria-invalid={!!field.errors}
-  aria-errormessage="login-email-error"
-/>
-{#if field.errors}
-  <div id="login-email-error">{field.errors[0]}</div>
-{/if}
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <input
+      {...field.props}
+      id="login-email"
+      value={field.input}
+      aria-invalid={!!field.errors}
+      aria-errormessage="login-email-error"
+    />
+    {#if field.errors}
+      <div id="login-email-error">{field.errors[0]}</div>
+    {/if}
+  {/snippet}
+</Field>
 ```
 
 Use page-unique ids rather than the field name. `field.props.name` is the JSON encoded path, such as `["email"]`, which is meant for form submission and not for `for` and `id` attributes.

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
@@ -77,7 +77,7 @@ Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte
 
 The rest of the spread still carries its weight: the attachment reaches the visible button through Bits UI's prop merging, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working.
 
-Dropping `onchange` also means change-mode validation never fires for this control, since `field.onInput` only runs the input mode. If you set `validate: 'change'`, call `field.props.onchange(new Event('change'))` inside the value callback, which ignores its argument. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+Dropping `onchange` also means change-mode validation never fires for this control, since `field.onInput` runs the input mode only. Use `validate: 'input'` if you want these controls validated as the value changes. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
 
 ## Displaying errors
 

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
@@ -75,7 +75,9 @@ Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte
 </Field>
 ```
 
-The rest of the spread still carries its weight: the attachment reaches the visible button through Bits UI's prop merging, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+The rest of the spread still carries its weight: the attachment reaches the visible button through Bits UI's prop merging, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working.
+
+Dropping `onchange` also means change-mode validation never fires for this control, since `field.onInput` only runs the input mode. If you set `validate: 'change'`, call `field.props.onchange(new Event('change'))` inside the value callback, which ignores its argument. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
 
 ## Displaying errors
 
@@ -263,7 +265,21 @@ Bits UI declares `name` as its own prop and renders a hidden native checkbox wit
 
 ### Select
 
-Use `type="single"` so the value is a plain string, and normalize the empty value in both directions, since `onValueChange` hands you a bare `string` while an unselected Formisch field is `undefined`:
+Use `type="single"` so the value is a plain string, and normalize the empty value in both directions, since `onValueChange` hands you a bare `string` while an unselected Formisch field is `undefined`. The snippets below share these option lists:
+
+```ts
+const frameworks = [
+  { value: 'angular', label: 'Angular' },
+  { value: 'react', label: 'React' },
+  { value: 'solid', label: 'Solid' },
+  { value: 'vue', label: 'Vue' },
+];
+
+const plans = [
+  { value: 'hobby', label: 'Hobby' },
+  { value: 'pro', label: 'Pro' },
+];
+```
 
 ```svelte
 <Field of={form} path={['framework']}>

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/bits-ui/index.mdx
@@ -289,7 +289,7 @@ const plans = [
     <Select.Root
       type="single"
       value={field.input ?? ''}
-      onValueChange={(value) => field.onInput(value as 'angular' | 'react')}
+      onValueChange={(value) => field.onInput(value as typeof field.input)}
     >
       <Select.Trigger
         {...fieldProps}

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
@@ -73,7 +73,9 @@ Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte
 </Field>
 ```
 
-The rest of the spread still carries its weight: the attachment survives both component hops and reaches the visible button, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+The rest of the spread still carries its weight: the attachment survives both component hops and reaches the visible button, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working.
+
+Dropping `onchange` also means change-mode validation never fires for this control, since `field.onInput` only runs the input mode. If you set `validate: 'change'`, call `field.props.onchange(new Event('change'))` inside the value callback, which ignores its argument. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
 
 ## Displaying errors
 
@@ -261,7 +263,21 @@ Name the checkbox with `aria-labelledby` in addition to the label's `for` attrib
 
 ### Select
 
-Use `type="single"` so the value is a plain string, and normalize the empty value in both directions, since `onValueChange` hands you a bare `string` while an unselected Formisch field is `undefined`. The trigger renders the current label itself:
+Use `type="single"` so the value is a plain string, and normalize the empty value in both directions, since `onValueChange` hands you a bare `string` while an unselected Formisch field is `undefined`. The trigger renders the current label itself. The snippets below share these option lists:
+
+```ts
+const frameworks = [
+  { value: 'angular', label: 'Angular' },
+  { value: 'react', label: 'React' },
+  { value: 'solid', label: 'Solid' },
+  { value: 'vue', label: 'Vue' },
+];
+
+const plans = [
+  { value: 'hobby', label: 'Hobby' },
+  { value: 'pro', label: 'Pro' },
+];
+```
 
 ```svelte
 <Field of={form} path={['framework']}>
@@ -289,6 +305,11 @@ Use `type="single"` so the value is a plain string, and normalize the empty valu
         {/each}
       </Select.Content>
     </Select.Root>
+    {#if field.errors}
+      <p id="project-framework-error" class="text-destructive text-sm">
+        {field.errors[0]}
+      </p>
+    {/if}
   {/snippet}
 </Field>
 ```

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
@@ -47,10 +47,14 @@ Choose the wiring from the element the generated component renders:
 Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte-check`, then throws at runtime because `field.input` is a getter rather than a `$state` reference, and the input silently drifts out of sync with the form. Use `value={field.input}` as above, or a function binding if you prefer that shape:
 
 ```svelte
-<Input
-  {...field.props}
-  bind:value={() => field.input ?? '', (value) => field.onInput(value)}
-/>
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <Input
+      {...field.props}
+      bind:value={() => field.input ?? '', (value) => field.onInput(value)}
+    />
+  {/snippet}
+</Field>
 ```
 
 ### Controlled components
@@ -82,18 +86,22 @@ Dropping `onchange` also means change-mode validation never fires for this contr
 Formisch exposes errors as `[string, ...string[]] | null`. The generated components have no error part, so render the message yourself, give it a stable id and point the control at it while errors exist:
 
 ```svelte
-<Input
-  {...field.props}
-  id="login-email"
-  value={field.input}
-  aria-invalid={!!field.errors}
-  aria-errormessage="login-email-error"
-/>
-{#if field.errors}
-  <p id="login-email-error" class="text-sm text-destructive">
-    {field.errors[0]}
-  </p>
-{/if}
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <Input
+      {...field.props}
+      id="login-email"
+      value={field.input}
+      aria-invalid={!!field.errors}
+      aria-errormessage="login-email-error"
+    />
+    {#if field.errors}
+      <p id="login-email-error" class="text-sm text-destructive">
+        {field.errors[0]}
+      </p>
+    {/if}
+  {/snippet}
+</Field>
 ```
 
 `aria-invalid` also switches the generated components to their destructive styling. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
@@ -75,7 +75,7 @@ Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte
 
 The rest of the spread still carries its weight: the attachment survives both component hops and reaches the visible button, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working.
 
-Dropping `onchange` also means change-mode validation never fires for this control, since `field.onInput` only runs the input mode. If you set `validate: 'change'`, call `field.props.onchange(new Event('change'))` inside the value callback, which ignores its argument. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+Dropping `onchange` also means change-mode validation never fires for this control, since `field.onInput` runs the input mode only. Use `validate: 'input'` if you want these controls validated as the value changes. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
 
 ## Displaying errors
 

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
@@ -287,7 +287,7 @@ const plans = [
     <Select.Root
       type="single"
       value={field.input ?? ''}
-      onValueChange={(value) => field.onInput(value as 'angular' | 'react')}
+      onValueChange={(value) => field.onInput(value as typeof field.input)}
     >
       <Select.Trigger
         {...fieldProps}

--- a/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(integration-guides)/shadcn-svelte/index.mdx
@@ -1,0 +1,394 @@
+---
+title: shadcn-svelte
+description: >-
+  Learn how to connect Formisch fields to shadcn-svelte inputs, selects, radio
+  groups, sliders and other form components.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# shadcn-svelte
+
+[shadcn-svelte](https://shadcn-svelte.com) generates accessible components into your own project, where you can adapt them to your needs. This guide targets shadcn-svelte v1 with its Bits UI v2 based components. No adapter package is needed: components that render a native element take the whole `field.props` spread, while the button based primitives receive the value plus the lifecycle props they forward.
+
+## Installation
+
+Install Formisch and Valibot, set up Tailwind CSS, then initialize shadcn-svelte and add the components used below:
+
+```bash
+npm install @formisch/svelte valibot
+npx shadcn-svelte@latest init
+npx shadcn-svelte@latest add button input label textarea checkbox select radio-group slider
+```
+
+The `init` command asks for a design system preset interactively, so run it in a terminal rather than a script. It also expects the `$lib` alias to exist. In a Vite project, add `resolve.alias` for `$lib` in `vite.config.ts` and a matching `paths` entry in `tsconfig.json`.
+
+## Wiring patterns
+
+Choose the wiring from the element the generated component renders:
+
+- If it forwards its props to a native `<input>` or `<textarea>`, spread `field.props` and pass `field.input` as the value.
+- If it wraps a Bits UI primitive built on a button or span, pass `field.input` as the value, forward the remaining props, and send the component's value callback to `field.onInput`.
+
+### Spreading field.props
+
+`Input` and `Textarea` render native elements and accept every entry of `field.props`, including the element reference that Formisch passes as a Svelte attachment:
+
+```svelte
+<Field of={loginForm} path={['email']}>
+  {#snippet children(field)}
+    <Input {...field.props} id="login-email" type="email" value={field.input} />
+  {/snippet}
+</Field>
+```
+
+Do not reach for `bind:value={field.input}` here. It compiles and passes `svelte-check`, then throws at runtime because `field.input` is a getter rather than a `$state` reference, and the input silently drifts out of sync with the form. Use `value={field.input}` as above, or a function binding if you prefer that shape:
+
+```svelte
+<Input
+  {...field.props}
+  bind:value={() => field.input ?? '', (value) => field.onInput(value)}
+/>
+```
+
+### Controlled components
+
+`Checkbox`, `Select`, `RadioGroup` and `Slider` are built on Bits UI primitives that render a button or span. Drop `oninput` and `onchange` from the spread and let the component report its value instead. Those two handlers read the value from the event target, which only exists on a native form element, and `svelte-check` rejects them on a button for the same reason:
+
+```svelte
+<Field of={loginForm} path={['rememberMe']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <Checkbox
+      {...fieldProps}
+      id="login-remember"
+      aria-labelledby="login-remember-label"
+      checked={field.input ?? false}
+      onCheckedChange={(checked) => field.onInput(checked)}
+    />
+    <Label id="login-remember-label" for="login-remember">Remember me</Label>
+  {/snippet}
+</Field>
+```
+
+The rest of the spread still carries its weight: the attachment survives both component hops and reaches the visible button, so <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing land on the control the user sees, and `onfocus` and `onblur` keep `isTouched` and blur validation working. `{@const}` has to be the first thing inside the snippet, before the surrounding markup.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. The generated components have no error part, so render the message yourself, give it a stable id and point the control at it while errors exist:
+
+```svelte
+<Input
+  {...field.props}
+  id="login-email"
+  value={field.input}
+  aria-invalid={!!field.errors}
+  aria-errormessage="login-email-error"
+/>
+{#if field.errors}
+  <p id="login-email-error" class="text-sm text-destructive">
+    {field.errors[0]}
+  </p>
+{/if}
+```
+
+`aria-invalid` also switches the generated components to their destructive styling. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/svelte/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs, a controlled checkbox and accessible errors:
+
+```svelte
+<script lang="ts">
+  import {
+    createForm,
+    Field,
+    Form,
+    type SubmitHandler,
+  } from '@formisch/svelte';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+  import { Input } from '$lib/components/ui/input/index.js';
+  import { Label } from '$lib/components/ui/label/index.js';
+  import * as v from 'valibot';
+
+  const LoginSchema = v.object({
+    email: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your email.'),
+      v.email('The email address is badly formatted.')
+    ),
+    password: v.pipe(
+      v.string(),
+      v.nonEmpty('Please enter your password.'),
+      v.minLength(8, 'Your password must have 8 characters or more.')
+    ),
+    rememberMe: v.optional(v.boolean(), false),
+  });
+
+  const loginForm = createForm({
+    schema: LoginSchema,
+    initialInput: { email: '', password: '', rememberMe: false },
+  });
+
+  const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+    console.log(output);
+  };
+</script>
+
+<Form of={loginForm} onsubmit={handleSubmit} class="flex flex-col gap-4">
+  <Field of={loginForm} path={['email']}>
+    {#snippet children(field)}
+      <div class="flex flex-col gap-2">
+        <Label for="login-email">Email</Label>
+        <Input
+          {...field.props}
+          id="login-email"
+          type="email"
+          value={field.input}
+          aria-invalid={!!field.errors}
+          aria-errormessage="login-email-error"
+        />
+        {#if field.errors}
+          <p id="login-email-error" class="text-sm text-destructive">
+            {field.errors[0]}
+          </p>
+        {/if}
+      </div>
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['password']}>
+    {#snippet children(field)}
+      <div class="flex flex-col gap-2">
+        <Label for="login-password">Password</Label>
+        <Input
+          {...field.props}
+          id="login-password"
+          type="password"
+          value={field.input}
+          aria-invalid={!!field.errors}
+          aria-errormessage="login-password-error"
+        />
+        {#if field.errors}
+          <p id="login-password-error" class="text-sm text-destructive">
+            {field.errors[0]}
+          </p>
+        {/if}
+      </div>
+    {/snippet}
+  </Field>
+
+  <Field of={loginForm} path={['rememberMe']}>
+    {#snippet children(field)}
+      {@const { oninput, onchange, ...fieldProps } = field.props}
+      <div class="flex items-center gap-2">
+        <Checkbox
+          {...fieldProps}
+          id="login-remember"
+          aria-labelledby="login-remember-label"
+          checked={field.input ?? false}
+          onCheckedChange={(checked) => field.onInput(checked)}
+        />
+        <Label id="login-remember-label" for="login-remember">Remember me</Label
+        >
+      </div>
+    {/snippet}
+  </Field>
+
+  <Button type="submit" disabled={loginForm.isSubmitting}>Login</Button>
+</Form>
+```
+
+The initial input keeps every control defined from its first render. The two inputs use the full spread, while the checkbox maps the value callback and forwards the remaining props.
+
+## Component reference
+
+The following snippets assume a form store named `form` and initialized values that match the schema.
+
+### Text input
+
+`Input` forwards to a native `<input>`, so spread `field.props` directly:
+
+```svelte
+<Field of={form} path={['email']}>
+  {#snippet children(field)}
+    <Label for="profile-email">Email</Label>
+    <Input
+      {...field.props}
+      id="profile-email"
+      type="email"
+      value={field.input}
+      aria-invalid={!!field.errors}
+      aria-errormessage="profile-email-error"
+    />
+    {#if field.errors}
+      <p id="profile-email-error" class="text-sm text-destructive">
+        {field.errors[0]}
+      </p>
+    {/if}
+  {/snippet}
+</Field>
+```
+
+`Textarea` works the same way because it also renders a native element.
+
+### Checkbox
+
+Name the checkbox with `aria-labelledby` in addition to the label's `for` attribute. The component renders a button, and not every browser derives a button's accessible name from a `<label>`:
+
+```svelte
+<Field of={form} path={['newsletter']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <Checkbox
+      {...fieldProps}
+      id="settings-newsletter"
+      aria-labelledby="settings-newsletter-label"
+      checked={field.input ?? false}
+      onCheckedChange={(checked) => field.onInput(checked)}
+    />
+    <Label id="settings-newsletter-label" for="settings-newsletter">
+      Newsletter
+    </Label>
+  {/snippet}
+</Field>
+```
+
+### Select
+
+Use `type="single"` so the value is a plain string, and normalize the empty value in both directions, since `onValueChange` hands you a bare `string` while an unselected Formisch field is `undefined`. The trigger renders the current label itself:
+
+```svelte
+<Field of={form} path={['framework']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <Label id="project-framework-label" for="project-framework">Framework</Label>
+    <Select.Root
+      type="single"
+      value={field.input ?? ''}
+      onValueChange={(value) => field.onInput(value as 'angular' | 'react')}
+    >
+      <Select.Trigger
+        {...fieldProps}
+        id="project-framework"
+        aria-labelledby="project-framework-label"
+        aria-invalid={!!field.errors}
+        aria-errormessage="project-framework-error"
+      >
+        {frameworks.find((item) => item.value === field.input)?.label ??
+          'Select a framework'}
+      </Select.Trigger>
+      <Select.Content>
+        {#each frameworks as framework (framework.value)}
+          <Select.Item value={framework.value} label={framework.label} />
+        {/each}
+      </Select.Content>
+    </Select.Root>
+  {/snippet}
+</Field>
+```
+
+### Radio group
+
+Spread the remaining props onto every item. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group, and the first one becomes the focus target:
+
+```svelte
+<Field of={form} path={['plan']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <span id="plan-label" class="text-sm font-medium">Plan</span>
+    <RadioGroup.Root
+      aria-labelledby="plan-label"
+      aria-invalid={!!field.errors}
+      value={field.input ?? 'hobby'}
+      onValueChange={(value) => field.onInput(value as 'hobby' | 'pro')}
+    >
+      {#each plans as plan (plan.value)}
+        <div class="flex items-center gap-2">
+          <RadioGroup.Item
+            {...fieldProps}
+            id="plan-{plan.value}"
+            value={plan.value}
+            aria-labelledby="plan-{plan.value}-label"
+          />
+          <Label id="plan-{plan.value}-label" for="plan-{plan.value}">
+            {plan.label}
+          </Label>
+        </div>
+      {/each}
+    </RadioGroup.Root>
+  {/snippet}
+</Field>
+```
+
+### Slider
+
+`type="single"` keeps the value a number and renders exactly one thumb. The generated `Slider` passes its remaining props to the root element, while the `slider` role and the accessible name belong on the thumb, so add a `thumbProps` prop to the generated component and forward it:
+
+```svelte
+<Field of={form} path={['volume']}>
+  {#snippet children(field)}
+    {@const { oninput, onchange, ...fieldProps } = field.props}
+    <span id="settings-volume-label" class="text-sm font-medium">Volume</span>
+    <Slider
+      type="single"
+      min={0}
+      max={100}
+      step={1}
+      value={field.input ?? 50}
+      onValueChange={(value) => field.onInput(value)}
+      thumbProps={{
+        ...fieldProps,
+        id: 'settings-volume',
+        'aria-label': 'Volume',
+        'aria-invalid': !!field.errors,
+      }}
+    />
+  {/snippet}
+</Field>
+```
+
+Since the generated components live in your project, add that prop to `src/lib/components/ui/slider/slider.svelte`:
+
+```svelte
+<script lang="ts">
+  let {
+    ref = $bindable(null),
+    value = $bindable(),
+    orientation = 'horizontal',
+    class: className,
+    thumbProps,
+    ...restProps
+  }: WithoutChildrenOrChild<SliderPrimitive.RootProps> & {
+    thumbProps?: Omit<
+      WithoutChildrenOrChild<SliderPrimitive.ThumbProps>,
+      'index'
+    >;
+  } = $props();
+</script>
+```
+
+Then spread it onto the thumb inside the same file:
+
+```svelte
+<SliderPrimitive.Thumb
+  data-slot="slider-thumb"
+  index={thumb.index}
+  {...thumbProps}
+/>
+```
+
+## Library-specific notes
+
+`field.props.autofocus` is a snapshot taken when the field is created, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own, so you rarely need to read it directly.
+
+Because shadcn-svelte builds on Bits UI, the wiring in our <Link href="/svelte/guides/bits-ui/">Bits UI guide</Link> applies to the primitives underneath. The difference is that you own the generated source, so a missing prop can be forwarded rather than worked around.
+
+## Next steps
+
+Read the <Link href="/svelte/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/svelte/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/svelte/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(main-concepts)/input-components/index.mdx
@@ -194,6 +194,7 @@ The `field.onInput` method updates the field value and triggers validation. For 
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/svelte/guides/shadcn-svelte/">shadcn-svelte</Link>
+- <Link href="/svelte/guides/ark-ui/">Ark UI</Link>
 - <Link href="/svelte/guides/bits-ui/">Bits UI</Link>
 
 ## Next steps

--- a/website/src/routes/(docs)/svelte/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(main-concepts)/input-components/index.mdx
@@ -191,6 +191,11 @@ When using component libraries that don't expose their underlying native HTML el
 
 The `field.onInput` method updates the field value and triggers validation. For more details, see the <Link href="/svelte/guides/controlled-fields/">controlled fields</Link> guide.
 
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/svelte/guides/shadcn-svelte/">shadcn-svelte</Link>
+- <Link href="/svelte/guides/bits-ui/">Bits UI</Link>
+
 ## Next steps
 
 Now that you know how to create reusable input components, continue to the <Link href="/svelte/guides/handle-submission/">handle submission</Link> guide to learn how to process form data when the user submits the form.

--- a/website/src/routes/(docs)/svelte/guides/menu.md
+++ b/website/src/routes/(docs)/svelte/guides/menu.md
@@ -35,4 +35,5 @@
 ## Integration guides
 
 - [shadcn-svelte](/svelte/guides/shadcn-svelte/)
+- [Ark UI](/svelte/guides/ark-ui/)
 - [Bits UI](/svelte/guides/bits-ui/)

--- a/website/src/routes/(docs)/svelte/guides/menu.md
+++ b/website/src/routes/(docs)/svelte/guides/menu.md
@@ -31,3 +31,8 @@
 
 - [From Superforms](/svelte/guides/migrate-from-superforms/)
 - [From TanStack Form](/svelte/guides/migrate-from-tanstack-form/)
+
+## Integration guides
+
+- [shadcn-svelte](/svelte/guides/shadcn-svelte/)
+- [Bits UI](/svelte/guides/bits-ui/)

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -155,6 +155,37 @@ For select elements, you control the value with `v-model`:
 
 The HTML `<input type="file" />` element is an exception because it cannot be controlled in the traditional way. However, you can control the UI around it. For inspiration, check out our <a href={`${import.meta.env.PUBLIC_GITHUB_URL}/blob/main/playgrounds/vue/src/components/FileInput.vue`} target={'\_blank'} rel="noreferrer">`FileInput`</a> component from the <Link href="/playground/special/">playground</Link>.
 
+## Custom inputs and component libraries
+
+Component libraries don't expose their underlying native element, so `v-bind="field.props"` does not work on them. Vue treats the `ref` entry inside that object as a real template ref, which would register the component instance instead of a DOM element. Bind the entries individually and let `v-model` write the value:
+
+```vue
+<template>
+  <Field :of="form" :path="['date']" v-slot="field">
+    <DatePicker
+      :ref="(instance) => field.props.ref(instance?.$el ?? instance)"
+      :name="field.props.name"
+      v-model="field.input"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
+```
+
+This is useful for:
+
+- **Component libraries** that wrap native elements without exposing them
+- **Complex custom inputs** like date pickers, rich text editors, or color pickers
+
+Assigning `field.input` updates the field value and triggers validation, just like a native input would. Registering the element keeps <Link href="/methods/api/focus/">`focus`</Link> working, and the focus handler is what marks the field as touched.
+
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/vue/guides/shadcn-vue/">shadcn-vue</Link>
+- <Link href="/vue/guides/reka-ui/">Reka UI</Link>
+- <Link href="/vue/guides/primevue/">PrimeVue</Link>
+
 ## Next steps
 
 Now that you understand controlled fields, you can explore more advanced topics like <Link href="/vue/guides/nested-fields/">nested fields</Link> and <Link href="/vue/guides/field-arrays/">field arrays</Link> to handle complex form structures.

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -165,6 +165,7 @@ Component libraries don't expose their underlying native element, so `v-bind="fi
     <DatePicker
       :ref="(instance) => field.props.ref(instance?.$el ?? instance)"
       :name="field.props.name"
+      :autofocus="field.props.autofocus"
       v-model="field.input"
       @focus="field.props.onFocus"
       @blur="field.props.onBlur"
@@ -178,7 +179,7 @@ This is useful for:
 - **Component libraries** that wrap native elements without exposing them
 - **Complex custom inputs** like date pickers, rich text editors, or color pickers
 
-Assigning `field.input` updates the field value and triggers validation, just like a native input would. Registering the element keeps <Link href="/methods/api/focus/">`focus`</Link> working, and the focus handler is what marks the field as touched.
+Assigning `field.input` updates the field value and triggers validation, just like a native input would. Registering the element keeps <Link href="/methods/api/focus/">`focus`</Link> working, and the focus handler is what marks the field as touched. Unwrapping `$el` only helps when the component's root is the focusable element; if it wraps its control in a container, reach for the library's own input ref instead.
 
 For ready-made wiring recipes, check out our integration guides:
 

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/controlled-fields/index.mdx
@@ -183,6 +183,7 @@ Assigning `field.input` updates the field value and triggers validation, just li
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/vue/guides/shadcn-vue/">shadcn-vue</Link>
+- <Link href="/vue/guides/ark-ui/">Ark UI</Link>
 - <Link href="/vue/guides/reka-ui/">Reka UI</Link>
 - <Link href="/vue/guides/primevue/">PrimeVue</Link>
 

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -107,15 +107,17 @@ Assigning `field.input` runs input-mode validation, so a form configured with `v
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires the error reference for you, and the text only renders while the field is invalid:
 
 ```vue
-<ArkField.Root
-  id="login-email"
-  :ids="{ errorText: 'login-email-error' }"
-  :invalid="!!field.errors"
->
-  <ArkField.Label>Email</ArkField.Label>
-  <ArkField.Input :ref="elementRef(field.props.ref)" v-model="field.input" />
-  <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
-</ArkField.Root>
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <ArkField.Root
+    id="login-email"
+    :ids="{ errorText: 'login-email-error' }"
+    :invalid="!!field.errors"
+  >
+    <ArkField.Label>Email</ArkField.Label>
+    <ArkField.Input :ref="elementRef(field.props.ref)" v-model="field.input" />
+    <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+  </ArkField.Root>
+</Field>
 ```
 
 Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -326,22 +326,22 @@ const frameworkCollection = createListCollection({
     :model-value="field.input ? [field.input] : []"
     :invalid="!!field.errors"
     @value-change="
-      (details) => (field.input = details.value[0] as 'angular' | 'vue')
+      (details) => (field.input = details.value[0] as typeof field.input)
     "
   >
     <Select.Label>Framework</Select.Label>
     <Select.Control>
-      <Select.Trigger aria-errormessage="project-framework-error">
+      <Select.Trigger
+        :autofocus="field.props.autofocus"
+        aria-errormessage="project-framework-error"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      >
         <Select.ValueText placeholder="Select a framework" />
         <Select.Indicator>▾</Select.Indicator>
       </Select.Trigger>
     </Select.Control>
-    <Select.HiddenSelect
-      :ref="elementRef(field.props.ref)"
-      :autofocus="field.props.autofocus"
-      @focus="field.props.onFocus"
-      @blur="field.props.onBlur"
-    />
+    <Select.HiddenSelect :ref="elementRef(field.props.ref)" />
     <span v-if="field.errors" id="project-framework-error">
       {{ field.errors[0] }}
     </span>
@@ -362,7 +362,7 @@ const frameworkCollection = createListCollection({
 </Field>
 ```
 
-The hidden select forwards focus to the visible trigger on its own, so `focus` lands on the button the user sees.
+Put the focus handlers on the trigger rather than on the hidden select, because that is the element a keyboard user lands on. `focus` still works, since Ark forwards focus from the hidden select to the visible trigger.
 
 ### Radio group
 
@@ -421,12 +421,13 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
       <Slider.Track>
         <Slider.Range />
       </Slider.Track>
-      <Slider.Thumb :index="0" aria-errormessage="settings-volume-error">
-        <Slider.HiddenInput
-          :ref="elementRef(field.props.ref)"
-          @focus="field.props.onFocus"
-          @blur="field.props.onBlur"
-        />
+      <Slider.Thumb
+        :index="0"
+        aria-errormessage="settings-volume-error"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      >
+        <Slider.HiddenInput :ref="elementRef(field.props.ref)" />
       </Slider.Thumb>
     </Slider.Control>
     <span v-if="field.errors" id="settings-volume-error">
@@ -442,7 +443,7 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
 
 `field.props.autofocus` is a snapshot taken when the field mounts, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
 
-Ark UI is also available for other frameworks. The part names and the `ids` and `invalid` props are identical there, so this wiring ports with only the framework API changing. See our <Link href="/react/guides/ark-ui/">React</Link> and <Link href="/solid/guides/ark-ui/">Solid</Link> guides.
+Ark UI is also available for other frameworks. The part names and the `ids` and `invalid` props are identical there, so this wiring ports with only the framework API changing. See our <Link href="/react/guides/ark-ui/">React</Link>, <Link href="/solid/guides/ark-ui/">Solid</Link> and <Link href="/svelte/guides/ark-ui/">Svelte</Link> guides.
 
 If you prefer a library where native elements stay plain elements, our <Link href="/vue/guides/reka-ui/">Reka UI guide</Link> covers that style, at the cost of writing the accessibility attributes yourself.
 

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -1,0 +1,451 @@
+---
+title: Ark UI
+description: >-
+  Learn how to connect Formisch fields to Ark UI inputs, checkboxes, selects,
+  radio groups and sliders in Vue.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Ark UI
+
+[Ark UI](https://ark-ui.com) is a headless component library built on state machines, available for Vue among other frameworks. This guide targets Ark UI v5 for Vue. No adapter package is needed, and Ark handles more of the accessibility wiring than most libraries: inside its `Field`, the label association, `aria-invalid` and the error message reference are derived for you.
+
+## Installation
+
+Install Formisch, Valibot and Ark UI:
+
+```bash
+npm install @formisch/vue valibot @ark-ui/vue
+```
+
+Ark UI ships unstyled, so every example below leaves styling to you.
+
+## Wiring patterns
+
+Every Ark UI part is a Vue component rather than a plain element, so there is only one pattern here: bind the field entries individually. Never use `v-bind="field.props"`, not even on a text input. Vue treats the `ref` entry inside that object as a real template ref, so the spread would hand Formisch the component instance, and `focus` would fail on an object that has no `focus` method.
+
+Because the parts are components, the element reference always needs unwrapping. Every Ark part exposes its real DOM node as `$el`, so one small helper covers all of them:
+
+```ts
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) =>
+    register(
+      instance && '$el' in instance
+        ? ((instance as ComponentPublicInstance).$el as Element | null)
+        : (instance as Element | null)
+    );
+}
+```
+
+Note also that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+
+### Text fields
+
+`Field.Input` wraps a native input, so it accepts `v-model` and forwards the lifecycle handlers to the element. Since Formisch and Ark UI both export a `Field`, the Ark one is imported as `ArkField`:
+
+```vue
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <ArkField.Root id="login-email" :invalid="!!field.errors">
+    <ArkField.Label>Email</ArkField.Label>
+    <ArkField.Input
+      :ref="elementRef(field.props.ref)"
+      v-model="field.input"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      type="email"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+    <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+  </ArkField.Root>
+</Field>
+```
+
+The component accepts `modelValue` rather than `value`, so `v-model` is the way to bind it. Set the `id` on `ArkField.Root` rather than on the input, because Ark derives the control id and the label's `for` from it.
+
+### Controlled components
+
+A composite component owns its value, so bind `modelValue` and handle the change event, then forward the lifecycle props to its hidden native part. Registering that part is what keeps <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing working:
+
+```vue
+<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+  <Checkbox.Root
+    :ids="{ hiddenInput: 'login-remember-me' }"
+    :name="field.props.name"
+    :checked="field.input ?? false"
+    :invalid="!!field.errors"
+    @checked-change="(details) => (field.input = details.checked === true)"
+  >
+    <Checkbox.HiddenInput
+      :ref="elementRef(field.props.ref)"
+      :autofocus="field.props.autofocus"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+    <Checkbox.Control>
+      <Checkbox.Indicator>✓</Checkbox.Indicator>
+    </Checkbox.Control>
+    <Checkbox.Label>Remember me</Checkbox.Label>
+  </Checkbox.Root>
+</Field>
+```
+
+`Checkbox.HiddenInput` is not optional: without it the checkbox does not react to clicks at all. Ark exposes its events as kebab-case emits, so the handler is `@checked-change` rather than a callback prop, and its payload can be `'indeterminate'`, which is normalized above.
+
+Prefer these explicit handlers over `v-model` on a composite root. Vue rejects `v-model` outright on the array based `Select.Root` and `Slider.Root`, and while it compiles on `Checkbox.Root` and `RadioGroup.Root`, it does not typecheck the write direction, so an indeterminate state or a `null` selection would flow into your field unchecked.
+
+Every Ark root also accepts an `ids` object, which is the supported way to give a hidden part a stable id. Setting `id` directly on a hidden part instead leaves the generated label pointing at the old value.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires the error reference for you, and the text only renders while the field is invalid:
+
+```vue
+<ArkField.Root
+  id="login-email"
+  :ids="{ errorText: 'login-email-error' }"
+  :invalid="!!field.errors"
+>
+  <ArkField.Label>Email</ArkField.Label>
+  <ArkField.Input :ref="elementRef(field.props.ref)" v-model="field.input" />
+  <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+</ArkField.Root>
+```
+
+Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/vue/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines two text fields, a controlled checkbox and accessible errors:
+
+```vue
+<script setup lang="ts">
+import { Checkbox } from '@ark-ui/vue/checkbox';
+import { Field as ArkField } from '@ark-ui/vue/field';
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/vue';
+import * as v from 'valibot';
+import type { ComponentPublicInstance } from 'vue';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: { email: '', password: '', rememberMe: false },
+});
+
+const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+  console.log(output);
+};
+
+// Every Ark UI part is a Vue component, so the ref callback receives a
+// component instance. Formisch calls `.focus()` on whatever it gets, so
+// unwrap the root DOM element before registering it.
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) =>
+    register(
+      instance && '$el' in instance
+        ? ((instance as ComponentPublicInstance).$el as Element | null)
+        : (instance as Element | null)
+    );
+}
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="handleSubmit">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <ArkField.Root
+        id="login-email"
+        :ids="{ errorText: 'login-email-error' }"
+        :invalid="!!field.errors"
+      >
+        <ArkField.Label>Email</ArkField.Label>
+        <ArkField.Input
+          :ref="elementRef(field.props.ref)"
+          v-model="field.input"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          type="email"
+          autocomplete="email"
+          placeholder="jane@example.com"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+      </ArkField.Root>
+    </Field>
+
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <ArkField.Root
+        id="login-password"
+        :ids="{ errorText: 'login-password-error' }"
+        :invalid="!!field.errors"
+      >
+        <ArkField.Label>Password</ArkField.Label>
+        <ArkField.Input
+          :ref="elementRef(field.props.ref)"
+          v-model="field.input"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          type="password"
+          autocomplete="current-password"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+      </ArkField.Root>
+    </Field>
+
+    <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+      <Checkbox.Root
+        :ids="{ hiddenInput: 'login-remember-me' }"
+        :name="field.props.name"
+        :checked="field.input ?? false"
+        :invalid="!!field.errors"
+        @checked-change="(details) => (field.input = details.checked === true)"
+      >
+        <Checkbox.HiddenInput
+          :ref="elementRef(field.props.ref)"
+          :autofocus="field.props.autofocus"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        />
+        <Checkbox.Control>
+          <Checkbox.Indicator>✓</Checkbox.Indicator>
+        </Checkbox.Control>
+        <Checkbox.Label>Remember me</Checkbox.Label>
+      </Checkbox.Root>
+    </Field>
+
+    <button type="submit" :disabled="loginForm.isSubmitting">Login</button>
+  </Form>
+</template>
+```
+
+The initial input keeps every control defined from its first render. Since `Field.Input` wraps a real native element, `@change` is worth forwarding there. On the composite controls it has nothing to fire on, so it stays unwired.
+
+## Component reference
+
+The following snippets assume a form store named `form`, initialized values that match the schema, and the `elementRef` helper from above.
+
+### Text input
+
+```vue
+<Field :of="form" :path="['email']" v-slot="field">
+  <ArkField.Root
+    id="profile-email"
+    :ids="{ errorText: 'profile-email-error' }"
+    :invalid="!!field.errors"
+  >
+    <ArkField.Label>Email</ArkField.Label>
+    <ArkField.Input
+      :ref="elementRef(field.props.ref)"
+      v-model="field.input"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      type="email"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+    <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+  </ArkField.Root>
+</Field>
+```
+
+Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the same wiring.
+
+### Checkbox
+
+```vue
+<Field :of="form" :path="['newsletter']" v-slot="field">
+  <Checkbox.Root
+    :ids="{ hiddenInput: 'settings-newsletter' }"
+    :name="field.props.name"
+    :checked="field.input ?? false"
+    :invalid="!!field.errors"
+    @checked-change="(details) => (field.input = details.checked === true)"
+  >
+    <Checkbox.HiddenInput
+      :ref="elementRef(field.props.ref)"
+      :autofocus="field.props.autofocus"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+    <Checkbox.Control>
+      <Checkbox.Indicator>✓</Checkbox.Indicator>
+    </Checkbox.Control>
+    <Checkbox.Label>Newsletter</Checkbox.Label>
+  </Checkbox.Root>
+</Field>
+```
+
+### Select
+
+Ark's select is array based even for a single selection, so wrap the value and unwrap the payload, narrowing it to the schema union. Items come from a collection, and since Ark UI for Vue exports no portal component, Vue's own `Teleport` positions the popup:
+
+```ts
+const frameworkCollection = createListCollection({
+  items: [
+    { label: 'Angular', value: 'angular' },
+    { label: 'React', value: 'react' },
+    { label: 'Solid', value: 'solid' },
+    { label: 'Vue', value: 'vue' },
+  ],
+});
+```
+
+```vue
+<Field :of="form" :path="['framework']" v-slot="field">
+  <Select.Root
+    :ids="{
+      trigger: 'project-framework',
+      hiddenSelect: 'project-framework-select',
+    }"
+    :collection="frameworkCollection"
+    :name="field.props.name"
+    :model-value="field.input ? [field.input] : []"
+    :invalid="!!field.errors"
+    @value-change="
+      (details) => (field.input = details.value[0] as 'angular' | 'vue')
+    "
+  >
+    <Select.Label>Framework</Select.Label>
+    <Select.Control>
+      <Select.Trigger aria-errormessage="project-framework-error">
+        <Select.ValueText placeholder="Select a framework" />
+        <Select.Indicator>▾</Select.Indicator>
+      </Select.Trigger>
+    </Select.Control>
+    <Select.HiddenSelect
+      :ref="elementRef(field.props.ref)"
+      :autofocus="field.props.autofocus"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+    <span v-if="field.errors" id="project-framework-error">
+      {{ field.errors[0] }}
+    </span>
+    <Teleport to="body">
+      <Select.Positioner>
+        <Select.Content>
+          <Select.Item
+            v-for="item in frameworkCollection.items"
+            :key="item.value"
+            :item="item"
+          >
+            <Select.ItemText>{{ item.label }}</Select.ItemText>
+          </Select.Item>
+        </Select.Content>
+      </Select.Positioner>
+    </Teleport>
+  </Select.Root>
+</Field>
+```
+
+The hidden select forwards focus to the visible trigger on its own, so `focus` lands on the button the user sees.
+
+### Radio group
+
+Register every item's hidden input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autofocus` on the first item only, otherwise every radio competes for focus:
+
+```vue
+<Field :of="form" :path="['plan']" v-slot="field">
+  <RadioGroup.Root
+    :ids="{ itemHiddenInput: (value) => `plan-${value}` }"
+    :name="field.props.name"
+    :model-value="field.input ?? null"
+    :invalid="!!field.errors"
+    aria-errormessage="plan-error"
+    @value-change="(details) => (field.input = details.value as 'hobby' | 'pro')"
+  >
+    <RadioGroup.Label>Plan</RadioGroup.Label>
+    <RadioGroup.Item
+      v-for="(plan, index) in plans"
+      :key="plan.value"
+      :value="plan.value"
+    >
+      <RadioGroup.ItemHiddenInput
+        :ref="elementRef(field.props.ref)"
+        :autofocus="index === 0 && field.props.autofocus"
+        :aria-invalid="field.errors ? true : undefined"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      />
+      <RadioGroup.ItemControl />
+      <RadioGroup.ItemText>{{ plan.label }}</RadioGroup.ItemText>
+    </RadioGroup.Item>
+    <span v-if="field.errors" id="plan-error">{{ field.errors[0] }}</span>
+  </RadioGroup.Root>
+</Field>
+```
+
+### Slider
+
+Ark's slider is array based like its select, and it uses `min` and `max` rather than `minValue` and `maxValue`. One `Slider.Thumb` renders exactly one thumb, and `Slider.Label` names it for you:
+
+```vue
+<Field :of="form" :path="['volume']" v-slot="field">
+  <Slider.Root
+    :ids="{ thumb: () => 'settings-volume-thumb' }"
+    :name="field.props.name"
+    :min="0"
+    :max="100"
+    :step="1"
+    :model-value="[field.input ?? 50]"
+    :invalid="!!field.errors"
+    @value-change="(details) => (field.input = details.value[0])"
+  >
+    <Slider.Label>Volume</Slider.Label>
+    <Slider.ValueText />
+    <Slider.Control>
+      <Slider.Track>
+        <Slider.Range />
+      </Slider.Track>
+      <Slider.Thumb :index="0" aria-errormessage="settings-volume-error">
+        <Slider.HiddenInput
+          :ref="elementRef(field.props.ref)"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        />
+      </Slider.Thumb>
+    </Slider.Control>
+    <span v-if="field.errors" id="settings-volume-error">
+      {{ field.errors[0] }}
+    </span>
+  </Slider.Root>
+</Field>
+```
+
+`Slider.HiddenInput` renders with the `hidden` attribute, which makes it unfocusable, so `focus` cannot move focus to this field. Keyboard users still reach the thumb normally, and validation, `isTouched` and blur validation are unaffected.
+
+## Library-specific notes
+
+`field.props.autofocus` is a snapshot taken when the field mounts, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
+
+Ark UI is also available for other frameworks. The part names and the `ids` and `invalid` props are identical there, so this wiring ports with only the framework API changing. See our <Link href="/react/guides/ark-ui/">React</Link> and <Link href="/solid/guides/ark-ui/">Solid</Link> guides.
+
+If you prefer a library where native elements stay plain elements, our <Link href="/vue/guides/reka-ui/">Reka UI guide</Link> covers that style, at the cost of writing the accessibility attributes yourself.
+
+## Next steps
+
+Read the <Link href="/vue/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/vue/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -423,6 +423,7 @@ Ark's slider is array based like its select, and it uses `min` and `max` rather 
       </Slider.Track>
       <Slider.Thumb
         :index="0"
+        :autofocus="field.props.autofocus"
         aria-errormessage="settings-volume-error"
         @focus="field.props.onFocus"
         @blur="field.props.onBlur"

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -40,7 +40,7 @@ function elementRef(register: (element: Element | null) => void) {
 }
 ```
 
-Note also that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+Note also that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation. Do not destructure the slot: write `v-slot="field"` rather than `v-slot="{ input }"`, because destructuring copies the value out of the accessor and assignments would go nowhere.
 
 ### Text fields
 

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -47,22 +47,24 @@ Note also that `field.input` is a getter and setter rather than a method. Assign
 `Field.Input` wraps a native input, so it accepts `v-model` and forwards the lifecycle handlers to the element. Since Formisch and Ark UI both export a `Field`, the Ark one is imported as `ArkField`:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <ArkField.Root id="login-email" :invalid="!!field.errors">
-    <ArkField.Label>Email</ArkField.Label>
-    <ArkField.Input
-      :ref="elementRef(field.props.ref)"
-      v-model="field.input"
-      :name="field.props.name"
-      :autofocus="field.props.autofocus"
-      type="email"
-      @focus="field.props.onFocus"
-      @change="field.props.onChange"
-      @blur="field.props.onBlur"
-    />
-    <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
-  </ArkField.Root>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <ArkField.Root id="login-email" :invalid="!!field.errors">
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input
+        :ref="elementRef(field.props.ref)"
+        v-model="field.input"
+        :name="field.props.name"
+        :autofocus="field.props.autofocus"
+        type="email"
+        @focus="field.props.onFocus"
+        @change="field.props.onChange"
+        @blur="field.props.onBlur"
+      />
+      <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+    </ArkField.Root>
+  </Field>
+</template>
 ```
 
 The component accepts `modelValue` rather than `value`, so `v-model` is the way to bind it. Set the `id` on `ArkField.Root` rather than on the input, because Ark derives the control id and the label's `for` from it.
@@ -72,26 +74,28 @@ The component accepts `modelValue` rather than `value`, so `v-model` is the way 
 A composite component owns its value, so bind `modelValue` and handle the change event, then forward the lifecycle props to its hidden native part. Registering that part is what keeps <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing working:
 
 ```vue
-<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
-  <Checkbox.Root
-    :ids="{ hiddenInput: 'login-remember-me' }"
-    :name="field.props.name"
-    :checked="field.input ?? false"
-    :invalid="!!field.errors"
-    @checked-change="(details) => (field.input = details.checked === true)"
-  >
-    <Checkbox.HiddenInput
-      :ref="elementRef(field.props.ref)"
-      :autofocus="field.props.autofocus"
-      @focus="field.props.onFocus"
-      @blur="field.props.onBlur"
-    />
-    <Checkbox.Control>
-      <Checkbox.Indicator>✓</Checkbox.Indicator>
-    </Checkbox.Control>
-    <Checkbox.Label>Remember me</Checkbox.Label>
-  </Checkbox.Root>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+    <Checkbox.Root
+      :ids="{ hiddenInput: 'login-remember-me' }"
+      :name="field.props.name"
+      :checked="field.input ?? false"
+      :invalid="!!field.errors"
+      @checked-change="(details) => (field.input = details.checked === true)"
+    >
+      <Checkbox.HiddenInput
+        :ref="elementRef(field.props.ref)"
+        :autofocus="field.props.autofocus"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Remember me</Checkbox.Label>
+    </Checkbox.Root>
+  </Field>
+</template>
 ```
 
 `Checkbox.HiddenInput` is not optional: without it the checkbox does not react to clicks at all. Ark exposes its events as kebab-case emits, so the handler is `@checked-change` rather than a callback prop, and its payload can be `'indeterminate'`, which is normalized above.
@@ -107,17 +111,22 @@ Assigning `field.input` runs input-mode validation, so a form configured with `v
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires the error reference for you, and the text only renders while the field is invalid:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <ArkField.Root
-    id="login-email"
-    :ids="{ errorText: 'login-email-error' }"
-    :invalid="!!field.errors"
-  >
-    <ArkField.Label>Email</ArkField.Label>
-    <ArkField.Input :ref="elementRef(field.props.ref)" v-model="field.input" />
-    <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
-  </ArkField.Root>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <ArkField.Root
+      id="login-email"
+      :ids="{ errorText: 'login-email-error' }"
+      :invalid="!!field.errors"
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input
+        :ref="elementRef(field.props.ref)"
+        v-model="field.input"
+      />
+      <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+    </ArkField.Root>
+  </Field>
+</template>
 ```
 
 Only `Field` has an error part. `Select`, `RadioGroup` and `Slider` have none, so render the message yourself and point the visible control at it with `aria-errormessage`. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
@@ -254,26 +263,28 @@ The following snippets assume a form store named `form`, initialized values that
 ### Text input
 
 ```vue
-<Field :of="form" :path="['email']" v-slot="field">
-  <ArkField.Root
-    id="profile-email"
-    :ids="{ errorText: 'profile-email-error' }"
-    :invalid="!!field.errors"
-  >
-    <ArkField.Label>Email</ArkField.Label>
-    <ArkField.Input
-      :ref="elementRef(field.props.ref)"
-      v-model="field.input"
-      :name="field.props.name"
-      :autofocus="field.props.autofocus"
-      type="email"
-      @focus="field.props.onFocus"
-      @change="field.props.onChange"
-      @blur="field.props.onBlur"
-    />
-    <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
-  </ArkField.Root>
-</Field>
+<template>
+  <Field :of="form" :path="['email']" v-slot="field">
+    <ArkField.Root
+      id="profile-email"
+      :ids="{ errorText: 'profile-email-error' }"
+      :invalid="!!field.errors"
+    >
+      <ArkField.Label>Email</ArkField.Label>
+      <ArkField.Input
+        :ref="elementRef(field.props.ref)"
+        v-model="field.input"
+        :name="field.props.name"
+        :autofocus="field.props.autofocus"
+        type="email"
+        @focus="field.props.onFocus"
+        @change="field.props.onChange"
+        @blur="field.props.onBlur"
+      />
+      <ArkField.ErrorText>{{ field.errors?.[0] }}</ArkField.ErrorText>
+    </ArkField.Root>
+  </Field>
+</template>
 ```
 
 Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the same wiring.
@@ -281,26 +292,28 @@ Swap `ArkField.Input` for `ArkField.Textarea` to get a multiline field with the 
 ### Checkbox
 
 ```vue
-<Field :of="form" :path="['newsletter']" v-slot="field">
-  <Checkbox.Root
-    :ids="{ hiddenInput: 'settings-newsletter' }"
-    :name="field.props.name"
-    :checked="field.input ?? false"
-    :invalid="!!field.errors"
-    @checked-change="(details) => (field.input = details.checked === true)"
-  >
-    <Checkbox.HiddenInput
-      :ref="elementRef(field.props.ref)"
-      :autofocus="field.props.autofocus"
-      @focus="field.props.onFocus"
-      @blur="field.props.onBlur"
-    />
-    <Checkbox.Control>
-      <Checkbox.Indicator>✓</Checkbox.Indicator>
-    </Checkbox.Control>
-    <Checkbox.Label>Newsletter</Checkbox.Label>
-  </Checkbox.Root>
-</Field>
+<template>
+  <Field :of="form" :path="['newsletter']" v-slot="field">
+    <Checkbox.Root
+      :ids="{ hiddenInput: 'settings-newsletter' }"
+      :name="field.props.name"
+      :checked="field.input ?? false"
+      :invalid="!!field.errors"
+      @checked-change="(details) => (field.input = details.checked === true)"
+    >
+      <Checkbox.HiddenInput
+        :ref="elementRef(field.props.ref)"
+        :autofocus="field.props.autofocus"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      />
+      <Checkbox.Control>
+        <Checkbox.Indicator>✓</Checkbox.Indicator>
+      </Checkbox.Control>
+      <Checkbox.Label>Newsletter</Checkbox.Label>
+    </Checkbox.Root>
+  </Field>
+</template>
 ```
 
 ### Select
@@ -319,51 +332,53 @@ const frameworkCollection = createListCollection({
 ```
 
 ```vue
-<Field :of="form" :path="['framework']" v-slot="field">
-  <Select.Root
-    :ids="{
-      trigger: 'project-framework',
-      hiddenSelect: 'project-framework-select',
-    }"
-    :collection="frameworkCollection"
-    :name="field.props.name"
-    :model-value="field.input ? [field.input] : []"
-    :invalid="!!field.errors"
-    @value-change="
-      (details) => (field.input = details.value[0] as typeof field.input)
-    "
-  >
-    <Select.Label>Framework</Select.Label>
-    <Select.Control>
-      <Select.Trigger
-        :autofocus="field.props.autofocus"
-        aria-errormessage="project-framework-error"
-        @focus="field.props.onFocus"
-        @blur="field.props.onBlur"
-      >
-        <Select.ValueText placeholder="Select a framework" />
-        <Select.Indicator>▾</Select.Indicator>
-      </Select.Trigger>
-    </Select.Control>
-    <Select.HiddenSelect :ref="elementRef(field.props.ref)" />
-    <span v-if="field.errors" id="project-framework-error">
-      {{ field.errors[0] }}
-    </span>
-    <Teleport to="body">
-      <Select.Positioner>
-        <Select.Content>
-          <Select.Item
-            v-for="item in frameworkCollection.items"
-            :key="item.value"
-            :item="item"
-          >
-            <Select.ItemText>{{ item.label }}</Select.ItemText>
-          </Select.Item>
-        </Select.Content>
-      </Select.Positioner>
-    </Teleport>
-  </Select.Root>
-</Field>
+<template>
+  <Field :of="form" :path="['framework']" v-slot="field">
+    <Select.Root
+      :ids="{
+        trigger: 'project-framework',
+        hiddenSelect: 'project-framework-select',
+      }"
+      :collection="frameworkCollection"
+      :name="field.props.name"
+      :model-value="field.input ? [field.input] : []"
+      :invalid="!!field.errors"
+      @value-change="
+        (details) => (field.input = details.value[0] as typeof field.input)
+      "
+    >
+      <Select.Label>Framework</Select.Label>
+      <Select.Control>
+        <Select.Trigger
+          :autofocus="field.props.autofocus"
+          aria-errormessage="project-framework-error"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        >
+          <Select.ValueText placeholder="Select a framework" />
+          <Select.Indicator>▾</Select.Indicator>
+        </Select.Trigger>
+      </Select.Control>
+      <Select.HiddenSelect :ref="elementRef(field.props.ref)" />
+      <span v-if="field.errors" id="project-framework-error">
+        {{ field.errors[0] }}
+      </span>
+      <Teleport to="body">
+        <Select.Positioner>
+          <Select.Content>
+            <Select.Item
+              v-for="item in frameworkCollection.items"
+              :key="item.value"
+              :item="item"
+            >
+              <Select.ItemText>{{ item.label }}</Select.ItemText>
+            </Select.Item>
+          </Select.Content>
+        </Select.Positioner>
+      </Teleport>
+    </Select.Root>
+  </Field>
+</template>
 ```
 
 Put the focus handlers on the trigger rather than on the hidden select, because that is the element a keyboard user lands on. `focus` still works, since Ark forwards focus from the hidden select to the visible trigger.
@@ -373,34 +388,36 @@ Put the focus handlers on the trigger rather than on the hidden select, because 
 Register every item's hidden input. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Put `autofocus` on the first item only, otherwise every radio competes for focus:
 
 ```vue
-<Field :of="form" :path="['plan']" v-slot="field">
-  <RadioGroup.Root
-    :ids="{ itemHiddenInput: (value) => `plan-${value}` }"
-    :name="field.props.name"
-    :model-value="field.input ?? null"
-    :invalid="!!field.errors"
-    aria-errormessage="plan-error"
-    @value-change="(details) => (field.input = details.value as 'hobby' | 'pro')"
-  >
-    <RadioGroup.Label>Plan</RadioGroup.Label>
-    <RadioGroup.Item
-      v-for="(plan, index) in plans"
-      :key="plan.value"
-      :value="plan.value"
+<template>
+  <Field :of="form" :path="['plan']" v-slot="field">
+    <RadioGroup.Root
+      :ids="{ itemHiddenInput: (value) => `plan-${value}` }"
+      :name="field.props.name"
+      :model-value="field.input ?? null"
+      :invalid="!!field.errors"
+      aria-errormessage="plan-error"
+      @value-change="(details) => (field.input = details.value as 'hobby' | 'pro')"
     >
-      <RadioGroup.ItemHiddenInput
-        :ref="elementRef(field.props.ref)"
-        :autofocus="index === 0 && field.props.autofocus"
-        :aria-invalid="field.errors ? true : undefined"
-        @focus="field.props.onFocus"
-        @blur="field.props.onBlur"
-      />
-      <RadioGroup.ItemControl />
-      <RadioGroup.ItemText>{{ plan.label }}</RadioGroup.ItemText>
-    </RadioGroup.Item>
-    <span v-if="field.errors" id="plan-error">{{ field.errors[0] }}</span>
-  </RadioGroup.Root>
-</Field>
+      <RadioGroup.Label>Plan</RadioGroup.Label>
+      <RadioGroup.Item
+        v-for="(plan, index) in plans"
+        :key="plan.value"
+        :value="plan.value"
+      >
+        <RadioGroup.ItemHiddenInput
+          :ref="elementRef(field.props.ref)"
+          :autofocus="index === 0 && field.props.autofocus"
+          :aria-invalid="field.errors ? true : undefined"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        />
+        <RadioGroup.ItemControl />
+        <RadioGroup.ItemText>{{ plan.label }}</RadioGroup.ItemText>
+      </RadioGroup.Item>
+      <span v-if="field.errors" id="plan-error">{{ field.errors[0] }}</span>
+    </RadioGroup.Root>
+  </Field>
+</template>
 ```
 
 ### Slider
@@ -408,38 +425,40 @@ Register every item's hidden input. Formisch keeps a list of registered elements
 Ark's slider is array based like its select, and it uses `min` and `max` rather than `minValue` and `maxValue`. One `Slider.Thumb` renders exactly one thumb, and `Slider.Label` names it for you:
 
 ```vue
-<Field :of="form" :path="['volume']" v-slot="field">
-  <Slider.Root
-    :ids="{ thumb: () => 'settings-volume-thumb' }"
-    :name="field.props.name"
-    :min="0"
-    :max="100"
-    :step="1"
-    :model-value="[field.input ?? 50]"
-    :invalid="!!field.errors"
-    @value-change="(details) => (field.input = details.value[0])"
-  >
-    <Slider.Label>Volume</Slider.Label>
-    <Slider.ValueText />
-    <Slider.Control>
-      <Slider.Track>
-        <Slider.Range />
-      </Slider.Track>
-      <Slider.Thumb
-        :index="0"
-        :autofocus="field.props.autofocus"
-        aria-errormessage="settings-volume-error"
-        @focus="field.props.onFocus"
-        @blur="field.props.onBlur"
-      >
-        <Slider.HiddenInput :ref="elementRef(field.props.ref)" />
-      </Slider.Thumb>
-    </Slider.Control>
-    <span v-if="field.errors" id="settings-volume-error">
-      {{ field.errors[0] }}
-    </span>
-  </Slider.Root>
-</Field>
+<template>
+  <Field :of="form" :path="['volume']" v-slot="field">
+    <Slider.Root
+      :ids="{ thumb: () => 'settings-volume-thumb' }"
+      :name="field.props.name"
+      :min="0"
+      :max="100"
+      :step="1"
+      :model-value="[field.input ?? 50]"
+      :invalid="!!field.errors"
+      @value-change="(details) => (field.input = details.value[0])"
+    >
+      <Slider.Label>Volume</Slider.Label>
+      <Slider.ValueText />
+      <Slider.Control>
+        <Slider.Track>
+          <Slider.Range />
+        </Slider.Track>
+        <Slider.Thumb
+          :index="0"
+          :autofocus="field.props.autofocus"
+          aria-errormessage="settings-volume-error"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        >
+          <Slider.HiddenInput :ref="elementRef(field.props.ref)" />
+        </Slider.Thumb>
+      </Slider.Control>
+      <span v-if="field.errors" id="settings-volume-error">
+        {{ field.errors[0] }}
+      </span>
+    </Slider.Root>
+  </Field>
+</template>
 ```
 
 `Slider.HiddenInput` renders with the `hidden` attribute, which makes it unfocusable, so `focus` cannot move focus to this field. Keyboard users still reach the thumb normally, and validation, `isTouched` and blur validation are unaffected.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/ark-ui/index.mdx
@@ -100,6 +100,8 @@ Prefer these explicit handlers over `v-model` on a composite root. Vue rejects `
 
 Every Ark root also accepts an `ids` object, which is the supported way to give a hidden part a stable id. Setting `id` directly on a hidden part instead leaves the generated label pointing at the old value.
 
+Assigning `field.input` runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit. Use `validate: 'input'` if you want them validated as the value changes.
+
 ## Displaying errors
 
 Formisch exposes errors as `[string, ...string[]] | null`. Inside `ArkField.Root`, pass `invalid` and render the message in `ArkField.ErrorText`. Ark adds `aria-invalid` and wires the error reference for you, and the text only renders while the field is invalid:

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
@@ -28,7 +28,7 @@ Choose the wiring from where the component keeps its focusable element:
 - `InputText` and `Textarea` render the native element as their root, so `v-model` plus the individual props reaches it directly.
 - `Checkbox`, `RadioButton`, `Select`, `Slider` and `Password` wrap their control in a styled element, so the element reference has to reach the inner control and some props travel through `pt`.
 
-Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Do not destructure the slot: write `v-slot="field"` rather than `v-slot="{ input }"`, because destructuring copies the value out of the accessor and assignments would go nowhere.
 
 ### Spreading field.props
 

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
@@ -1,0 +1,410 @@
+---
+title: PrimeVue
+description: >-
+  Learn how to connect Formisch fields to PrimeVue inputs, selects, radio
+  buttons, sliders and other form components.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# PrimeVue
+
+[PrimeVue](https://primevue.org) is a full featured component library for Vue with a large set of styled form controls. This guide targets PrimeVue v5. No adapter package is needed: every component binds its value with `v-model`, and the remaining field props are bound individually, sometimes through the component's pass through API.
+
+## Installation
+
+Install Formisch, Valibot and PrimeVue, then register a theme as described in the [PrimeVue setup guide](https://primevue.org/vite):
+
+```bash
+npm install @formisch/vue valibot primevue @primeuix/themes
+```
+
+## Wiring patterns
+
+Choose the wiring from where the component keeps its focusable element:
+
+- `InputText` and `Textarea` render the native element as their root, so `v-model` plus the individual props reaches it directly.
+- `Checkbox`, `RadioButton`, `Select`, `Slider` and `Password` wrap their control in a styled element, so the element reference has to reach the inner control and some props travel through `pt`.
+
+Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+
+### Spreading field.props
+
+Never spread `field.props` onto a PrimeVue component. Vue treats the `ref` entry inside a `v-bind` object as a real template ref, so the spread would hand Formisch the component instance, and `focus` would fail on an object that has no `focus` method. Bind the entries individually instead:
+
+```vue
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <InputText
+    id="login-email"
+    type="email"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    v-model="field.input"
+    :invalid="!!field.errors"
+    @focus="field.props.onFocus"
+    @change="field.props.onChange"
+    @blur="field.props.onBlur"
+  />
+</Field>
+```
+
+### Controlled components
+
+Because most PrimeVue components wrap their control, the reference helper looks for the focusable element inside the root. Registering the real control is what keeps <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing working:
+
+```ts
+const FOCUSABLE = 'input, select, textarea, [tabindex]';
+
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) => {
+    const root = (
+      instance && '$el' in instance ? instance.$el : instance
+    ) as HTMLElement | null;
+    register(
+      root?.matches(FOCUSABLE) ? root : (root?.querySelector(FOCUSABLE) ?? root)
+    );
+  };
+}
+```
+
+```vue
+<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+  <Checkbox
+    input-id="login-remember-me"
+    binary
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :model-value="field.input ?? false"
+    :invalid="!!field.errors"
+    :pt="{ input: { autofocus: field.props.autofocus } }"
+    @update:model-value="(value) => (field.input = value as boolean)"
+    @focus="field.props.onFocus"
+    @change="field.props.onChange"
+    @blur="field.props.onBlur"
+  />
+  <label for="login-remember-me">Remember me</label>
+</Field>
+```
+
+Two PrimeVue conventions show up here. `inputId` puts an id on the real control so a `<label for>` can reach it, while a plain `id` would land on the wrapper. The `pt` object is spread onto an internal element, so it carries any attribute or listener you need to place there. Forwarding `@focus` matters as well, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Prefer PrimeVue's own `invalid` prop over setting `aria-invalid` yourself, since the component writes `aria-invalid` onto the inner control and omits it while the field is valid:
+
+```vue
+<InputText
+  id="login-email"
+  :ref="elementRef(field.props.ref)"
+  v-model="field.input"
+  :invalid="!!field.errors"
+  aria-errormessage="login-email-error"
+/>
+<small v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</small>
+```
+
+For a wrapped control, route `aria-errormessage` through `pt` so it lands on the element that carries the role. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/vue/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines text inputs, a controlled checkbox and accessible errors:
+
+```vue
+<script setup lang="ts">
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/vue';
+import Button from 'primevue/button';
+import Checkbox from 'primevue/checkbox';
+import InputText from 'primevue/inputtext';
+import Password from 'primevue/password';
+import * as v from 'valibot';
+import type { ComponentPublicInstance } from 'vue';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: { email: '', password: '', rememberMe: false },
+});
+
+const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+  console.log(output);
+};
+
+// PrimeVue renders its focusable control inside a styled wrapper, so a ref
+// placed on the component yields the wrapper, not the control. Formisch calls
+// `.focus()` on whatever it is given, so hand it the real focusable element.
+const FOCUSABLE = 'input, select, textarea, [tabindex]';
+
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) => {
+    const root = (
+      instance && '$el' in instance ? instance.$el : instance
+    ) as HTMLElement | null;
+    register(
+      root?.matches(FOCUSABLE) ? root : (root?.querySelector(FOCUSABLE) ?? root)
+    );
+  };
+}
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="handleSubmit">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <div>
+        <label for="login-email">Email</label>
+        <InputText
+          id="login-email"
+          type="email"
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          v-model="field.input"
+          :invalid="!!field.errors"
+          aria-errormessage="login-email-error"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <small v-if="field.errors" id="login-email-error">
+          {{ field.errors[0] }}
+        </small>
+      </div>
+    </Field>
+
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <div>
+        <label for="login-password">Password</label>
+        <Password
+          input-id="login-password"
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          v-model="field.input"
+          :feedback="false"
+          :invalid="!!field.errors"
+          :input-props="{
+            'aria-errormessage': 'login-password-error',
+            onFocus: field.props.onFocus,
+            onChange: field.props.onChange,
+            onBlur: field.props.onBlur,
+          }"
+        />
+        <small v-if="field.errors" id="login-password-error">
+          {{ field.errors[0] }}
+        </small>
+      </div>
+    </Field>
+
+    <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+      <div>
+        <Checkbox
+          input-id="login-remember-me"
+          binary
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :model-value="field.input ?? false"
+          :invalid="!!field.errors"
+          :pt="{
+            input: {
+              autofocus: field.props.autofocus,
+              'aria-errormessage': 'login-remember-me-error',
+            },
+          }"
+          @update:model-value="(value) => (field.input = value as boolean)"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <label for="login-remember-me">Remember me</label>
+        <small v-if="field.errors" id="login-remember-me-error">
+          {{ field.errors[0] }}
+        </small>
+      </div>
+    </Field>
+
+    <Button type="submit" label="Login" :disabled="loginForm.isSubmitting" />
+  </Form>
+</template>
+```
+
+The initial input keeps every control defined from its first render. `Password` takes its handlers through `inputProps`, since that component exposes its inner input that way.
+
+## Component reference
+
+The following snippets assume a form store named `form`, initialized values that match the schema, and the `elementRef` helper from above.
+
+### Text input
+
+`InputText` renders the native element as its root, so the reference reaches it without a lookup:
+
+```vue
+<Field :of="form" :path="['email']" v-slot="field">
+  <label for="profile-email">Email</label>
+  <InputText
+    id="profile-email"
+    type="email"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    v-model="field.input"
+    :invalid="!!field.errors"
+    aria-errormessage="profile-email-error"
+    @focus="field.props.onFocus"
+    @change="field.props.onChange"
+    @blur="field.props.onBlur"
+  />
+</Field>
+```
+
+`Textarea` works the same way.
+
+### Checkbox
+
+A boolean field needs the `binary` prop, and the payload is typed loosely, so narrow it:
+
+```vue
+<Field :of="form" :path="['newsletter']" v-slot="field">
+  <Checkbox
+    input-id="settings-newsletter"
+    binary
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :model-value="field.input ?? false"
+    :invalid="!!field.errors"
+    :pt="{ input: { autofocus: field.props.autofocus } }"
+    @update:model-value="(value) => (field.input = value as boolean)"
+    @focus="field.props.onFocus"
+    @change="field.props.onChange"
+    @blur="field.props.onBlur"
+  />
+  <label for="settings-newsletter">Newsletter</label>
+</Field>
+```
+
+### Select
+
+The focusable part is a span with a `combobox` role, which a `<label>` cannot name. PrimeVue writes its own `aria-label` from the current selection, so set `aria-label` explicitly to keep the name stable. Its change event is a PrimeVue payload rather than a DOM event, so forward the original:
+
+```vue
+<Field :of="form" :path="['framework']" v-slot="field">
+  <label for="project-framework">Framework</label>
+  <Select
+    label-id="project-framework"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :model-value="field.input"
+    :options="frameworks"
+    option-label="label"
+    option-value="value"
+    placeholder="Select a framework"
+    aria-label="Framework"
+    :invalid="!!field.errors"
+    :pt="{
+      label: {
+        autofocus: field.props.autofocus,
+        'aria-errormessage': 'project-framework-error',
+      },
+    }"
+    @update:model-value="(value) => (field.input = value)"
+    @focus="field.props.onFocus"
+    @change="(event) => field.props.onChange(event.originalEvent)"
+    @blur="field.props.onBlur"
+  />
+</Field>
+```
+
+### Radio group
+
+Register every button. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group:
+
+```vue
+<Field :of="form" :path="['plan']" v-slot="field">
+  <span id="plan-label">Plan</span>
+  <RadioButtonGroup
+    :name="field.props.name"
+    :model-value="field.input"
+    aria-labelledby="plan-label"
+    @update:model-value="(value) => (field.input = value)"
+  >
+    <div v-for="plan in plans" :key="plan.value">
+      <RadioButton
+        :input-id="`plan-${plan.value}`"
+        :ref="elementRef(field.props.ref)"
+        :value="plan.value"
+        :invalid="!!field.errors"
+        :pt="{
+          input: {
+            autofocus: field.props.autofocus,
+            'aria-errormessage': 'plan-error',
+          },
+        }"
+        @focus="field.props.onFocus"
+        @change="field.props.onChange"
+        @blur="field.props.onBlur"
+      />
+      <label :for="`plan-${plan.value}`">{{ plan.label }}</label>
+    </div>
+  </RadioButtonGroup>
+</Field>
+```
+
+### Slider
+
+`Slider` emits no focus or blur events of its own, so route those handlers through `pt` onto the inner range input. Its change event carries a raw number, so use `slideend` when you need the underlying DOM event:
+
+```vue
+<Field :of="form" :path="['volume']" v-slot="field">
+  <label for="settings-volume">Volume</label>
+  <Slider
+    input-id="settings-volume"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :model-value="field.input"
+    :min="0"
+    :max="100"
+    :step="1"
+    aria-label="Volume"
+    :invalid="!!field.errors"
+    :pt="{
+      input: {
+        autofocus: field.props.autofocus,
+        'aria-invalid': !!field.errors,
+        'aria-errormessage': 'settings-volume-error',
+        onFocus: field.props.onFocus,
+        onBlur: field.props.onBlur,
+      },
+    }"
+    @update:model-value="(value) => (field.input = value as number)"
+    @slideend="(event) => field.props.onChange(event.originalEvent)"
+  />
+</Field>
+```
+
+The slider's `slider` role sits on a real range input, and the default single-value mode renders exactly one.
+
+## Library-specific notes
+
+PrimeVue v5 ships its own `Form` and `FormField` components built around its resolver based validation. You do not need them with Formisch: use Formisch's <Link href="/vue/api/Form/">`Form`</Link> and <Link href="/vue/api/Field/">`Field`</Link> and let your Valibot schema drive validation.
+
+`field.props.autofocus` is a snapshot taken when the field mounts, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
+
+## Next steps
+
+Read the <Link href="/vue/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/vue/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
@@ -91,6 +91,8 @@ function elementRef(register: (element: Element | null) => void) {
 
 Two PrimeVue conventions show up here. `inputId` puts an id on the real control so a `<label for>` can reach it, while a plain `id` would land on the wrapper. The `pt` object is spread onto an internal element, so it carries any attribute or listener you need to place there. Forwarding `@focus` matters as well, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
 
+Assigning `field.input` runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit. Use `validate: 'input'` if you want them validated as the value changes.
+
 ## Displaying errors
 
 Formisch exposes errors as `[string, ...string[]] | null`. Prefer PrimeVue's own `invalid` prop over setting `aria-invalid` yourself, since the component writes `aria-invalid` onto the inner control and omits it while the field is valid:

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
@@ -98,14 +98,16 @@ Assigning `field.input` runs input-mode validation, so a form configured with `v
 Formisch exposes errors as `[string, ...string[]] | null`. Prefer PrimeVue's own `invalid` prop over setting `aria-invalid` yourself, since the component writes `aria-invalid` onto the inner control and omits it while the field is valid:
 
 ```vue
-<InputText
-  id="login-email"
-  :ref="elementRef(field.props.ref)"
-  v-model="field.input"
-  :invalid="!!field.errors"
-  aria-errormessage="login-email-error"
-/>
-<small v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</small>
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <InputText
+    id="login-email"
+    :ref="elementRef(field.props.ref)"
+    v-model="field.input"
+    :invalid="!!field.errors"
+    aria-errormessage="login-email-error"
+  />
+  <small v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</small>
+</Field>
 ```
 
 For a wrapped control, route `aria-errormessage` through `pt` so it lands on the element that carries the role. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/primevue/index.mdx
@@ -35,20 +35,22 @@ Note that `field.input` is a getter and setter rather than a method. Assigning i
 Never spread `field.props` onto a PrimeVue component. Vue treats the `ref` entry inside a `v-bind` object as a real template ref, so the spread would hand Formisch the component instance, and `focus` would fail on an object that has no `focus` method. Bind the entries individually instead:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <InputText
-    id="login-email"
-    type="email"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    v-model="field.input"
-    :invalid="!!field.errors"
-    @focus="field.props.onFocus"
-    @change="field.props.onChange"
-    @blur="field.props.onBlur"
-  />
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <InputText
+      id="login-email"
+      type="email"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      v-model="field.input"
+      :invalid="!!field.errors"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
 ```
 
 ### Controlled components
@@ -71,22 +73,24 @@ function elementRef(register: (element: Element | null) => void) {
 ```
 
 ```vue
-<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
-  <Checkbox
-    input-id="login-remember-me"
-    binary
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :model-value="field.input ?? false"
-    :invalid="!!field.errors"
-    :pt="{ input: { autofocus: field.props.autofocus } }"
-    @update:model-value="(value) => (field.input = value as boolean)"
-    @focus="field.props.onFocus"
-    @change="field.props.onChange"
-    @blur="field.props.onBlur"
-  />
-  <label for="login-remember-me">Remember me</label>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+    <Checkbox
+      input-id="login-remember-me"
+      binary
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :model-value="field.input ?? false"
+      :invalid="!!field.errors"
+      :pt="{ input: { autofocus: field.props.autofocus } }"
+      @update:model-value="(value) => (field.input = value as boolean)"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+    <label for="login-remember-me">Remember me</label>
+  </Field>
+</template>
 ```
 
 Two PrimeVue conventions show up here. `inputId` puts an id on the real control so a `<label for>` can reach it, while a plain `id` would land on the wrapper. The `pt` object is spread onto an internal element, so it carries any attribute or listener you need to place there. Forwarding `@focus` matters as well, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
@@ -98,16 +102,20 @@ Assigning `field.input` runs input-mode validation, so a form configured with `v
 Formisch exposes errors as `[string, ...string[]] | null`. Prefer PrimeVue's own `invalid` prop over setting `aria-invalid` yourself, since the component writes `aria-invalid` onto the inner control and omits it while the field is valid:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <InputText
-    id="login-email"
-    :ref="elementRef(field.props.ref)"
-    v-model="field.input"
-    :invalid="!!field.errors"
-    aria-errormessage="login-email-error"
-  />
-  <small v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</small>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <InputText
+      id="login-email"
+      :ref="elementRef(field.props.ref)"
+      v-model="field.input"
+      :invalid="!!field.errors"
+      aria-errormessage="login-email-error"
+    />
+    <small v-if="field.errors" id="login-email-error">{{
+      field.errors[0]
+    }}</small>
+  </Field>
+</template>
 ```
 
 For a wrapped control, route `aria-errormessage` through `pt` so it lands on the element that carries the role. Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
@@ -259,22 +267,24 @@ The following snippets assume a form store named `form`, initialized values that
 `InputText` renders the native element as its root, so the reference reaches it without a lookup:
 
 ```vue
-<Field :of="form" :path="['email']" v-slot="field">
-  <label for="profile-email">Email</label>
-  <InputText
-    id="profile-email"
-    type="email"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    v-model="field.input"
-    :invalid="!!field.errors"
-    aria-errormessage="profile-email-error"
-    @focus="field.props.onFocus"
-    @change="field.props.onChange"
-    @blur="field.props.onBlur"
-  />
-</Field>
+<template>
+  <Field :of="form" :path="['email']" v-slot="field">
+    <label for="profile-email">Email</label>
+    <InputText
+      id="profile-email"
+      type="email"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      v-model="field.input"
+      :invalid="!!field.errors"
+      aria-errormessage="profile-email-error"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
 ```
 
 `Textarea` works the same way.
@@ -284,22 +294,24 @@ The following snippets assume a form store named `form`, initialized values that
 A boolean field needs the `binary` prop, and the payload is typed loosely, so narrow it:
 
 ```vue
-<Field :of="form" :path="['newsletter']" v-slot="field">
-  <Checkbox
-    input-id="settings-newsletter"
-    binary
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :model-value="field.input ?? false"
-    :invalid="!!field.errors"
-    :pt="{ input: { autofocus: field.props.autofocus } }"
-    @update:model-value="(value) => (field.input = value as boolean)"
-    @focus="field.props.onFocus"
-    @change="field.props.onChange"
-    @blur="field.props.onBlur"
-  />
-  <label for="settings-newsletter">Newsletter</label>
-</Field>
+<template>
+  <Field :of="form" :path="['newsletter']" v-slot="field">
+    <Checkbox
+      input-id="settings-newsletter"
+      binary
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :model-value="field.input ?? false"
+      :invalid="!!field.errors"
+      :pt="{ input: { autofocus: field.props.autofocus } }"
+      @update:model-value="(value) => (field.input = value as boolean)"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+    <label for="settings-newsletter">Newsletter</label>
+  </Field>
+</template>
 ```
 
 ### Select
@@ -307,31 +319,33 @@ A boolean field needs the `binary` prop, and the payload is typed loosely, so na
 The focusable part is a span with a `combobox` role, which a `<label>` cannot name. PrimeVue writes its own `aria-label` from the current selection, so set `aria-label` explicitly to keep the name stable. Its change event is a PrimeVue payload rather than a DOM event, so forward the original:
 
 ```vue
-<Field :of="form" :path="['framework']" v-slot="field">
-  <label for="project-framework">Framework</label>
-  <Select
-    label-id="project-framework"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :model-value="field.input"
-    :options="frameworks"
-    option-label="label"
-    option-value="value"
-    placeholder="Select a framework"
-    aria-label="Framework"
-    :invalid="!!field.errors"
-    :pt="{
-      label: {
-        autofocus: field.props.autofocus,
-        'aria-errormessage': 'project-framework-error',
-      },
-    }"
-    @update:model-value="(value) => (field.input = value)"
-    @focus="field.props.onFocus"
-    @change="(event) => field.props.onChange(event.originalEvent)"
-    @blur="field.props.onBlur"
-  />
-</Field>
+<template>
+  <Field :of="form" :path="['framework']" v-slot="field">
+    <label for="project-framework">Framework</label>
+    <Select
+      label-id="project-framework"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :model-value="field.input"
+      :options="frameworks"
+      option-label="label"
+      option-value="value"
+      placeholder="Select a framework"
+      aria-label="Framework"
+      :invalid="!!field.errors"
+      :pt="{
+        label: {
+          autofocus: field.props.autofocus,
+          'aria-errormessage': 'project-framework-error',
+        },
+      }"
+      @update:model-value="(value) => (field.input = value)"
+      @focus="field.props.onFocus"
+      @change="(event) => field.props.onChange(event.originalEvent)"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
 ```
 
 ### Radio group
@@ -339,34 +353,36 @@ The focusable part is a span with a `combobox` role, which a `<label>` cannot na
 Register every button. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group:
 
 ```vue
-<Field :of="form" :path="['plan']" v-slot="field">
-  <span id="plan-label">Plan</span>
-  <RadioButtonGroup
-    :name="field.props.name"
-    :model-value="field.input"
-    aria-labelledby="plan-label"
-    @update:model-value="(value) => (field.input = value)"
-  >
-    <div v-for="plan in plans" :key="plan.value">
-      <RadioButton
-        :input-id="`plan-${plan.value}`"
-        :ref="elementRef(field.props.ref)"
-        :value="plan.value"
-        :invalid="!!field.errors"
-        :pt="{
-          input: {
-            autofocus: field.props.autofocus,
-            'aria-errormessage': 'plan-error',
-          },
-        }"
-        @focus="field.props.onFocus"
-        @change="field.props.onChange"
-        @blur="field.props.onBlur"
-      />
-      <label :for="`plan-${plan.value}`">{{ plan.label }}</label>
-    </div>
-  </RadioButtonGroup>
-</Field>
+<template>
+  <Field :of="form" :path="['plan']" v-slot="field">
+    <span id="plan-label">Plan</span>
+    <RadioButtonGroup
+      :name="field.props.name"
+      :model-value="field.input"
+      aria-labelledby="plan-label"
+      @update:model-value="(value) => (field.input = value)"
+    >
+      <div v-for="plan in plans" :key="plan.value">
+        <RadioButton
+          :input-id="`plan-${plan.value}`"
+          :ref="elementRef(field.props.ref)"
+          :value="plan.value"
+          :invalid="!!field.errors"
+          :pt="{
+            input: {
+              autofocus: field.props.autofocus,
+              'aria-errormessage': 'plan-error',
+            },
+          }"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <label :for="`plan-${plan.value}`">{{ plan.label }}</label>
+      </div>
+    </RadioButtonGroup>
+  </Field>
+</template>
 ```
 
 ### Slider
@@ -374,31 +390,33 @@ Register every button. Formisch keeps a list of registered elements, so each rad
 `Slider` emits no focus or blur events of its own, so route those handlers through `pt` onto the inner range input. Its change event carries a raw number, so use `slideend` when you need the underlying DOM event:
 
 ```vue
-<Field :of="form" :path="['volume']" v-slot="field">
-  <label for="settings-volume">Volume</label>
-  <Slider
-    input-id="settings-volume"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :model-value="field.input"
-    :min="0"
-    :max="100"
-    :step="1"
-    aria-label="Volume"
-    :invalid="!!field.errors"
-    :pt="{
-      input: {
-        autofocus: field.props.autofocus,
-        'aria-invalid': !!field.errors,
-        'aria-errormessage': 'settings-volume-error',
-        onFocus: field.props.onFocus,
-        onBlur: field.props.onBlur,
-      },
-    }"
-    @update:model-value="(value) => (field.input = value as number)"
-    @slideend="(event) => field.props.onChange(event.originalEvent)"
-  />
-</Field>
+<template>
+  <Field :of="form" :path="['volume']" v-slot="field">
+    <label for="settings-volume">Volume</label>
+    <Slider
+      input-id="settings-volume"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :model-value="field.input"
+      :min="0"
+      :max="100"
+      :step="1"
+      aria-label="Volume"
+      :invalid="!!field.errors"
+      :pt="{
+        input: {
+          autofocus: field.props.autofocus,
+          'aria-invalid': !!field.errors,
+          'aria-errormessage': 'settings-volume-error',
+          onFocus: field.props.onFocus,
+          onBlur: field.props.onBlur,
+        },
+      }"
+      @update:model-value="(value) => (field.input = value as number)"
+      @slideend="(event) => field.props.onChange(event.originalEvent)"
+    />
+  </Field>
+</template>
 ```
 
 The slider's `slider` role sits on a real range input, and the default single-value mode renders exactly one.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
@@ -372,7 +372,7 @@ Register every item. Formisch keeps a list of registered elements, so each radio
 
 Passing `name` makes Reka UI render a hidden native control so the value takes part in a native form submission. Formisch submits from its own store, so these extra nodes are harmless.
 
-`field.props.onChange` only triggers change-mode validation and never writes a value. Under the default settings it never fires, so the primitives above leave it unwired. If you set `validate: 'change'`, call `field.props.onChange(new Event('change'))` inside the value handler, since a button based primitive emits no native `change` event.
+`field.props.onChange` only triggers change-mode validation and never writes a value. Under the default settings it never fires, so the primitives above leave it unwired. Assigning `field.input` runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit; use `validate: 'input'` if you want them validated as the value changes.
 
 `field.props.autofocus` is a snapshot taken when the field mounts, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
 

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
@@ -1,0 +1,381 @@
+---
+title: Reka UI
+description: >-
+  Learn how to connect Formisch fields to Reka UI checkboxes, selects, radio
+  groups, sliders and other form primitives.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Reka UI
+
+[Reka UI](https://reka-ui.com) is a collection of headless, accessible primitives for Vue. This guide targets Reka UI v2. No adapter package is needed: native elements take the `field.props` spread together with `v-model`, while a primitive receives its value through `v-model` and the remaining props individually.
+
+## Installation
+
+Install Formisch, Valibot and Reka UI:
+
+```bash
+npm install @formisch/vue valibot reka-ui
+```
+
+Reka UI ships primitives only, so text inputs, textareas and buttons stay native elements that you style yourself.
+
+## Wiring patterns
+
+Choose the wiring from what you are rendering:
+
+- On a native element, spread `field.props` and bind the value with `v-model="field.input"`.
+- On a component, bind the props individually and normalize the element reference, because a spread would register the component instance instead of a DOM node.
+
+Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+
+### Spreading field.props
+
+A native input takes both bindings at once. They cannot collide: `v-model` listens for the `input` event, while the spread installs its handler on `change`:
+
+```vue
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <input v-bind="field.props" id="login-email" v-model="field.input" type="email" />
+</Field>
+```
+
+### Controlled components
+
+Do not spread `field.props` onto a component. Vue treats the `ref` entry inside a `v-bind` object as a real template ref, so the spread would hand Formisch the component instance, and `focus` would fail on an object that has no `focus` method. Bind the entries individually and unwrap the root element for the reference:
+
+```ts
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) =>
+    register(
+      instance && '$el' in instance
+        ? ((instance as ComponentPublicInstance).$el as Element | null)
+        : (instance as Element | null)
+    );
+}
+```
+
+```vue
+<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+  <CheckboxRoot
+    id="login-remember-me"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    :model-value="field.input ?? false"
+    @update:model-value="
+      (value) => (field.input = value === 'indeterminate' ? false : value)
+    "
+    @focus="field.props.onFocus"
+    @blur="field.props.onBlur"
+  >
+    <CheckboxIndicator>✓</CheckboxIndicator>
+  </CheckboxRoot>
+  <label for="login-remember-me">Remember me</label>
+</Field>
+```
+
+Reka UI renders each of these primitives with the focusable element as its root, so unwrapping `$el` is enough for <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing to reach the control. Forwarding `@focus` matters too, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Reka UI has no error primitive, so render the message yourself, give it a stable id and point the control at it while errors exist:
+
+```vue
+<input
+  v-bind="field.props"
+  id="login-email"
+  v-model="field.input"
+  :aria-invalid="!!field.errors"
+  aria-errormessage="login-email-error"
+/>
+<div v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</div>
+```
+
+Use page-unique ids rather than the field name. `field.props.name` is the JSON encoded path, such as `["email"]`, which is meant for form submission and not for `for` and `id` attributes.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/vue/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines native inputs, a controlled checkbox and accessible errors:
+
+```vue
+<script setup lang="ts">
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/vue';
+import { CheckboxIndicator, CheckboxRoot } from 'reka-ui';
+import * as v from 'valibot';
+import type { ComponentPublicInstance } from 'vue';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: { email: '', password: '', rememberMe: false },
+});
+
+const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+  console.log(output);
+};
+
+// Reka UI renders composite controls as components, so the ref callback
+// receives a component instance. Formisch calls `.focus()` on whatever it
+// gets, so unwrap the root DOM element before registering it.
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) =>
+    register(
+      instance && '$el' in instance
+        ? ((instance as ComponentPublicInstance).$el as Element | null)
+        : (instance as Element | null)
+    );
+}
+</script>
+
+<template>
+  <Form :of="loginForm" @submit="handleSubmit">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <div>
+        <label for="login-email">Email</label>
+        <input
+          v-bind="field.props"
+          id="login-email"
+          v-model="field.input"
+          type="email"
+          :aria-invalid="!!field.errors"
+          aria-errormessage="login-email-error"
+        />
+        <div v-if="field.errors" id="login-email-error">
+          {{ field.errors[0] }}
+        </div>
+      </div>
+    </Field>
+
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <div>
+        <label for="login-password">Password</label>
+        <input
+          v-bind="field.props"
+          id="login-password"
+          v-model="field.input"
+          type="password"
+          :aria-invalid="!!field.errors"
+          aria-errormessage="login-password-error"
+        />
+        <div v-if="field.errors" id="login-password-error">
+          {{ field.errors[0] }}
+        </div>
+      </div>
+    </Field>
+
+    <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+      <div>
+        <CheckboxRoot
+          id="login-remember-me"
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          :model-value="field.input ?? false"
+          :aria-invalid="!!field.errors"
+          @update:model-value="
+            (value) => (field.input = value === 'indeterminate' ? false : value)
+          "
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        >
+          <CheckboxIndicator>✓</CheckboxIndicator>
+        </CheckboxRoot>
+        <label for="login-remember-me">Remember me</label>
+      </div>
+    </Field>
+
+    <button type="submit" :disabled="loginForm.isSubmitting">Login</button>
+  </Form>
+</template>
+```
+
+The initial input keeps every control defined from its first render. The two inputs use the spread with `v-model`, while the checkbox binds its props individually and normalizes the element reference.
+
+## Component reference
+
+The following snippets assume a form store named `form`, initialized values that match the schema, and the `elementRef` helper from above.
+
+### Text input
+
+Native elements take the whole spread:
+
+```vue
+<Field :of="form" :path="['email']" v-slot="field">
+  <label for="profile-email">Email</label>
+  <input
+    v-bind="field.props"
+    id="profile-email"
+    v-model="field.input"
+    type="email"
+    :aria-invalid="!!field.errors"
+    aria-errormessage="profile-email-error"
+  />
+  <div v-if="field.errors" id="profile-email-error">{{ field.errors[0] }}</div>
+</Field>
+```
+
+A `<textarea>` works the same way. For a `v.number()` field, `v-model` on `<input type="number" />` already stores a number, so the `.number` modifier is unnecessary.
+
+### Checkbox
+
+`CheckboxRoot` reports `boolean | 'indeterminate'`, so normalize the value before storing it:
+
+```vue
+<Field :of="form" :path="['newsletter']" v-slot="field">
+  <CheckboxRoot
+    id="settings-newsletter"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    :model-value="field.input ?? false"
+    :aria-invalid="!!field.errors"
+    @update:model-value="
+      (value) => (field.input = value === 'indeterminate' ? false : value)
+    "
+    @focus="field.props.onFocus"
+    @blur="field.props.onBlur"
+  >
+    <CheckboxIndicator>✓</CheckboxIndicator>
+  </CheckboxRoot>
+  <label for="settings-newsletter">Newsletter</label>
+</Field>
+```
+
+The primitive renders a button, which a `<label>` cannot name on its own. Reka UI solves this for you: given an `id`, it derives the accessible name from the matching label element.
+
+### Select
+
+`SelectRoot` infers its value type from `modelValue`, so no cast is needed. Put the element reference and the lifecycle handlers on the trigger, which is the focusable part:
+
+```vue
+<Field :of="form" :path="['framework']" v-slot="field">
+  <label id="project-framework-label" for="project-framework">Framework</label>
+  <SelectRoot
+    :name="field.props.name"
+    :model-value="field.input"
+    @update:model-value="(value) => (field.input = value)"
+  >
+    <SelectTrigger
+      id="project-framework"
+      :ref="elementRef(field.props.ref)"
+      :autofocus="field.props.autofocus"
+      aria-labelledby="project-framework-label project-framework"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="project-framework-error"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    >
+      <SelectValue placeholder="Select a framework" />
+    </SelectTrigger>
+    <SelectPortal>
+      <SelectContent position="popper" :side-offset="4">
+        <SelectViewport>
+          <SelectItem
+            v-for="framework in frameworks"
+            :key="framework.value"
+            :value="framework.value"
+          >
+            <SelectItemText>{{ framework.label }}</SelectItemText>
+          </SelectItem>
+        </SelectViewport>
+      </SelectContent>
+    </SelectPortal>
+  </SelectRoot>
+</Field>
+```
+
+`SelectContent` renders in a portal, so give it a background and a stacking context, otherwise the options are unclickable.
+
+### Radio group
+
+Register every item. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Unlike the select, the group's payload includes `null`, so narrow it to the schema union:
+
+```vue
+<Field :of="form" :path="['plan']" v-slot="field">
+  <span id="plan-label">Plan</span>
+  <RadioGroupRoot
+    :name="field.props.name"
+    :model-value="field.input"
+    aria-labelledby="plan-label"
+    :aria-invalid="!!field.errors"
+    aria-errormessage="plan-error"
+    @update:model-value="(value) => (field.input = value as 'hobby' | 'pro')"
+  >
+    <div v-for="plan in plans" :key="plan.value">
+      <RadioGroupItem
+        :id="`plan-${plan.value}`"
+        :ref="elementRef(field.props.ref)"
+        :value="plan.value"
+        :autofocus="field.props.autofocus"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      >
+        <RadioGroupIndicator />
+      </RadioGroupItem>
+      <label :for="`plan-${plan.value}`">{{ plan.label }}</label>
+    </div>
+  </RadioGroupRoot>
+</Field>
+```
+
+### Slider
+
+`SliderRoot` works with an array of values, so wrap the number for the single thumb and unwrap it in the handler. One `SliderThumb` renders exactly one `slider` role, and Reka UI does not derive a name for it, so set `aria-label` yourself:
+
+```vue
+<Field :of="form" :path="['volume']" v-slot="field">
+  <label id="settings-volume-label">Volume</label>
+  <SliderRoot
+    :name="field.props.name"
+    :model-value="[field.input ?? 0]"
+    :min="0"
+    :max="100"
+    :step="1"
+    @update:model-value="(value) => (field.input = value?.[0])"
+  >
+    <SliderTrack>
+      <SliderRange />
+    </SliderTrack>
+    <SliderThumb
+      id="settings-volume"
+      :ref="elementRef(field.props.ref)"
+      :autofocus="field.props.autofocus"
+      aria-label="Volume"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="settings-volume-error"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+  </SliderRoot>
+</Field>
+```
+
+## Library-specific notes
+
+Passing `name` makes Reka UI render a hidden native control so the value takes part in a native form submission. Formisch submits from its own store, so these extra nodes are harmless.
+
+`field.props.onChange` only triggers change-mode validation and never writes a value. Under the default settings it never fires, so the primitives above leave it unwired. If you set `validate: 'change'`, call `field.props.onChange(new Event('change'))` inside the value handler, since a button based primitive emits no native `change` event.
+
+`field.props.autofocus` is a snapshot taken when the field mounts, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
+
+## Next steps
+
+Read the <Link href="/vue/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/vue/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
@@ -37,9 +37,16 @@ Note that `field.input` is a getter and setter rather than a method. Assigning i
 A native input takes both bindings at once. They cannot collide: `v-model` listens for the `input` event, while the spread installs its handler on `change`:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <input v-bind="field.props" id="login-email" v-model="field.input" type="email" />
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <input
+      v-bind="field.props"
+      id="login-email"
+      v-model="field.input"
+      type="email"
+    />
+  </Field>
+</template>
 ```
 
 ### Controlled components
@@ -58,23 +65,25 @@ function elementRef(register: (element: Element | null) => void) {
 ```
 
 ```vue
-<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
-  <CheckboxRoot
-    id="login-remember-me"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    :model-value="field.input ?? false"
-    @update:model-value="
-      (value) => (field.input = value === 'indeterminate' ? false : value)
-    "
-    @focus="field.props.onFocus"
-    @blur="field.props.onBlur"
-  >
-    <CheckboxIndicator>✓</CheckboxIndicator>
-  </CheckboxRoot>
-  <label for="login-remember-me">Remember me</label>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+    <CheckboxRoot
+      id="login-remember-me"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      :model-value="field.input ?? false"
+      @update:model-value="
+        (value) => (field.input = value === 'indeterminate' ? false : value)
+      "
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    >
+      <CheckboxIndicator>✓</CheckboxIndicator>
+    </CheckboxRoot>
+    <label for="login-remember-me">Remember me</label>
+  </Field>
+</template>
 ```
 
 Reka UI renders each of these primitives with the focusable element as its root, so unwrapping `$el` is enough for <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing to reach the control. Forwarding `@focus` matters too, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
@@ -84,16 +93,18 @@ Reka UI renders each of these primitives with the focusable element as its root,
 Formisch exposes errors as `[string, ...string[]] | null`. Reka UI has no error primitive, so render the message yourself, give it a stable id and point the control at it while errors exist:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <input
-    v-bind="field.props"
-    id="login-email"
-    v-model="field.input"
-    :aria-invalid="!!field.errors"
-    aria-errormessage="login-email-error"
-  />
-  <div v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</div>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <input
+      v-bind="field.props"
+      id="login-email"
+      v-model="field.input"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="login-email-error"
+    />
+    <div v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</div>
+  </Field>
+</template>
 ```
 
 Use page-unique ids rather than the field name. `field.props.name` is the JSON encoded path, such as `["email"]`, which is meant for form submission and not for `for` and `id` attributes.
@@ -220,18 +231,22 @@ The following snippets assume a form store named `form`, initialized values that
 Native elements take the whole spread:
 
 ```vue
-<Field :of="form" :path="['email']" v-slot="field">
-  <label for="profile-email">Email</label>
-  <input
-    v-bind="field.props"
-    id="profile-email"
-    v-model="field.input"
-    type="email"
-    :aria-invalid="!!field.errors"
-    aria-errormessage="profile-email-error"
-  />
-  <div v-if="field.errors" id="profile-email-error">{{ field.errors[0] }}</div>
-</Field>
+<template>
+  <Field :of="form" :path="['email']" v-slot="field">
+    <label for="profile-email">Email</label>
+    <input
+      v-bind="field.props"
+      id="profile-email"
+      v-model="field.input"
+      type="email"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="profile-email-error"
+    />
+    <div v-if="field.errors" id="profile-email-error">
+      {{ field.errors[0] }}
+    </div>
+  </Field>
+</template>
 ```
 
 A `<textarea>` works the same way. For a `v.number()` field, `v-model` on `<input type="number" />` already stores a number, so the `.number` modifier is unnecessary.
@@ -241,24 +256,26 @@ A `<textarea>` works the same way. For a `v.number()` field, `v-model` on `<inpu
 `CheckboxRoot` reports `boolean | 'indeterminate'`, so normalize the value before storing it:
 
 ```vue
-<Field :of="form" :path="['newsletter']" v-slot="field">
-  <CheckboxRoot
-    id="settings-newsletter"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    :model-value="field.input ?? false"
-    :aria-invalid="!!field.errors"
-    @update:model-value="
-      (value) => (field.input = value === 'indeterminate' ? false : value)
-    "
-    @focus="field.props.onFocus"
-    @blur="field.props.onBlur"
-  >
-    <CheckboxIndicator>✓</CheckboxIndicator>
-  </CheckboxRoot>
-  <label for="settings-newsletter">Newsletter</label>
-</Field>
+<template>
+  <Field :of="form" :path="['newsletter']" v-slot="field">
+    <CheckboxRoot
+      id="settings-newsletter"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      :model-value="field.input ?? false"
+      :aria-invalid="!!field.errors"
+      @update:model-value="
+        (value) => (field.input = value === 'indeterminate' ? false : value)
+      "
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    >
+      <CheckboxIndicator>✓</CheckboxIndicator>
+    </CheckboxRoot>
+    <label for="settings-newsletter">Newsletter</label>
+  </Field>
+</template>
 ```
 
 The primitive renders a button, which a `<label>` cannot name on its own. Reka UI solves this for you: given an `id`, it derives the accessible name from the matching label element.
@@ -268,40 +285,44 @@ The primitive renders a button, which a `<label>` cannot name on its own. Reka U
 `SelectRoot` infers its value type from `modelValue`, so no cast is needed. Put the element reference and the lifecycle handlers on the trigger, which is the focusable part:
 
 ```vue
-<Field :of="form" :path="['framework']" v-slot="field">
-  <label id="project-framework-label" for="project-framework">Framework</label>
-  <SelectRoot
-    :name="field.props.name"
-    :model-value="field.input"
-    @update:model-value="(value) => (field.input = value)"
-  >
-    <SelectTrigger
-      id="project-framework"
-      :ref="elementRef(field.props.ref)"
-      :autofocus="field.props.autofocus"
-      aria-labelledby="project-framework-label project-framework"
-      :aria-invalid="!!field.errors"
-      aria-errormessage="project-framework-error"
-      @focus="field.props.onFocus"
-      @blur="field.props.onBlur"
+<template>
+  <Field :of="form" :path="['framework']" v-slot="field">
+    <label id="project-framework-label" for="project-framework"
+      >Framework</label
     >
-      <SelectValue placeholder="Select a framework" />
-    </SelectTrigger>
-    <SelectPortal>
-      <SelectContent position="popper" :side-offset="4">
-        <SelectViewport>
-          <SelectItem
-            v-for="framework in frameworks"
-            :key="framework.value"
-            :value="framework.value"
-          >
-            <SelectItemText>{{ framework.label }}</SelectItemText>
-          </SelectItem>
-        </SelectViewport>
-      </SelectContent>
-    </SelectPortal>
-  </SelectRoot>
-</Field>
+    <SelectRoot
+      :name="field.props.name"
+      :model-value="field.input"
+      @update:model-value="(value) => (field.input = value)"
+    >
+      <SelectTrigger
+        id="project-framework"
+        :ref="elementRef(field.props.ref)"
+        :autofocus="field.props.autofocus"
+        aria-labelledby="project-framework-label project-framework"
+        :aria-invalid="!!field.errors"
+        aria-errormessage="project-framework-error"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      >
+        <SelectValue placeholder="Select a framework" />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectContent position="popper" :side-offset="4">
+          <SelectViewport>
+            <SelectItem
+              v-for="framework in frameworks"
+              :key="framework.value"
+              :value="framework.value"
+            >
+              <SelectItemText>{{ framework.label }}</SelectItemText>
+            </SelectItem>
+          </SelectViewport>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+  </Field>
+</template>
 ```
 
 `SelectContent` renders in a portal, so give it a background and a stacking context, otherwise the options are unclickable.
@@ -311,31 +332,33 @@ The primitive renders a button, which a `<label>` cannot name on its own. Reka U
 Register every item. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group. Unlike the select, the group's payload includes `null`, so narrow it to the schema union:
 
 ```vue
-<Field :of="form" :path="['plan']" v-slot="field">
-  <span id="plan-label">Plan</span>
-  <RadioGroupRoot
-    :name="field.props.name"
-    :model-value="field.input"
-    aria-labelledby="plan-label"
-    :aria-invalid="!!field.errors"
-    aria-errormessage="plan-error"
-    @update:model-value="(value) => (field.input = value as 'hobby' | 'pro')"
-  >
-    <div v-for="plan in plans" :key="plan.value">
-      <RadioGroupItem
-        :id="`plan-${plan.value}`"
-        :ref="elementRef(field.props.ref)"
-        :value="plan.value"
-        :autofocus="field.props.autofocus"
-        @focus="field.props.onFocus"
-        @blur="field.props.onBlur"
-      >
-        <RadioGroupIndicator />
-      </RadioGroupItem>
-      <label :for="`plan-${plan.value}`">{{ plan.label }}</label>
-    </div>
-  </RadioGroupRoot>
-</Field>
+<template>
+  <Field :of="form" :path="['plan']" v-slot="field">
+    <span id="plan-label">Plan</span>
+    <RadioGroupRoot
+      :name="field.props.name"
+      :model-value="field.input"
+      aria-labelledby="plan-label"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="plan-error"
+      @update:model-value="(value) => (field.input = value as 'hobby' | 'pro')"
+    >
+      <div v-for="plan in plans" :key="plan.value">
+        <RadioGroupItem
+          :id="`plan-${plan.value}`"
+          :ref="elementRef(field.props.ref)"
+          :value="plan.value"
+          :autofocus="field.props.autofocus"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        >
+          <RadioGroupIndicator />
+        </RadioGroupItem>
+        <label :for="`plan-${plan.value}`">{{ plan.label }}</label>
+      </div>
+    </RadioGroupRoot>
+  </Field>
+</template>
 ```
 
 ### Slider
@@ -343,31 +366,33 @@ Register every item. Formisch keeps a list of registered elements, so each radio
 `SliderRoot` works with an array of values, so wrap the number for the single thumb and unwrap it in the handler. One `SliderThumb` renders exactly one `slider` role, and Reka UI does not derive a name for it, so set `aria-label` yourself:
 
 ```vue
-<Field :of="form" :path="['volume']" v-slot="field">
-  <label id="settings-volume-label">Volume</label>
-  <SliderRoot
-    :name="field.props.name"
-    :model-value="[field.input ?? 0]"
-    :min="0"
-    :max="100"
-    :step="1"
-    @update:model-value="(value) => (field.input = value?.[0])"
-  >
-    <SliderTrack>
-      <SliderRange />
-    </SliderTrack>
-    <SliderThumb
-      id="settings-volume"
-      :ref="elementRef(field.props.ref)"
-      :autofocus="field.props.autofocus"
-      aria-label="Volume"
-      :aria-invalid="!!field.errors"
-      aria-errormessage="settings-volume-error"
-      @focus="field.props.onFocus"
-      @blur="field.props.onBlur"
-    />
-  </SliderRoot>
-</Field>
+<template>
+  <Field :of="form" :path="['volume']" v-slot="field">
+    <label id="settings-volume-label">Volume</label>
+    <SliderRoot
+      :name="field.props.name"
+      :model-value="[field.input ?? 0]"
+      :min="0"
+      :max="100"
+      :step="1"
+      @update:model-value="(value) => (field.input = value?.[0])"
+    >
+      <SliderTrack>
+        <SliderRange />
+      </SliderTrack>
+      <SliderThumb
+        id="settings-volume"
+        :ref="elementRef(field.props.ref)"
+        :autofocus="field.props.autofocus"
+        aria-label="Volume"
+        :aria-invalid="!!field.errors"
+        aria-errormessage="settings-volume-error"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      />
+    </SliderRoot>
+  </Field>
+</template>
 ```
 
 ## Library-specific notes

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
@@ -84,14 +84,16 @@ Reka UI renders each of these primitives with the focusable element as its root,
 Formisch exposes errors as `[string, ...string[]] | null`. Reka UI has no error primitive, so render the message yourself, give it a stable id and point the control at it while errors exist:
 
 ```vue
-<input
-  v-bind="field.props"
-  id="login-email"
-  v-model="field.input"
-  :aria-invalid="!!field.errors"
-  aria-errormessage="login-email-error"
-/>
-<div v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</div>
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <input
+    v-bind="field.props"
+    id="login-email"
+    v-model="field.input"
+    :aria-invalid="!!field.errors"
+    aria-errormessage="login-email-error"
+  />
+  <div v-if="field.errors" id="login-email-error">{{ field.errors[0] }}</div>
+</Field>
 ```
 
 Use page-unique ids rather than the field name. `field.props.name` is the JSON encoded path, such as `["email"]`, which is meant for form submission and not for `for` and `id` attributes.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/reka-ui/index.mdx
@@ -30,7 +30,7 @@ Choose the wiring from what you are rendering:
 - On a native element, spread `field.props` and bind the value with `v-model="field.input"`.
 - On a component, bind the props individually and normalize the element reference, because a spread would register the component instance instead of a DOM node.
 
-Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Do not destructure the slot: write `v-slot="field"` rather than `v-slot="{ input }"`, because destructuring copies the value out of the accessor and assignments would go nowhere.
 
 ### Spreading field.props
 

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
@@ -89,6 +89,8 @@ The composite components are thin wrappers that forward both attributes and the 
 
 Forwarding `@focus` matters, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
 
+Assigning `field.input` runs input-mode validation, so a form configured with `validate: 'change'` does not validate these controls until submit. Use `validate: 'input'` if you want them validated as the value changes.
+
 ## Displaying errors
 
 Formisch exposes errors as `[string, ...string[]] | null`. Render the message yourself, give it a stable id and point the control at it while errors exist. `aria-invalid` also switches the generated components to their destructive styling:

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
@@ -302,7 +302,7 @@ Put the element reference and the lifecycle handlers on the trigger, which is th
   <Select
     :name="field.props.name"
     :model-value="field.input"
-    @update:model-value="(value) => (field.input = value as 'angular' | 'vue')"
+    @update:model-value="(value) => (field.input = value as typeof field.input)"
   >
     <SelectTrigger
       id="project-framework"

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
@@ -50,19 +50,21 @@ function elementRef(register: (element: Element | null) => void) {
 ```
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <Input
-    id="login-email"
-    type="email"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    v-model="field.input"
-    @focus="field.props.onFocus"
-    @change="field.props.onChange"
-    @blur="field.props.onBlur"
-  />
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <Input
+      id="login-email"
+      type="email"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      v-model="field.input"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
 ```
 
 ### Controlled components
@@ -70,21 +72,23 @@ function elementRef(register: (element: Element | null) => void) {
 The composite components are thin wrappers that forward both attributes and the element reference, so the same shape applies. Because each of them renders the focusable element as its root, unwrapping `$el` is enough for <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing to reach the control:
 
 ```vue
-<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
-  <Checkbox
-    id="login-remember-me"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    :model-value="field.input ?? false"
-    @update:model-value="
-      (value) => (field.input = value === 'indeterminate' ? false : value)
-    "
-    @focus="field.props.onFocus"
-    @blur="field.props.onBlur"
-  />
-  <Label for="login-remember-me">Remember me</Label>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+    <Checkbox
+      id="login-remember-me"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      :model-value="field.input ?? false"
+      @update:model-value="
+        (value) => (field.input = value === 'indeterminate' ? false : value)
+      "
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+    <Label for="login-remember-me">Remember me</Label>
+  </Field>
+</template>
 ```
 
 Forwarding `@focus` matters, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
@@ -96,18 +100,24 @@ Assigning `field.input` runs input-mode validation, so a form configured with `v
 Formisch exposes errors as `[string, ...string[]] | null`. Render the message yourself, give it a stable id and point the control at it while errors exist. `aria-invalid` also switches the generated components to their destructive styling:
 
 ```vue
-<Field :of="loginForm" :path="['email']" v-slot="field">
-  <Input
-    id="login-email"
-    :ref="elementRef(field.props.ref)"
-    v-model="field.input"
-    :aria-invalid="!!field.errors"
-    aria-errormessage="login-email-error"
-  />
-  <p v-if="field.errors" id="login-email-error" class="text-destructive text-sm">
-    {{ field.errors[0] }}
-  </p>
-</Field>
+<template>
+  <Field :of="loginForm" :path="['email']" v-slot="field">
+    <Input
+      id="login-email"
+      :ref="elementRef(field.props.ref)"
+      v-model="field.input"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="login-email-error"
+    />
+    <p
+      v-if="field.errors"
+      id="login-email-error"
+      class="text-destructive text-sm"
+    >
+      {{ field.errors[0] }}
+    </p>
+  </Field>
+</template>
 ```
 
 Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
@@ -253,22 +263,24 @@ The following snippets assume a form store named `form`, initialized values that
 `Input` keeps the native element as its root, so attributes and the reference reach it directly:
 
 ```vue
-<Field :of="form" :path="['email']" v-slot="field">
-  <Label for="profile-email">Email</Label>
-  <Input
-    id="profile-email"
-    type="email"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    v-model="field.input"
-    :aria-invalid="!!field.errors"
-    aria-errormessage="profile-email-error"
-    @focus="field.props.onFocus"
-    @change="field.props.onChange"
-    @blur="field.props.onBlur"
-  />
-</Field>
+<template>
+  <Field :of="form" :path="['email']" v-slot="field">
+    <Label for="profile-email">Email</Label>
+    <Input
+      id="profile-email"
+      type="email"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      v-model="field.input"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="profile-email-error"
+      @focus="field.props.onFocus"
+      @change="field.props.onChange"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
 ```
 
 `Textarea` works the same way.
@@ -278,22 +290,24 @@ The following snippets assume a form store named `form`, initialized values that
 The component reports `boolean | 'indeterminate'`, so normalize the value before storing it:
 
 ```vue
-<Field :of="form" :path="['newsletter']" v-slot="field">
-  <Checkbox
-    id="settings-newsletter"
-    :ref="elementRef(field.props.ref)"
-    :name="field.props.name"
-    :autofocus="field.props.autofocus"
-    :model-value="field.input ?? false"
-    :aria-invalid="!!field.errors"
-    @update:model-value="
-      (value) => (field.input = value === 'indeterminate' ? false : value)
-    "
-    @focus="field.props.onFocus"
-    @blur="field.props.onBlur"
-  />
-  <Label for="settings-newsletter">Newsletter</Label>
-</Field>
+<template>
+  <Field :of="form" :path="['newsletter']" v-slot="field">
+    <Checkbox
+      id="settings-newsletter"
+      :ref="elementRef(field.props.ref)"
+      :name="field.props.name"
+      :autofocus="field.props.autofocus"
+      :model-value="field.input ?? false"
+      :aria-invalid="!!field.errors"
+      @update:model-value="
+        (value) => (field.input = value === 'indeterminate' ? false : value)
+      "
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+    <Label for="settings-newsletter">Newsletter</Label>
+  </Field>
+</template>
 ```
 
 ### Select
@@ -301,36 +315,40 @@ The component reports `boolean | 'indeterminate'`, so normalize the value before
 Put the element reference and the lifecycle handlers on the trigger, which is the focusable part. Unlike Reka UI's primitive, the generated component drops the value type parameter, so narrow the payload to the schema union:
 
 ```vue
-<Field :of="form" :path="['framework']" v-slot="field">
-  <Label id="project-framework-label" for="project-framework">Framework</Label>
-  <Select
-    :name="field.props.name"
-    :model-value="field.input"
-    @update:model-value="(value) => (field.input = value as typeof field.input)"
-  >
-    <SelectTrigger
-      id="project-framework"
-      :ref="elementRef(field.props.ref)"
-      :autofocus="field.props.autofocus"
-      aria-labelledby="project-framework-label project-framework"
-      :aria-invalid="!!field.errors"
-      aria-errormessage="project-framework-error"
-      @focus="field.props.onFocus"
-      @blur="field.props.onBlur"
+<template>
+  <Field :of="form" :path="['framework']" v-slot="field">
+    <Label id="project-framework-label" for="project-framework"
+      >Framework</Label
     >
-      <SelectValue placeholder="Select a framework" />
-    </SelectTrigger>
-    <SelectContent>
-      <SelectItem
-        v-for="framework in frameworks"
-        :key="framework.value"
-        :value="framework.value"
+    <Select
+      :name="field.props.name"
+      :model-value="field.input"
+      @update:model-value="(value) => (field.input = value as typeof field.input)"
+    >
+      <SelectTrigger
+        id="project-framework"
+        :ref="elementRef(field.props.ref)"
+        :autofocus="field.props.autofocus"
+        aria-labelledby="project-framework-label project-framework"
+        :aria-invalid="!!field.errors"
+        aria-errormessage="project-framework-error"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
       >
-        {{ framework.label }}
-      </SelectItem>
-    </SelectContent>
-  </Select>
-</Field>
+        <SelectValue placeholder="Select a framework" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem
+          v-for="framework in frameworks"
+          :key="framework.value"
+          :value="framework.value"
+        >
+          {{ framework.label }}
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  </Field>
+</template>
 ```
 
 ### Radio group
@@ -338,29 +356,35 @@ Put the element reference and the lifecycle handlers on the trigger, which is th
 Register every item. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group:
 
 ```vue
-<Field :of="form" :path="['plan']" v-slot="field">
-  <span id="plan-label" class="text-sm font-medium">Plan</span>
-  <RadioGroup
-    :name="field.props.name"
-    :model-value="field.input"
-    aria-labelledby="plan-label"
-    :aria-invalid="!!field.errors"
-    aria-errormessage="plan-error"
-    @update:model-value="(value) => (field.input = value as 'hobby' | 'pro')"
-  >
-    <div v-for="plan in plans" :key="plan.value" class="flex items-center gap-2">
-      <RadioGroupItem
-        :id="`plan-${plan.value}`"
-        :ref="elementRef(field.props.ref)"
-        :value="plan.value"
-        :autofocus="field.props.autofocus"
-        @focus="field.props.onFocus"
-        @blur="field.props.onBlur"
-      />
-      <Label :for="`plan-${plan.value}`">{{ plan.label }}</Label>
-    </div>
-  </RadioGroup>
-</Field>
+<template>
+  <Field :of="form" :path="['plan']" v-slot="field">
+    <span id="plan-label" class="text-sm font-medium">Plan</span>
+    <RadioGroup
+      :name="field.props.name"
+      :model-value="field.input"
+      aria-labelledby="plan-label"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="plan-error"
+      @update:model-value="(value) => (field.input = value as 'hobby' | 'pro')"
+    >
+      <div
+        v-for="plan in plans"
+        :key="plan.value"
+        class="flex items-center gap-2"
+      >
+        <RadioGroupItem
+          :id="`plan-${plan.value}`"
+          :ref="elementRef(field.props.ref)"
+          :value="plan.value"
+          :autofocus="field.props.autofocus"
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        />
+        <Label :for="`plan-${plan.value}`">{{ plan.label }}</Label>
+      </div>
+    </RadioGroup>
+  </Field>
+</template>
 ```
 
 ### Slider
@@ -382,38 +406,42 @@ const delegatedProps = reactiveOmit(props, 'class', 'thumbProps');
 Then spread it onto the thumb in the same file:
 
 ```vue
-<SliderThumb
-  v-for="(_, key) in modelValue"
-  :key="key"
-  data-slot="slider-thumb"
-  v-bind="props.thumbProps"
-/>
+<template>
+  <SliderThumb
+    v-for="(_, key) in modelValue"
+    :key="key"
+    data-slot="slider-thumb"
+    v-bind="props.thumbProps"
+  />
+</template>
 ```
 
 With that in place, the field wiring reads naturally. The value is an array, so wrap the number and unwrap it in the handler:
 
 ```vue
-<Field :of="form" :path="['volume']" v-slot="field">
-  <Label for="settings-volume">Volume</Label>
-  <Slider
-    :name="field.props.name"
-    :model-value="[field.input ?? 0]"
-    :min="0"
-    :max="100"
-    :step="1"
-    :thumb-props="{
-      id: 'settings-volume',
-      ref: elementRef(field.props.ref),
-      autofocus: field.props.autofocus,
-      'aria-label': 'Volume',
-      'aria-invalid': !!field.errors,
-      'aria-errormessage': 'settings-volume-error',
-      onFocus: field.props.onFocus,
-      onBlur: field.props.onBlur,
-    }"
-    @update:model-value="(value) => (field.input = value?.[0])"
-  />
-</Field>
+<template>
+  <Field :of="form" :path="['volume']" v-slot="field">
+    <Label for="settings-volume">Volume</Label>
+    <Slider
+      :name="field.props.name"
+      :model-value="[field.input ?? 0]"
+      :min="0"
+      :max="100"
+      :step="1"
+      :thumb-props="{
+        id: 'settings-volume',
+        ref: elementRef(field.props.ref),
+        autofocus: field.props.autofocus,
+        'aria-label': 'Volume',
+        'aria-invalid': !!field.errors,
+        'aria-errormessage': 'settings-volume-error',
+        onFocus: field.props.onFocus,
+        onBlur: field.props.onBlur,
+      }"
+      @update:model-value="(value) => (field.input = value?.[0])"
+    />
+  </Field>
+</template>
 ```
 
 ## Library-specific notes

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
@@ -32,7 +32,7 @@ Choose the wiring from what the generated component renders:
 - `Input` and `Textarea` keep the native element as their root and pass attributes through, so `v-model` plus the individual props reaches it directly.
 - `Checkbox`, `Select`, `RadioGroup` and `Slider` wrap Reka UI primitives, so bind their value through `v-model` and forward the remaining props individually.
 
-Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Do not destructure the slot: write `v-slot="field"` rather than `v-slot="{ input }"`, because destructuring copies the value out of the accessor and assignments would go nowhere.
 
 ### Spreading field.props
 
@@ -361,12 +361,10 @@ Register every item. Formisch keeps a list of registered elements, so each radio
 
 ### Slider
 
-The generated `Slider` renders its thumbs internally without a slot, so attributes placed on it land on the track container rather than on the element that carries the `slider` role. Since the component lives in your project, add a `thumbProps` passthrough to it:
+The generated `Slider` renders its thumbs internally without a slot, so attributes placed on it land on the track container rather than on the element that carries the `slider` role. Since the component lives in your project, add a `thumbProps` passthrough to `src/components/ui/slider/Slider.vue`. Extend its existing `defineProps` and keep the new prop out of what is forwarded to the root:
 
-```vue
-<script setup lang="ts">
-import type { HTMLAttributes, VNodeRef } from 'vue';
-
+```ts
+// Add `VNodeRef` to the existing `vue` type import
 const props = defineProps<
   SliderRootProps & {
     class?: HTMLAttributes['class'];
@@ -375,10 +373,9 @@ const props = defineProps<
 >();
 
 const delegatedProps = reactiveOmit(props, 'class', 'thumbProps');
-</script>
 ```
 
-Then spread it onto the thumb inside the same file:
+Then spread it onto the thumb in the same file:
 
 ```vue
 <SliderThumb

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
@@ -1,0 +1,428 @@
+---
+title: shadcn-vue
+description: >-
+  Learn how to connect Formisch fields to shadcn-vue inputs, selects, radio
+  groups, sliders and other form components.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# shadcn-vue
+
+[shadcn-vue](https://shadcn-vue.com) generates accessible components into your own project, where you can adapt them to your needs. This guide targets shadcn-vue v2 with its Reka UI v2 based components. No adapter package is needed: the input components behave like native elements, while the composite components take their value through `v-model` and the remaining field props individually.
+
+## Installation
+
+Install Formisch and Valibot, then initialize shadcn-vue and add the components used below:
+
+```bash
+npm install @formisch/vue valibot
+npx shadcn-vue@latest init
+npx shadcn-vue@latest add button input textarea label checkbox select radio-group slider
+```
+
+If your `tsconfig.json` sets both `baseUrl` and `paths`, drop `baseUrl` and keep `paths` alone, since recent TypeScript versions report the combination as deprecated.
+
+## Wiring patterns
+
+Choose the wiring from what the generated component renders:
+
+- `Input` and `Textarea` keep the native element as their root and pass attributes through, so `v-model` plus the individual props reaches it directly.
+- `Checkbox`, `Select`, `RadioGroup` and `Slider` wrap Reka UI primitives, so bind their value through `v-model` and forward the remaining props individually.
+
+Note that `field.input` is a getter and setter rather than a method. Assigning it is what stores a value and runs validation, so `v-model` and an explicit `@update:model-value` handler are equivalent. Keep the slot undestructured as `v-slot="field"`, since destructuring copies the value out of the accessor and assignments would go nowhere.
+
+### Spreading field.props
+
+Never spread `field.props` onto a component. Vue treats the `ref` entry inside a `v-bind` object as a real template ref, so the spread would hand Formisch the component instance, and `focus` would fail on an object that has no `focus` method. Bind the entries individually and unwrap the root element for the reference:
+
+```ts
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) =>
+    register(
+      instance && '$el' in instance
+        ? ((instance as ComponentPublicInstance).$el as Element | null)
+        : (instance as Element | null)
+    );
+}
+```
+
+```vue
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <Input
+    id="login-email"
+    type="email"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    v-model="field.input"
+    @focus="field.props.onFocus"
+    @change="field.props.onChange"
+    @blur="field.props.onBlur"
+  />
+</Field>
+```
+
+### Controlled components
+
+The composite components are thin wrappers that forward both attributes and the element reference, so the same shape applies. Because each of them renders the focusable element as its root, unwrapping `$el` is enough for <Link href="/methods/api/focus/">`focus`</Link> and submit-time error focusing to reach the control:
+
+```vue
+<Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+  <Checkbox
+    id="login-remember-me"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    :model-value="field.input ?? false"
+    @update:model-value="
+      (value) => (field.input = value === 'indeterminate' ? false : value)
+    "
+    @focus="field.props.onFocus"
+    @blur="field.props.onBlur"
+  />
+  <Label for="login-remember-me">Remember me</Label>
+</Field>
+```
+
+Forwarding `@focus` matters, because assigning `field.input` updates the value but only the focus handler marks the field as touched.
+
+## Displaying errors
+
+Formisch exposes errors as `[string, ...string[]] | null`. Render the message yourself, give it a stable id and point the control at it while errors exist. `aria-invalid` also switches the generated components to their destructive styling:
+
+```vue
+<Input
+  id="login-email"
+  :ref="elementRef(field.props.ref)"
+  v-model="field.input"
+  :aria-invalid="!!field.errors"
+  aria-errormessage="login-email-error"
+/>
+<p v-if="field.errors" id="login-email-error" class="text-destructive text-sm">
+  {{ field.errors[0] }}
+</p>
+```
+
+Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.
+
+By default, Formisch validates on submit and revalidates on input. The <Link href="/vue/guides/validation/">validation guide</Link> explains how to change that timing.
+
+## Login form example
+
+This complete example combines two inputs, a controlled checkbox and accessible errors:
+
+```vue
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Field, Form, type SubmitHandler, useForm } from '@formisch/vue';
+import * as v from 'valibot';
+import type { ComponentPublicInstance } from 'vue';
+
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your email.'),
+    v.email('The email address is badly formatted.')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
+  ),
+  rememberMe: v.optional(v.boolean(), false),
+});
+
+const loginForm = useForm({
+  schema: LoginSchema,
+  initialInput: { email: '', password: '', rememberMe: false },
+});
+
+const handleSubmit: SubmitHandler<typeof LoginSchema> = (output) => {
+  console.log(output);
+};
+
+// shadcn-vue components are wrappers, so the ref callback receives a component
+// instance instead of a DOM node. Formisch calls `.focus()` on whatever it is
+// given, so unwrap the root element before registering it.
+function elementRef(register: (element: Element | null) => void) {
+  return (instance: Element | ComponentPublicInstance | null) =>
+    register(
+      instance && '$el' in instance
+        ? ((instance as ComponentPublicInstance).$el as Element | null)
+        : (instance as Element | null)
+    );
+}
+</script>
+
+<template>
+  <Form :of="loginForm" class="flex flex-col gap-4" @submit="handleSubmit">
+    <Field :of="loginForm" :path="['email']" v-slot="field">
+      <div class="flex flex-col gap-1">
+        <Label for="login-email">Email</Label>
+        <Input
+          id="login-email"
+          type="email"
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          v-model="field.input"
+          :aria-invalid="!!field.errors"
+          aria-errormessage="login-email-error"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <p
+          v-if="field.errors"
+          id="login-email-error"
+          class="text-destructive text-sm"
+        >
+          {{ field.errors[0] }}
+        </p>
+      </div>
+    </Field>
+
+    <Field :of="loginForm" :path="['password']" v-slot="field">
+      <div class="flex flex-col gap-1">
+        <Label for="login-password">Password</Label>
+        <Input
+          id="login-password"
+          type="password"
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          v-model="field.input"
+          :aria-invalid="!!field.errors"
+          aria-errormessage="login-password-error"
+          @focus="field.props.onFocus"
+          @change="field.props.onChange"
+          @blur="field.props.onBlur"
+        />
+        <p
+          v-if="field.errors"
+          id="login-password-error"
+          class="text-destructive text-sm"
+        >
+          {{ field.errors[0] }}
+        </p>
+      </div>
+    </Field>
+
+    <Field :of="loginForm" :path="['rememberMe']" v-slot="field">
+      <div class="flex items-center gap-2">
+        <Checkbox
+          id="login-remember-me"
+          :ref="elementRef(field.props.ref)"
+          :name="field.props.name"
+          :autofocus="field.props.autofocus"
+          :model-value="field.input ?? false"
+          :aria-invalid="!!field.errors"
+          @update:model-value="
+            (value) => (field.input = value === 'indeterminate' ? false : value)
+          "
+          @focus="field.props.onFocus"
+          @blur="field.props.onBlur"
+        />
+        <Label for="login-remember-me">Remember me</Label>
+      </div>
+    </Field>
+
+    <Button type="submit" :disabled="loginForm.isSubmitting">Login</Button>
+  </Form>
+</template>
+```
+
+The initial input keeps every control defined from its first render. The inputs use `v-model` with the individual props, while the checkbox normalizes the indeterminate value before storing it.
+
+## Component reference
+
+The following snippets assume a form store named `form`, initialized values that match the schema, and the `elementRef` helper from above.
+
+### Text input
+
+`Input` keeps the native element as its root, so attributes and the reference reach it directly:
+
+```vue
+<Field :of="form" :path="['email']" v-slot="field">
+  <Label for="profile-email">Email</Label>
+  <Input
+    id="profile-email"
+    type="email"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    v-model="field.input"
+    :aria-invalid="!!field.errors"
+    aria-errormessage="profile-email-error"
+    @focus="field.props.onFocus"
+    @change="field.props.onChange"
+    @blur="field.props.onBlur"
+  />
+</Field>
+```
+
+`Textarea` works the same way.
+
+### Checkbox
+
+The component reports `boolean | 'indeterminate'`, so normalize the value before storing it:
+
+```vue
+<Field :of="form" :path="['newsletter']" v-slot="field">
+  <Checkbox
+    id="settings-newsletter"
+    :ref="elementRef(field.props.ref)"
+    :name="field.props.name"
+    :autofocus="field.props.autofocus"
+    :model-value="field.input ?? false"
+    :aria-invalid="!!field.errors"
+    @update:model-value="
+      (value) => (field.input = value === 'indeterminate' ? false : value)
+    "
+    @focus="field.props.onFocus"
+    @blur="field.props.onBlur"
+  />
+  <Label for="settings-newsletter">Newsletter</Label>
+</Field>
+```
+
+### Select
+
+Put the element reference and the lifecycle handlers on the trigger, which is the focusable part. Unlike Reka UI's primitive, the generated component drops the value type parameter, so narrow the payload to the schema union:
+
+```vue
+<Field :of="form" :path="['framework']" v-slot="field">
+  <Label id="project-framework-label" for="project-framework">Framework</Label>
+  <Select
+    :name="field.props.name"
+    :model-value="field.input"
+    @update:model-value="(value) => (field.input = value as 'angular' | 'vue')"
+  >
+    <SelectTrigger
+      id="project-framework"
+      :ref="elementRef(field.props.ref)"
+      :autofocus="field.props.autofocus"
+      aria-labelledby="project-framework-label project-framework"
+      :aria-invalid="!!field.errors"
+      aria-errormessage="project-framework-error"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    >
+      <SelectValue placeholder="Select a framework" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem
+        v-for="framework in frameworks"
+        :key="framework.value"
+        :value="framework.value"
+      >
+        {{ framework.label }}
+      </SelectItem>
+    </SelectContent>
+  </Select>
+</Field>
+```
+
+### Radio group
+
+Register every item. Formisch keeps a list of registered elements, so each radio registers itself just like a native radio group:
+
+```vue
+<Field :of="form" :path="['plan']" v-slot="field">
+  <span id="plan-label" class="text-sm font-medium">Plan</span>
+  <RadioGroup
+    :name="field.props.name"
+    :model-value="field.input"
+    aria-labelledby="plan-label"
+    :aria-invalid="!!field.errors"
+    aria-errormessage="plan-error"
+    @update:model-value="(value) => (field.input = value as 'hobby' | 'pro')"
+  >
+    <div v-for="plan in plans" :key="plan.value" class="flex items-center gap-2">
+      <RadioGroupItem
+        :id="`plan-${plan.value}`"
+        :ref="elementRef(field.props.ref)"
+        :value="plan.value"
+        :autofocus="field.props.autofocus"
+        @focus="field.props.onFocus"
+        @blur="field.props.onBlur"
+      />
+      <Label :for="`plan-${plan.value}`">{{ plan.label }}</Label>
+    </div>
+  </RadioGroup>
+</Field>
+```
+
+### Slider
+
+The generated `Slider` renders its thumbs internally without a slot, so attributes placed on it land on the track container rather than on the element that carries the `slider` role. Since the component lives in your project, add a `thumbProps` passthrough to it:
+
+```vue
+<script setup lang="ts">
+import type { HTMLAttributes, VNodeRef } from 'vue';
+
+const props = defineProps<
+  SliderRootProps & {
+    class?: HTMLAttributes['class'];
+    thumbProps?: HTMLAttributes & { autofocus?: boolean; ref?: VNodeRef };
+  }
+>();
+
+const delegatedProps = reactiveOmit(props, 'class', 'thumbProps');
+</script>
+```
+
+Then spread it onto the thumb inside the same file:
+
+```vue
+<SliderThumb
+  v-for="(_, key) in modelValue"
+  :key="key"
+  data-slot="slider-thumb"
+  v-bind="props.thumbProps"
+/>
+```
+
+With that in place, the field wiring reads naturally. The value is an array, so wrap the number and unwrap it in the handler:
+
+```vue
+<Field :of="form" :path="['volume']" v-slot="field">
+  <Label for="settings-volume">Volume</Label>
+  <Slider
+    :name="field.props.name"
+    :model-value="[field.input ?? 0]"
+    :min="0"
+    :max="100"
+    :step="1"
+    :thumb-props="{
+      id: 'settings-volume',
+      ref: elementRef(field.props.ref),
+      autofocus: field.props.autofocus,
+      'aria-label': 'Volume',
+      'aria-invalid': !!field.errors,
+      'aria-errormessage': 'settings-volume-error',
+      onFocus: field.props.onFocus,
+      onBlur: field.props.onBlur,
+    }"
+    @update:model-value="(value) => (field.input = value?.[0])"
+  />
+</Field>
+```
+
+## Library-specific notes
+
+shadcn-vue also generates a `form` component, but it is built on VeeValidate and Zod. You do not need it with Formisch: use Formisch's <Link href="/vue/api/Form/">`Form`</Link> and <Link href="/vue/api/Field/">`Field`</Link> together with `Label` and your own error paragraph.
+
+Because shadcn-vue builds on Reka UI, the wiring in our <Link href="/vue/guides/reka-ui/">Reka UI guide</Link> applies to the primitives underneath. The difference is that you own the generated source, so a missing prop can be forwarded rather than worked around.
+
+`field.props.autofocus` is a snapshot taken when the field mounts, not a reactive value. Formisch moves focus to the first invalid field after a failed submit on its own.
+
+## Next steps
+
+Read the <Link href="/vue/guides/input-components/">input components</Link> guide to package repeated wiring into reusable controls, the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide for the underlying pattern, and the <Link href="/vue/guides/validation/">validation</Link> guide for validation timing.

--- a/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(integration-guides)/shadcn-vue/index.mdx
@@ -96,16 +96,18 @@ Assigning `field.input` runs input-mode validation, so a form configured with `v
 Formisch exposes errors as `[string, ...string[]] | null`. Render the message yourself, give it a stable id and point the control at it while errors exist. `aria-invalid` also switches the generated components to their destructive styling:
 
 ```vue
-<Input
-  id="login-email"
-  :ref="elementRef(field.props.ref)"
-  v-model="field.input"
-  :aria-invalid="!!field.errors"
-  aria-errormessage="login-email-error"
-/>
-<p v-if="field.errors" id="login-email-error" class="text-destructive text-sm">
-  {{ field.errors[0] }}
-</p>
+<Field :of="loginForm" :path="['email']" v-slot="field">
+  <Input
+    id="login-email"
+    :ref="elementRef(field.props.ref)"
+    v-model="field.input"
+    :aria-invalid="!!field.errors"
+    aria-errormessage="login-email-error"
+  />
+  <p v-if="field.errors" id="login-email-error" class="text-destructive text-sm">
+    {{ field.errors[0] }}
+  </p>
+</Field>
 ```
 
 Use page-unique ids rather than the field name, because `field.props.name` is the JSON encoded path, such as `["email"]`.

--- a/website/src/routes/(docs)/vue/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(main-concepts)/input-components/index.mdx
@@ -158,6 +158,7 @@ Component libraries render their own components instead of plain elements, so yo
     <DatePicker
       :ref="(instance) => field.props.ref(instance?.$el ?? instance)"
       :name="field.props.name"
+      :autofocus="field.props.autofocus"
       v-model="field.input"
       @focus="field.props.onFocus"
       @blur="field.props.onBlur"
@@ -166,7 +167,7 @@ Component libraries render their own components instead of plain elements, so yo
 </template>
 ```
 
-Assigning `field.input` updates the field value and triggers validation, while the focus handler is what marks the field as touched. For more details, see the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide.
+Assigning `field.input` updates the field value and triggers validation, while the focus handler is what marks the field as touched. Unwrapping `$el` only helps when the component's root is the focusable element; if it wraps its control in a container, reach for the library's own input ref instead, or accept that <Link href="/methods/api/focus/">`focus`</Link> cannot target that field. For more details, see the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide.
 
 For ready-made wiring recipes, check out our integration guides:
 

--- a/website/src/routes/(docs)/vue/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(main-concepts)/input-components/index.mdx
@@ -148,6 +148,32 @@ const model = defineModel<string | number | undefined>({ required: true });
 </template>
 ```
 
+## Using component libraries
+
+Component libraries render their own components instead of plain elements, so you cannot use `v-bind="field.props"` on them. Vue treats the `ref` entry inside that object as a real template ref, which would register the component instance rather than a DOM element. Bind the entries individually and set the value through `v-model`:
+
+```vue
+<template>
+  <Field :of="form" :path="['date']" v-slot="field">
+    <DatePicker
+      :ref="(instance) => field.props.ref(instance?.$el ?? instance)"
+      :name="field.props.name"
+      v-model="field.input"
+      @focus="field.props.onFocus"
+      @blur="field.props.onBlur"
+    />
+  </Field>
+</template>
+```
+
+Assigning `field.input` updates the field value and triggers validation, while the focus handler is what marks the field as touched. For more details, see the <Link href="/vue/guides/controlled-fields/">controlled fields</Link> guide.
+
+For ready-made wiring recipes, check out our integration guides:
+
+- <Link href="/vue/guides/shadcn-vue/">shadcn-vue</Link>
+- <Link href="/vue/guides/reka-ui/">Reka UI</Link>
+- <Link href="/vue/guides/primevue/">PrimeVue</Link>
+
 ## Next steps
 
 Now that you know how to create reusable input components, continue to the <Link href="/vue/guides/handle-submission/">handle submission</Link> guide to learn how to process form data when the user submits the form.

--- a/website/src/routes/(docs)/vue/guides/(main-concepts)/input-components/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(main-concepts)/input-components/index.mdx
@@ -171,6 +171,7 @@ Assigning `field.input` updates the field value and triggers validation, while t
 For ready-made wiring recipes, check out our integration guides:
 
 - <Link href="/vue/guides/shadcn-vue/">shadcn-vue</Link>
+- <Link href="/vue/guides/ark-ui/">Ark UI</Link>
 - <Link href="/vue/guides/reka-ui/">Reka UI</Link>
 - <Link href="/vue/guides/primevue/">PrimeVue</Link>
 

--- a/website/src/routes/(docs)/vue/guides/menu.md
+++ b/website/src/routes/(docs)/vue/guides/menu.md
@@ -36,5 +36,6 @@
 ## Integration guides
 
 - [shadcn-vue](/vue/guides/shadcn-vue/)
+- [Ark UI](/vue/guides/ark-ui/)
 - [Reka UI](/vue/guides/reka-ui/)
 - [PrimeVue](/vue/guides/primevue/)

--- a/website/src/routes/(docs)/vue/guides/menu.md
+++ b/website/src/routes/(docs)/vue/guides/menu.md
@@ -32,3 +32,9 @@
 - [From VeeValidate](/vue/guides/migrate-from-vee-validate/)
 - [From FormKit](/vue/guides/migrate-from-formkit/)
 - [From TanStack Form](/vue/guides/migrate-from-tanstack-form/)
+
+## Integration guides
+
+- [shadcn-vue](/vue/guides/shadcn-vue/)
+- [Reka UI](/vue/guides/reka-ui/)
+- [PrimeVue](/vue/guides/primevue/)


### PR DESCRIPTION
Follow-up to #191, which added the first integration guide. This extends the format to four more React libraries and to Solid, Svelte, Vue and React Native, for 16 guides in total.

## What is included

| Framework | Guides |
| --- | --- |
| React | shadcn/ui (existing), Ark UI, Base UI, Chakra UI, Mantine, React Aria |
| Solid | Kobalte, Ark UI |
| Svelte | shadcn-svelte, Ark UI, Bits UI |
| Vue | shadcn-vue, Ark UI, Reka UI, PrimeVue |
| React Native | React Native Paper, gluestack-ui |

Each guide follows the structure the shadcn/ui guide settled on: installation, the two wiring patterns, error display, a complete login form, a component reference for text input, checkbox, select, radio group and slider, and any library specific notes.

Ark UI gets a guide on all four frameworks it publishes for, and those four cross-link each other. Its component API is identical everywhere, since the parts share the same state machines, so those guides differ only where the framework does.

The authoring skill is generalized in its own commit. It now carries a porting table for how the field contract is spelled per framework and a React Native variant of the structure.

## Verification

Every snippet is transcribed from code that compiled and ran. For each library a throwaway app was scaffolded, built for production and driven in a browser, checking that errors render and are associated with their control, that focus marks a field as touched, that `focus` reaches the intended element, that sliders render one thumb per value, that visible labels are the accessible names, and that the submitted output contains the parsed values.

The non-React apps were built against locally packed framework tarballs, because the parameterless focus and blur handler types are not released yet.

Where something genuinely does not work, the guide says so instead of hiding it. Kobalte's hidden select does not delegate focus to its trigger, Ark UI's slider input is not focusable on any framework, React Aria's select exposes no native element, and gluestack's select cannot be opened programmatically.

Two guides also show the small edit needed in generated source to reach a slider thumb, which is fair since the reader owns that code.

## Notes for review

- Vue had no component library section in its input components and controlled fields guides. Both were added in Vue's own `v-model` idiom.
- The Svelte Ark UI guide places the focus handlers on the visible trigger and thumb rather than on the hidden input. Measured: with them on the hidden part, a keyboard user focusing the control never marks the field touched. The same refinement may be worth applying to the React, Solid and Vue Ark UI guides, which currently follow the hidden-part placement.
- The website build passes, and 64 checks against the built site confirm every route, edit link, menu placement and cross-link list.

## Release dependency

The Solid, Svelte and Vue guides document the parameterless `onFocus` and `onBlur` handler types from #186, which are not in `1.0.0-rc.0` yet. Those packages need a release before or with the next website deploy, otherwise readers copying the examples will hit type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added integration guides for popular React, React Native, Solid, Svelte, and Vue component libraries.
  * Added practical examples covering fields, selection controls, validation, accessibility, focus handling, and form submission.
  * Improved controlled-field guidance with framework-specific wiring recommendations.
  * Added navigation links connecting the new guides throughout the documentation.
  * Expanded React Native guidance for gluestack-ui and React Native Paper.
  * Added guidance for Ark UI, Base UI, Chakra UI, Mantine, PrimeVue, Reka UI, and related libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->