### PR TITLE
Configure Worker observability

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -11,7 +11,7 @@
   "compatibility_date": "2026-06-04",
   "main": "./worker/index.ts",
   "observability": {
-    "enabled": false,
+    "enabled": true,
     "head_sampling_rate": 1,
     "logs": {
       "enabled": true,

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -10,6 +10,21 @@
   "name": "formisch-website",
   "compatibility_date": "2026-06-04",
   "main": "./worker/index.ts",
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1,
+    },
+  },
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",


### PR DESCRIPTION
## Summary

- configure Workers Logs and invocation logs in `wrangler.jsonc`
- enable and persist Workers Traces
- preserve the dashboard's 100% sampling settings

## Why

The observability settings currently live only in the Cloudflare dashboard. Declaring them in Wrangler keeps deployments consistent and prevents future deploys from overwriting the dashboard configuration.

## Validation

- `prettier --check website/wrangler.jsonc`
- `wrangler deploy --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled enhanced Cloudflare Workers observability.
  * Added full-rate sampling, persisted logs and traces, invocation logging, and observability logs for improved monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->