### PR TITLE
Add RSS feed for blog

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,4 +1,5 @@
 public/og/
+public/feed.xml
 public/sitemap.xml
 public/llms.txt
 public/llms-*.txt

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "qwik build",
     "build.client": "vite build",
-    "build.cloudflare": "pnpm --filter @formisch/core --filter @formisch/methods --filter @formisch/qwik build && pnpm sitemap && pnpm llms && pnpm agents && pnpm og && pnpm build",
+    "build.cloudflare": "pnpm --filter @formisch/core --filter @formisch/methods --filter @formisch/qwik build && pnpm sitemap && pnpm llms && pnpm agents && pnpm og && pnpm rss && pnpm build",
     "build.preview": "vite build --ssr src/entry.preview.tsx",
     "build.server": "vite build -c adapters/static/vite.config.ts",
     "build.types": "tsc --incremental --noEmit",
@@ -29,6 +29,7 @@
     "agents": "tsm ./scripts/agents.ts",
     "og": "tsm ./scripts/og-images.ts",
     "preview": "qwik build preview && vite preview --open",
+    "rss": "tsm ./scripts/rss.ts",
     "sitemap": "tsm ./scripts/sitemap.ts",
     "start": "vite --open --mode ssr",
     "qwik": "qwik"

--- a/website/public/_headers
+++ b/website/public/_headers
@@ -13,6 +13,9 @@
   Cache-Control: public, max-age=31536000, s-maxage=31536000, immutable
 /og/*
   Cache-Control: public, max-age=86400, s-maxage=86400
+/feed.xml
+  Content-Type: application/atom+xml; charset=utf-8
+  Cache-Control: public, max-age=3600, s-maxage=3600
 
 # The splat greedily matches any path prefix at any depth, including none
 /*q-data.json

--- a/website/scripts/rss.ts
+++ b/website/scripts/rss.ts
@@ -1,0 +1,111 @@
+import matter from 'gray-matter';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ORIGIN = 'https://formisch.dev';
+
+/**
+ * Escapes XML special characters of text nodes and attribute values.
+ *
+ * @param text The text to escape.
+ *
+ * @returns The escaped text.
+ */
+function escapeXml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+// Read frontmatter of every blog post and sort posts by date
+const postsDirPath = path.join('src', 'routes', 'blog', '(posts)');
+const posts = fs
+  .readdirSync(postsDirPath)
+  .map((dirName) => ({
+    name: dirName,
+    path: path.join(postsDirPath, dirName, 'index.mdx'),
+  }))
+  .filter((post) => fs.existsSync(post.path))
+  .map((post) => {
+    const { data } = matter.read(post.path);
+    const published = new Date(data.published);
+    // The feed is consumed by external readers, so fail the build on
+    // incomplete frontmatter instead of emitting invalid entries. Atom
+    // requires at least one author and a valid date for every entry.
+    if (
+      typeof data.title !== 'string' ||
+      data.title.trim() === '' ||
+      typeof data.description !== 'string' ||
+      data.description.trim() === '' ||
+      // A forgotten value is parsed as `null`, which `Date` maps to 1970
+      !data.published ||
+      Number.isNaN(published.getTime()) ||
+      !Array.isArray(data.authors) ||
+      data.authors.length === 0 ||
+      data.authors.some(
+        (author) => typeof author !== 'string' || author.trim() === ''
+      )
+    ) {
+      throw new Error(
+        `Missing or invalid frontmatter in blog post: ${post.path}`
+      );
+    }
+    return {
+      name: post.name,
+      title: data.title as string,
+      description: data.description as string,
+      published,
+      authors: data.authors as string[],
+    };
+  })
+  .sort(
+    // The name is a tie-breaker for equal dates to keep the output
+    // deterministic, as the file system does not guarantee entry order
+    (post1, post2) =>
+      post2.published.getTime() - post1.published.getTime() ||
+      (post1.name < post2.name ? -1 : 1)
+  );
+
+// Create an Atom entry for each blog post
+const entries = posts
+  .map((post) => {
+    const url = `${ORIGIN}/blog/${post.name}/`;
+    const date = post.published.toISOString();
+    return (
+      `<entry>` +
+      `<title>${escapeXml(post.title)}</title>` +
+      `<link rel="alternate" type="text/html" href="${url}"/>` +
+      `<link rel="enclosure" type="image/png" href="${ORIGIN}/og/blog_${post.name}.png"/>` +
+      `<id>${url}</id>` +
+      `<published>${date}</published>` +
+      `<updated>${date}</updated>` +
+      post.authors
+        .map(
+          (author) =>
+            `<author><name>${escapeXml(author)}</name><uri>https://github.com/${escapeXml(author)}</uri></author>`
+        )
+        .join('') +
+      `<summary>${escapeXml(post.description)}</summary>` +
+      `</entry>`
+    );
+  })
+  .join('');
+
+// Write feed.xml to public directory. The feed date is the newest post's
+// date instead of the build time to keep the output deterministic.
+fs.writeFileSync(
+  path.join('public', 'feed.xml'),
+  `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">` +
+    `<title>Formisch Blog</title>` +
+    `<subtitle>Official announcements, project updates, and practical insights from the Formisch team.</subtitle>` +
+    `<link rel="self" type="application/atom+xml" href="${ORIGIN}/feed.xml"/>` +
+    `<link rel="alternate" type="text/html" href="${ORIGIN}/blog/"/>` +
+    `<id>${ORIGIN}/blog/</id>` +
+    `<updated>${posts[0].published.toISOString()}</updated>` +
+    `<icon>${ORIGIN}/icon-32px.png</icon>` +
+    entries +
+    `</feed>`
+);

--- a/website/src/components/HeadContent.tsx
+++ b/website/src/components/HeadContent.tsx
@@ -110,6 +110,12 @@ export const HeadContent = component$(() => {
       />
       <link rel="canonical" href={location.url.href} />
       <link rel="manifest" href="/manifest.json" />
+      <link
+        rel="alternate"
+        type="application/atom+xml"
+        title="Formisch Blog"
+        href="/feed.xml"
+      />
 
       {/* Icon metadata */}
       <link rel="icon" type="image/png" sizes="32x32" href="/icon-32px.png" />

--- a/website/src/components/PostCover.tsx
+++ b/website/src/components/PostCover.tsx
@@ -1,5 +1,6 @@
 import { component$ } from '@qwik.dev/core';
 import clsx from 'clsx';
+import { RssIcon } from '~/icons';
 
 type PostCoverProps = {
   variant: 'blog' | 'post';
@@ -18,8 +19,6 @@ export const PostCover = component$<PostCoverProps>(({ variant, label }) => (
       variant === 'post' &&
         'mx-3 lg:mx-10 lg:rounded-[32px] lg:border-[3px] 2xl:mx-0'
     )}
-    role="img"
-    aria-label="Post cover image"
   >
     <div class="absolute -right-[20%] -top-[60%] h-[150%] w-[60%] bg-[radial-gradient(theme(--color-yellow-500/.06),transparent_70%)] dark:bg-[radial-gradient(theme(--color-yellow-300/.05),transparent_70%)]" />
     <div class="absolute -bottom-[60%] -left-[20%] h-[150%] w-[60%] bg-[radial-gradient(theme(--color-sky-600/.08),transparent_70%)] dark:bg-[radial-gradient(theme(--color-sky-400/.08),transparent_70%)]" />
@@ -29,8 +28,21 @@ export const PostCover = component$<PostCoverProps>(({ variant, label }) => (
         variant === 'blog' && 'md:text-[3vw] lg:text-3xl',
         variant === 'post' && 'lg:text-7xl'
       )}
+      role="img"
+      aria-label="Post cover image"
     >
       {label}
     </div>
+    {variant === 'post' && (
+      <a
+        class="absolute right-4 top-4 text-slate-500 transition-colors hover:text-slate-700 lg:right-6 lg:top-6 dark:text-slate-400 dark:hover:text-slate-300"
+        href="/feed.xml"
+        target="_blank"
+        rel="noreferrer"
+        aria-label="RSS feed"
+      >
+        <RssIcon class="h-5 lg:h-6" />
+      </a>
+    )}
   </div>
 ));

--- a/website/src/icons/RssIcon.tsx
+++ b/website/src/icons/RssIcon.tsx
@@ -1,0 +1,18 @@
+import { component$, type PropsOf } from '@qwik.dev/core';
+
+export const RssIcon = component$<PropsOf<'svg'>>((props) => (
+  <svg
+    viewBox="0 0 48 48"
+    role="img"
+    aria-label="RSS icon"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width={4}
+    {...props}
+  >
+    <path d="M8 22a18 18 0 0 1 18 18M8 8a32 32 0 0 1 32 32" />
+    <circle cx="10" cy="38" r="2" fill="currentColor" />
+  </svg>
+));

--- a/website/src/icons/index.ts
+++ b/website/src/icons/index.ts
@@ -22,6 +22,7 @@ export * from './PlusIcon';
 export * from './PreactIcon';
 export * from './QwikIcon';
 export * from './ReactIcon';
+export * from './RssIcon';
 export * from './SearchIcon';
 export * from './ShareIcon';
 export * from './SolidIcon';

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "cd ../packages/core && pnpm build && cd ../methods && pnpm build && cd ../../frameworks/qwik && pnpm build && cd ../../website && pnpm sitemap && pnpm llms && pnpm agents && pnpm og && pnpm build",
+  "buildCommand": "cd ../packages/core && pnpm build && cd ../methods && pnpm build && cd ../../frameworks/qwik && pnpm build && cd ../../website && pnpm sitemap && pnpm llms && pnpm agents && pnpm og && pnpm rss && pnpm build",
   "outputDirectory": "dist",
   "cleanUrls": true,
   "trailingSlash": true,
@@ -209,6 +209,19 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=86400, s-maxage=86400"
+        }
+      ]
+    },
+    {
+      "source": "/feed.xml",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/atom+xml; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, s-maxage=3600"
         }
       ]
     },


### PR DESCRIPTION
Adds an Atom 1.0 feed for the blog at [formisch.dev/feed.xml](https://formisch.dev/feed.xml), generated at build time as a static file.

Mirrors open-circle/valibot#1597.

## Why Atom instead of RSS 2.0

Our post authors are GitHub usernames without email addresses. Atom's `<author><name>/<uri>` handles that natively, while RSS 2.0's `<author>` element requires an email and would need Dublin Core plus Atom namespaces bolted on to express the same thing. Dates are plain `toISOString()` output (RFC 3339). The file is still called `feed.xml`, which every reader picks up.

## Implementation

`scripts/rss.ts` reads the frontmatter of every post in `src/routes/blog/(posts)` with `gray-matter` and writes `public/feed.xml`, following the same pattern as our existing `sitemap`, `llms`, `agents` and `og` scripts. It is wired into both production build chains (`build.cloudflare` and the Vercel `buildCommand`), and the generated file is gitignored.

Entries carry the `description` from the frontmatter as their `<summary>`. Full post content would require converting MDX to HTML, which is not worth a new dependency for a feed. No XML library either, just a four-line `escapeXml` helper for text nodes and attribute values.

The feed lives at the root rather than under `/blog/` because `/blog/*` is in `run_worker_first` in `wrangler.jsonc`, so a feed under that prefix would be handled by the Worker and get documentation `Link` headers it should not have.

The output is deterministic: the feed-level `<updated>` is the newest post's date rather than the build time, and posts with equal dates are ordered by directory name, since `readdirSync` does not guarantee an order. Incomplete frontmatter (missing title, description, published date or authors) throws with the file path and fails the build, so we never publish broken entries to external readers.

## Discovery

- Autodiscovery `<link rel="alternate" type="application/atom+xml">` in `HeadContent`, so readers find the feed from any page
- An RSS icon in the top right corner of the cover image on post pages. `role="img"` and its label moved from the cover root to the inner label element, otherwise the root's image role would hide the new link from the accessibility tree.
- `Content-Type: application/atom+xml; charset=utf-8` and a one hour cache set in both `public/_headers` and `vercel.json`, since the inferred type would otherwise be a generic `application/xml`

## Verification

The generated feed passes `xmllint` and the [W3C Feed Validation Service](https://validator.w3.org/feed/) as valid Atom 1.0. Prettier, ESLint and `tsc` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Atom RSS feed at `/feed.xml`, including blog post metadata, authors, publication dates, and links.
  - Added RSS feed discovery metadata and visible feed links with an RSS icon.
  - Configured appropriate XML content handling and one-hour caching for the feed.
- **Bug Fixes**
  - Improved accessibility for post cover content and RSS feed controls.
- **Chores**
  - Updated production builds to generate the RSS feed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->