### PR TITLE
fix: handle missing dynamic array field stores

### DIFF
--- a/frameworks/angular/src/directives/FormischControl/FormischControl.test.ts
+++ b/frameworks/angular/src/directives/FormischControl/FormischControl.test.ts
@@ -58,7 +58,7 @@ describe('FormischControl', () => {
     const internalFieldStore = getFieldStore(
       fixture.componentInstance.form[INTERNAL],
       ['email']
-    );
+    )!;
     expect(internalFieldStore.elements).toContain(input);
   });
 
@@ -68,7 +68,7 @@ describe('FormischControl', () => {
     const internalFieldStore = getFieldStore(
       fixture.componentInstance.form[INTERNAL],
       ['email']
-    );
+    )!;
     expect(internalFieldStore.elements).toContain(input);
 
     fixture.destroy();
@@ -282,8 +282,8 @@ describe('FormischControl re-registration', () => {
       fixture.nativeElement as HTMLElement
     ).querySelector<HTMLInputElement>('[data-testid="input"]')!;
     const internalFormStore = fixture.componentInstance.form[INTERNAL];
-    const fieldAStore = getFieldStore(internalFormStore, ['a']);
-    const fieldBStore = getFieldStore(internalFormStore, ['b']);
+    const fieldAStore = getFieldStore(internalFormStore, ['a'])!;
+    const fieldBStore = getFieldStore(internalFormStore, ['b'])!;
 
     expect(fieldAStore.elements).toContain(input);
     expect(fieldBStore.elements).not.toContain(input);
@@ -333,8 +333,12 @@ describe('FormischControl path changes', () => {
       fixture.nativeElement as HTMLElement
     ).querySelector<HTMLInputElement>('[data-testid="input"]')!;
     const internalFormStore = fixture.componentInstance.form[INTERNAL];
-    const firstStore = getFieldStore(internalFormStore, ['items', 0, 'label']);
-    const secondStore = getFieldStore(internalFormStore, ['items', 1, 'label']);
+    const firstStore = getFieldStore(internalFormStore, ['items', 0, 'label'])!;
+    const secondStore = getFieldStore(internalFormStore, [
+      'items',
+      1,
+      'label',
+    ])!;
 
     expect(firstStore.elements).toContain(input);
     expect(secondStore.elements).not.toContain(input);

--- a/frameworks/angular/src/directives/FormischField/FormischField.test.ts
+++ b/frameworks/angular/src/directives/FormischField/FormischField.test.ts
@@ -83,7 +83,7 @@ describe('FormischField', () => {
     const internalFieldStore = getFieldStore(
       fixture.componentInstance.form[INTERNAL],
       ['email']
-    );
+    )!;
     expect(internalFieldStore.elements).toContain(input);
   });
 

--- a/frameworks/angular/src/functions/injectField/injectField.test.ts
+++ b/frameworks/angular/src/functions/injectField/injectField.test.ts
@@ -99,7 +99,7 @@ describe('injectField', () => {
 
   it('registers and unregisters the element via the control ref', () => {
     const { form, field } = setup();
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
     const element = document.createElement('input');
     const cleanup = field[CONTROL].ref(element);
     expect(internalFieldStore.elements).toContain(element);
@@ -110,7 +110,7 @@ describe('injectField', () => {
 
   it('does not register an element that is already present', () => {
     const { form, field } = setup();
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
     const element = document.createElement('input');
     // Simulate an array reorder having already transferred the element
     internalFieldStore.elements.push(element);
@@ -120,14 +120,14 @@ describe('injectField', () => {
 
   it('ignores a null element passed to the control ref', () => {
     const { form, field } = setup();
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
     expect(field[CONTROL].ref(null)).toBeUndefined();
     expect(internalFieldStore.elements).toHaveLength(0);
   });
 
   it('keeps initialElements in sync when unregistering the element', () => {
     const { form, field } = setup();
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
     const element = document.createElement('input');
     const cleanup = field[CONTROL].ref(element);
     expect(internalFieldStore.initialElements).toContain(element);
@@ -147,7 +147,7 @@ describe('injectField', () => {
       const form = injectForm({ schema: Schema });
       return { form, field: injectField(form, { path: ['email'] }) };
     });
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
 
     const connected = document.createElement('input');
     document.body.append(connected);
@@ -167,7 +167,7 @@ describe('injectField', () => {
 
   it('does not touch initialElements when a reorder moved the elements', () => {
     const { form, field } = setup();
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
     const element = document.createElement('input');
     const cleanup = field[CONTROL].ref(element);
     const initialElements = internalFieldStore.initialElements;
@@ -187,7 +187,7 @@ describe('injectField', () => {
       const form = injectForm({ schema: Schema });
       return { form, field: injectField(form, { path: ['email'] }) };
     });
-    const internalFieldStore = getFieldStore(form[INTERNAL], ['email']);
+    const internalFieldStore = getFieldStore(form[INTERNAL], ['email'])!;
 
     const element = document.createElement('input');
     field[CONTROL].ref(element);

--- a/frameworks/angular/src/functions/injectField/injectField.ts
+++ b/frameworks/angular/src/functions/injectField/injectField.ts
@@ -70,8 +70,8 @@ export function injectField(
   const destroyRef = inject(DestroyRef);
   const path = computed(() => readSignalOrValue(config.path));
   const internalFormStore = computed(() => readSignalOrValue(form)[INTERNAL]);
-  const internalFieldStore = computed(() =>
-    getFieldStore(internalFormStore(), path())
+  const internalFieldStore = computed(
+    () => getFieldStore(internalFormStore(), path())!
   );
 
   destroyRef.onDestroy(() => {

--- a/frameworks/preact/src/hooks/useField/useField.ts
+++ b/frameworks/preact/src/hooks/useField/useField.ts
@@ -50,8 +50,8 @@ export function useField<
 export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
   const pathSignal = usePathSignal(config.path);
   const internalFormStore = form[INTERNAL];
-  const internalFieldStore = useComputed(() =>
-    getFieldStore(internalFormStore, pathSignal.value)
+  const internalFieldStore = useComputed(
+    () => getFieldStore(internalFormStore, pathSignal.value)!
   );
 
   useSignalEffect(() => {

--- a/frameworks/qwik/src/hooks/useField/useField.ts
+++ b/frameworks/qwik/src/hooks/useField/useField.ts
@@ -55,8 +55,8 @@ export function useField<
 export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
   const pathSignal = usePathSignal(config.path);
   const internalFormStore = form[INTERNAL];
-  const internalFieldStore = useComputed$(() =>
-    getFieldStore(internalFormStore, pathSignal.value)
+  const internalFieldStore = useComputed$(
+    () => getFieldStore(internalFormStore, pathSignal.value)!
   );
 
   useTask$(({ track, cleanup }) => {

--- a/frameworks/react-native/src/hooks/useField/useField.ts
+++ b/frameworks/react-native/src/hooks/useField/useField.ts
@@ -50,7 +50,7 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
   useSignals();
 
   const internalFormStore = form[INTERNAL];
-  const internalFieldStore = getFieldStore(internalFormStore, config.path);
+  const internalFieldStore = getFieldStore(internalFormStore, config.path)!;
 
   // Track the last registered element instance as a fallback for React 18,
   // which ignores ref cleanup functions and calls the ref with `null` instead

--- a/frameworks/react/src/hooks/useField/useField.ts
+++ b/frameworks/react/src/hooks/useField/useField.ts
@@ -50,7 +50,7 @@ export function useField(form: FormStore, config: UseFieldConfig): FieldStore {
   useSignals();
 
   const internalFormStore = form[INTERNAL];
-  const internalFieldStore = getFieldStore(internalFormStore, config.path);
+  const internalFieldStore = getFieldStore(internalFormStore, config.path)!;
 
   useEffect(() => {
     return () => {

--- a/frameworks/solid/src/primitives/useField/useField.test.tsx
+++ b/frameworks/solid/src/primitives/useField/useField.test.tsx
@@ -416,7 +416,9 @@ describe('useField', () => {
         const form = createForm({ schema });
         return { form, field: useField(form, { path: ['name'] }) };
       });
-      const internalFieldStore = getFieldStore(result.form[INTERNAL], ['name']);
+      const internalFieldStore = getFieldStore(result.form[INTERNAL], [
+        'name',
+      ])!;
       const element = document.createElement('input');
       // Simulate an array reorder having already transferred the element
       internalFieldStore.elements.push(element);
@@ -457,17 +459,17 @@ describe('useField', () => {
 
       render(() => <Test />);
       expect(
-        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])!.elements
       ).toHaveLength(1);
 
       swap(formStore!, { path: ['todos'], at: 0, and: 1 });
 
       await vi.waitFor(() => {
         expect(
-          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])!.elements
         ).toHaveLength(1);
         expect(
-          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label'])!.elements
         ).toHaveLength(1);
       });
     });
@@ -488,7 +490,7 @@ describe('useField', () => {
       const element = screen.getByTestId('input');
       const internalFieldStore = getFieldStore(capturedForm![INTERNAL], [
         'name',
-      ]);
+      ])!;
       expect(internalFieldStore.initialElements).toContain(element);
 
       // Simulate an array operation moving the elements to another store

--- a/frameworks/solid/src/primitives/useField/useField.ts
+++ b/frameworks/solid/src/primitives/useField/useField.ts
@@ -52,8 +52,8 @@ export function useField(
 ): FieldStore {
   const getPath = createMemo(() => unwrap(config).path);
   const getInternalFormStore = createMemo(() => unwrap(form)[INTERNAL]);
-  const getInternalFieldStore = createMemo(() =>
-    getFieldStore(getInternalFormStore(), getPath())
+  const getInternalFieldStore = createMemo(
+    () => getFieldStore(getInternalFormStore(), getPath())!
   );
 
   const getInput = createMemo(() => getFieldInput(getInternalFieldStore()));

--- a/frameworks/svelte/src/runes/useField/useField.svelte.ts
+++ b/frameworks/svelte/src/runes/useField/useField.svelte.ts
@@ -52,7 +52,7 @@ export function useField(
 ): FieldStore {
   const path = $derived(unwrap(config).path);
   const internalFormStore = $derived(unwrap(form)[INTERNAL]);
-  const internalFieldStore = $derived(getFieldStore(internalFormStore, path));
+  const internalFieldStore = $derived(getFieldStore(internalFormStore, path)!);
 
   const input = $derived(getFieldInput(internalFieldStore));
   const isTouched = $derived(getFieldBool(internalFieldStore, 'isTouched'));

--- a/frameworks/svelte/src/runes/useField/useField.test.ts
+++ b/frameworks/svelte/src/runes/useField/useField.test.ts
@@ -333,7 +333,7 @@ describe('useField', () => {
       });
       const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
         'name',
-      ]);
+      ])!;
       const element = document.createElement('input');
       // Simulate an array reorder having already transferred the element
       internalFieldStore.elements.push(element);
@@ -368,7 +368,7 @@ describe('useField', () => {
       });
 
       expect(
-        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])!.elements
       ).toHaveLength(1);
 
       swap(formStore!, { path: ['todos'], at: 0, and: 1 });
@@ -376,10 +376,10 @@ describe('useField', () => {
 
       await vi.waitFor(() => {
         expect(
-          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])!.elements
         ).toHaveLength(1);
         expect(
-          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label'])!.elements
         ).toHaveLength(1);
       });
     });

--- a/frameworks/vue/src/composables/useField/useField.test.ts
+++ b/frameworks/vue/src/composables/useField/useField.test.ts
@@ -1,5 +1,5 @@
 import { getFieldStore, INTERNAL } from '@formisch/core/vue';
-import { swap } from '@formisch/methods/vue';
+import { remove, swap } from '@formisch/methods/vue';
 import { mount } from '@vue/test-utils';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
@@ -381,6 +381,60 @@ describe('useField', () => {
       wrapper.unmount();
 
       expect(document.querySelector('[data-testid="input"]')).toBeNull();
+    });
+
+    test('should clean up a dynamic array field when its item is removed', async () => {
+      const schema = v.object({
+        todos: v.array(v.object({ label: v.string() })),
+      });
+      let formStore: FormStore<typeof schema> | undefined;
+
+      const Row = defineComponent({
+        props: {
+          form: { type: Object, required: true },
+          index: { type: Number, required: true },
+        },
+        setup(props) {
+          const field = useField(
+            props.form as FormStore<typeof schema>,
+            () => ({ path: ['todos', props.index, 'label'] as const })
+          );
+          return () => h('input', { 'data-testid': 'input', ...field.props });
+        },
+      });
+
+      const Test = defineComponent({
+        setup() {
+          const form = useForm({
+            schema,
+            initialInput: { todos: [{ label: 'a' }] },
+          });
+          formStore = form;
+          const fieldArray = useFieldArray(form, { path: ['todos'] });
+          return () =>
+            fieldArray.items.map((id, index) =>
+              h(Row, { key: id, form, index })
+            );
+        },
+      });
+
+      const wrapper = mount(Test, { attachTo: document.body });
+      const removedFieldStore = getFieldStore(formStore![INTERNAL], [
+        'todos',
+        0,
+        'label',
+      ])!;
+      expect(removedFieldStore.elements).toHaveLength(1);
+
+      remove(formStore!, { path: ['todos'], at: 0 });
+      await wrapper.vm.$nextTick();
+
+      expect(document.querySelector('[data-testid="input"]')).toBeNull();
+      expect(removedFieldStore.elements).toEqual([]);
+      expect(removedFieldStore.initialElements).toEqual([]);
+      expect(
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])
+      ).toBeUndefined();
     });
 
     test('should not register an element that is already present', () => {

--- a/frameworks/vue/src/composables/useField/useField.test.ts
+++ b/frameworks/vue/src/composables/useField/useField.test.ts
@@ -391,7 +391,7 @@ describe('useField', () => {
       });
       const internalFieldStore = getFieldStore(result.current.form[INTERNAL], [
         'name',
-      ]);
+      ])!;
       const element = document.createElement('input');
       // Simulate an array reorder having already transferred the element
       internalFieldStore.elements.push(element);
@@ -436,17 +436,17 @@ describe('useField', () => {
 
       mount(Test, { attachTo: document.body });
       expect(
-        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+        getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])!.elements
       ).toHaveLength(1);
 
       swap(formStore!, { path: ['todos'], at: 0, and: 1 });
 
       await vi.waitFor(() => {
         expect(
-          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label']).elements
+          getFieldStore(formStore![INTERNAL], ['todos', 0, 'label'])!.elements
         ).toHaveLength(1);
         expect(
-          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label']).elements
+          getFieldStore(formStore![INTERNAL], ['todos', 1, 'label'])!.elements
         ).toHaveLength(1);
       });
     });
@@ -469,7 +469,7 @@ describe('useField', () => {
       const element = document.querySelector('[data-testid="input"]');
       const internalFieldStore = getFieldStore(capturedForm![INTERNAL], [
         'name',
-      ]);
+      ])!;
       expect(internalFieldStore.initialElements).toContain(element);
 
       // Simulate an array operation moving the elements to another store

--- a/frameworks/vue/src/composables/useField/useField.ts
+++ b/frameworks/vue/src/composables/useField/useField.ts
@@ -52,8 +52,8 @@ export function useField(
 ): FieldStore {
   const path = computed(() => toValue(config).path);
   const internalFormStore = computed(() => toValue(form)[INTERNAL]);
-  const internalFieldStore = computed(() =>
-    getFieldStore(internalFormStore.value, path.value)
+  const internalFieldStore = computed(
+    () => getFieldStore(internalFormStore.value, path.value)!
   );
 
   onUnmounted(() => {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the library will be documented in this file.
 - Remove internal `validators` counter in favor of the new internal validation ID
 - Fix select and file inputs bound to array fields to always return an array by deriving the value shape from the schema instead of the `multiple` attribute
 - Fix checkbox groups to stay array-valued with one rendered option and to ignore disabled or same-named controls from other forms
+- Fix field store lookups for missing dynamic array items and prevent array item tracking in Vue
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/packages/core/src/field/getFieldStore/getFieldStore.test.ts
+++ b/packages/core/src/field/getFieldStore/getFieldStore.test.ts
@@ -58,4 +58,31 @@ describe('getFieldStore', () => {
       }
     }
   });
+
+  test('should return undefined for missing array item store', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: [] },
+    });
+    expect(getFieldStore(store, ['items', 0])).toBeUndefined();
+  });
+
+  test('should return undefined for child of missing array item store', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+    expect(getFieldStore(store, ['items', 0, 'name'])).toBeUndefined();
+  });
+
+  test('should return undefined for removed array item store', () => {
+    const store = createTestStore(v.object({ items: v.array(v.string()) }), {
+      initialInput: { items: ['a', 'b'] },
+    });
+    const itemsStore = store.children.items;
+    expect(itemsStore.kind).toBe('array');
+    if (itemsStore.kind === 'array') {
+      itemsStore.items.value = itemsStore.items.value.slice(0, 1);
+      expect(getFieldStore(store, ['items', 1])).toBeUndefined();
+    }
+  });
 });

--- a/packages/core/src/field/getFieldStore/getFieldStore.ts
+++ b/packages/core/src/field/getFieldStore/getFieldStore.ts
@@ -1,3 +1,4 @@
+import { untrack } from '../../framework/index.ts';
 import type {
   InternalFieldStore,
   InternalFormStore,
@@ -11,23 +12,28 @@ import type {
  * @param internalFormStore The form store to traverse.
  * @param path The path to the field store.
  *
- * @returns The field store.
+ * @returns The field store, or `undefined` if a dynamic array item in the path
+ * does not exist at runtime.
  */
 // @__NO_SIDE_EFFECTS__
 export function getFieldStore(
   internalFormStore: InternalFormStore,
   path: Path
-): InternalFieldStore {
+): InternalFieldStore | undefined {
   // Start at form store root
   let internalFieldStore: InternalFieldStore = internalFormStore;
 
   // Traverse path to find target field store
-  // TODO: This does not guard against paths that exist in the type but not at
-  // runtime (e.g. a not-yet-created dynamic array index), so navigating into a
-  // missing child returns `undefined` and crashes consumers like the deep error
-  // methods. A clean fix likely throws an error or returns `undefined` here
-  // and handles it in all callers.
   for (const key of path) {
+    // Return early if array item does not exist at runtime
+    if (
+      internalFieldStore.kind === 'array' &&
+      // @ts-expect-error
+      !untrack(() => internalFieldStore.items.value)[key]
+    ) {
+      return undefined;
+    }
+
     // Navigate to child at current path key
     // @ts-expect-error
     internalFieldStore = internalFieldStore.children[key];

--- a/packages/core/src/field/getFieldStore/getFieldStore.vue.ts
+++ b/packages/core/src/field/getFieldStore/getFieldStore.vue.ts
@@ -1,9 +1,15 @@
-import { untrack } from '../../framework/index.ts';
 import type {
   InternalFieldStore,
   InternalFormStore,
   Path,
 } from '../../types/index.ts';
+
+// This framework-specific implementation exists because Vue does not expose a
+// public `untrack` API. Formisch creates its Vue signals with `shallowRef`,
+// which stores the current value in `_value`. Reading it directly avoids
+// subscribing an enclosing computed or watcher to array item changes. The
+// public `value` fallback preserves the previous behavior if Vue removes this
+// internal property in the future.
 
 /**
  * Returns the field store at the specified path by traversing the form store's
@@ -29,7 +35,9 @@ export function getFieldStore(
     if (
       internalFieldStore.kind === 'array' &&
       // @ts-expect-error
-      untrack(() => internalFieldStore.items.value)[key] === undefined
+      (internalFieldStore.items._value ?? internalFieldStore.items.value)[
+        key
+      ] === undefined
     ) {
       return undefined;
     }

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the library will be documented in this file.
 - Add React Native build output with `@formisch/methods/react-native` export (issue #117)
 - Add React Native specific `handleSubmit` and `setInput` functions that work without a native form element (issue #117)
 - Remove `submit` from the React Native build output as it depends on a native form element (issue #117)
+- Fix methods to ignore paths inside missing dynamic array items instead of throwing
 
 ## v1.0.0-rc.0 (June 23, 2026)
 

--- a/packages/methods/src/focus/focus.ts
+++ b/packages/methods/src/focus/focus.ts
@@ -37,5 +37,8 @@ export function focus<
   form: BaseFormStore<TSchema>,
   config: FocusFieldConfig<TSchema, TFieldPath>
 ): void {
-  focusFieldElement(getFieldStore(form[INTERNAL], config.path));
+  const internalFieldStore = getFieldStore(form[INTERNAL], config.path);
+  if (internalFieldStore) {
+    focusFieldElement(internalFieldStore);
+  }
 }

--- a/packages/methods/src/getDeepError/getDeepError.test.ts
+++ b/packages/methods/src/getDeepError/getDeepError.test.ts
@@ -109,6 +109,15 @@ describe('getDeepError', () => {
     expect(getDeepError(store)).toBe('Name is required');
   });
 
+  test('should return null for missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(getDeepError(store, { path: ['items', 0, 'name'] })).toBeNull();
+  });
+
   test('should include form-level errors', () => {
     const store = createTestStore(v.object({ name: v.string() }));
     store.errors.value = ['Form is invalid'];

--- a/packages/methods/src/getDeepError/getDeepError.ts
+++ b/packages/methods/src/getDeepError/getDeepError.ts
@@ -76,18 +76,22 @@ export function getDeepError(
     | GetFormDeepErrorConfig
     | GetFieldDeepErrorConfig<FormSchema, RequiredPath>
 ): string | null {
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  if (!internalFieldStore) {
+    return null;
+  }
+
   // Walk the field store tree in depth-first order and stop at the first
   // field with errors, so errors of a field surface before its descendants
   let deepError: string | null = null;
-  walkFieldStore(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    (internalFieldStore) => {
-      const errors = internalFieldStore.errors.value;
-      if (errors) {
-        deepError = errors[0];
-        return true;
-      }
+  walkFieldStore(internalFieldStore, (internalFieldStore) => {
+    const errors = internalFieldStore.errors.value;
+    if (errors) {
+      deepError = errors[0];
+      return true;
     }
-  );
+  });
   return deepError;
 }

--- a/packages/methods/src/getDeepErrorEntries/getDeepErrorEntries.test.ts
+++ b/packages/methods/src/getDeepErrorEntries/getDeepErrorEntries.test.ts
@@ -106,6 +106,17 @@ describe('getDeepErrorEntries', () => {
     ]);
   });
 
+  test('should return empty array for missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(
+      getDeepErrorEntries(store, { path: ['items', 0, 'name'] })
+    ).toStrictEqual([]);
+  });
+
   test('should include form-level errors with an empty path', () => {
     const store = createTestStore(v.object({ name: v.string() }));
     store.errors.value = ['Form is invalid'];

--- a/packages/methods/src/getDeepErrorEntries/getDeepErrorEntries.ts
+++ b/packages/methods/src/getDeepErrorEntries/getDeepErrorEntries.ts
@@ -92,21 +92,25 @@ export function getDeepErrorEntries(
     | GetFormDeepErrorEntriesConfig
     | GetFieldDeepErrorEntriesConfig<FormSchema, RequiredPath>
 ): DeepErrorEntry[] {
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  if (!internalFieldStore) {
+    return [];
+  }
+
   // Collect entries of errored fields by walking the field store tree, reading
   // each field's own path instead of reconstructing it during the walk
   const entries: DeepErrorEntry[] = [];
-  walkFieldStore(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    (internalFieldStore) => {
-      // Emit an entry if field has errors; form-level errors are emitted
-      const errors = internalFieldStore.errors.value;
-      if (errors) {
-        entries.push({
-          path: internalFieldStore.path,
-          errors,
-        });
-      }
+  walkFieldStore(internalFieldStore, (internalFieldStore) => {
+    // Emit an entry if field has errors; form-level errors are emitted
+    const errors = internalFieldStore.errors.value;
+    if (errors) {
+      entries.push({
+        path: internalFieldStore.path,
+        errors,
+      });
     }
-  );
+  });
   return entries;
 }

--- a/packages/methods/src/getDeepErrorEntry/getDeepErrorEntry.test.ts
+++ b/packages/methods/src/getDeepErrorEntry/getDeepErrorEntry.test.ts
@@ -126,6 +126,15 @@ describe('getDeepErrorEntry', () => {
     });
   });
 
+  test('should return null for missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(getDeepErrorEntry(store, { path: ['items', 0, 'name'] })).toBeNull();
+  });
+
   test('should include form-level errors with an empty path', () => {
     const store = createTestStore(v.object({ name: v.string() }));
     store.errors.value = ['Form is invalid'];

--- a/packages/methods/src/getDeepErrorEntry/getDeepErrorEntry.ts
+++ b/packages/methods/src/getDeepErrorEntry/getDeepErrorEntry.ts
@@ -83,21 +83,25 @@ export function getDeepErrorEntry(
     | GetFormDeepErrorEntryConfig
     | GetFieldDeepErrorEntryConfig<FormSchema, RequiredPath>
 ): DeepErrorEntry | null {
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  if (!internalFieldStore) {
+    return null;
+  }
+
   // Walk the field store tree in depth-first order and stop at the first
   // field with errors, so errors of a field surface before its descendants
   let entry: DeepErrorEntry | null = null;
-  walkFieldStore(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    (internalFieldStore) => {
-      const errors = internalFieldStore.errors.value;
-      if (errors) {
-        entry = {
-          path: internalFieldStore.path,
-          errors,
-        };
-        return true;
-      }
+  walkFieldStore(internalFieldStore, (internalFieldStore) => {
+    const errors = internalFieldStore.errors.value;
+    if (errors) {
+      entry = {
+        path: internalFieldStore.path,
+        errors,
+      };
+      return true;
     }
-  );
+  });
   return entry;
 }

--- a/packages/methods/src/getDeepErrors/getDeepErrors.test.ts
+++ b/packages/methods/src/getDeepErrors/getDeepErrors.test.ts
@@ -123,6 +123,15 @@ describe('getDeepErrors', () => {
     expect(result).toBeNull();
   });
 
+  test('should return null for missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(getDeepErrors(store, { path: ['items', 0, 'name'] })).toBeNull();
+  });
+
   test('should include form-level errors', () => {
     const store = createTestStore(v.object({ name: v.string() }));
     store.errors.value = ['Form is invalid'];

--- a/packages/methods/src/getDeepErrors/getDeepErrors.ts
+++ b/packages/methods/src/getDeepErrors/getDeepErrors.ts
@@ -74,19 +74,23 @@ export function getDeepErrors(
     | GetFormDeepErrorsConfig
     | GetFieldDeepErrorsConfig<FormSchema, RequiredPath>
 ): [string, ...string[]] | null {
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  if (!internalFieldStore) {
+    return null;
+  }
+
   let deepErrors: [string, ...string[]] | null = null;
-  walkFieldStore(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    (internalFieldStore) => {
-      const errors = internalFieldStore.errors.value;
-      if (errors) {
-        if (deepErrors) {
-          deepErrors.push(...errors);
-        } else {
-          deepErrors = [...errors];
-        }
+  walkFieldStore(internalFieldStore, (internalFieldStore) => {
+    const errors = internalFieldStore.errors.value;
+    if (errors) {
+      if (deepErrors) {
+        deepErrors.push(...errors);
+      } else {
+        deepErrors = [...errors];
       }
     }
-  );
+  });
   return deepErrors;
 }

--- a/packages/methods/src/getDirtyInput/getDirtyInput.ts
+++ b/packages/methods/src/getDirtyInput/getDirtyInput.ts
@@ -83,7 +83,10 @@ export function getDirtyInput(
     | GetFormDirtyInputConfig
     | GetFieldDirtyInputConfig<FormSchema, RequiredPath>
 ): unknown {
-  return getDirtyFieldInput(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL]
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return internalFieldStore
+    ? getDirtyFieldInput(internalFieldStore)
+    : undefined;
 }

--- a/packages/methods/src/getDirtyPaths/getDirtyPaths.ts
+++ b/packages/methods/src/getDirtyPaths/getDirtyPaths.ts
@@ -79,10 +79,12 @@ export function getDirtyPaths(
   // Collect paths of dirty fields via a single recursive walk, reading each
   // field's own path instead of reconstructing it during the walk
   const paths: RequiredPath[] = [];
-  collectDirtyPaths(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    paths
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  if (internalFieldStore) {
+    collectDirtyPaths(internalFieldStore, paths);
+  }
 
   // Return collected paths
   return paths;

--- a/packages/methods/src/getErrors/getErrors.test.ts
+++ b/packages/methods/src/getErrors/getErrors.test.ts
@@ -70,4 +70,13 @@ describe('getErrors', () => {
 
     expect(result).toEqual(['Item error']);
   });
+
+  test('should return null for missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(getErrors(store, { path: ['items', 0, 'name'] })).toBeNull();
+  });
 });

--- a/packages/methods/src/getErrors/getErrors.ts
+++ b/packages/methods/src/getErrors/getErrors.ts
@@ -69,7 +69,8 @@ export function getErrors(
   form: BaseFormStore,
   config?: GetFormErrorsConfig | GetFieldErrorsConfig<FormSchema, RequiredPath>
 ): [string, ...string[]] | null {
-  return (
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL]
-  ).errors.value;
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return internalFieldStore?.errors.value ?? null;
 }

--- a/packages/methods/src/getInput/getInput.test.ts
+++ b/packages/methods/src/getInput/getInput.test.ts
@@ -69,6 +69,15 @@ describe('getInput', () => {
     expect(result).toBe('John');
   });
 
+  test('should return undefined for missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(getInput(store, { path: ['items', 0, 'name'] })).toBeUndefined();
+  });
+
   test('should return undefined for uninitialized field', () => {
     const store = createTestStore(v.object({ name: v.optional(v.string()) }));
 

--- a/packages/methods/src/getInput/getInput.ts
+++ b/packages/methods/src/getInput/getInput.ts
@@ -74,7 +74,8 @@ export function getInput(
   form: BaseFormStore,
   config?: GetFormInputConfig | GetFieldInputConfig<FormSchema, RequiredPath>
 ): unknown {
-  return getFieldInput(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL]
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return internalFieldStore ? getFieldInput(internalFieldStore) : undefined;
 }

--- a/packages/methods/src/insert/insert.test.ts
+++ b/packages/methods/src/insert/insert.test.ts
@@ -265,6 +265,19 @@ describe('insert', () => {
     }
   });
 
+  test('should ignore missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({
+        groups: v.array(v.object({ items: v.array(v.string()) })),
+      }),
+      { initialInput: { groups: [] } }
+    );
+
+    expect(() =>
+      insert(store, { path: ['groups', 0, 'items'], initialInput: 'foo' })
+    ).not.toThrow();
+  });
+
   test('should insert into nested array', () => {
     const store = createTestStore(
       v.object({ outer: v.object({ items: v.array(v.string()) }) }),

--- a/packages/methods/src/insert/insert.test.ts
+++ b/packages/methods/src/insert/insert.test.ts
@@ -276,6 +276,14 @@ describe('insert', () => {
     expect(() =>
       insert(store, { path: ['groups', 0, 'items'], initialInput: 'foo' })
     ).not.toThrow();
+
+    const groupsStore = store.children.groups;
+    expect(groupsStore.kind).toBe('array');
+    if (groupsStore.kind === 'array') {
+      expect(groupsStore.items.value).toEqual([]);
+      expect(groupsStore.children).toEqual([]);
+      expect(groupsStore.isDirty.value).toBe(false);
+    }
   });
 
   test('should insert into nested array', () => {

--- a/packages/methods/src/insert/insert.ts
+++ b/packages/methods/src/insert/insert.ts
@@ -5,6 +5,7 @@ import {
   createId,
   type DeepPartial,
   type FormSchema,
+  getFieldStore,
   initializeFieldStore,
   INTERNAL,
   type InternalArrayStore,
@@ -60,84 +61,85 @@ export function insert<
   // Get internal form store
   const internalFormStore = form[INTERNAL];
 
-  // Walk path to get internal field store and mark all parents as having input
-  let internalFieldStore: InternalFieldStore = internalFormStore;
-  for (let index = 0; index < config.path.length; index++) {
-    // @ts-expect-error
-    internalFieldStore = internalFieldStore.children[config.path[index]];
-    if (index < config.path.length - 1) {
+  // Get internal array store
+  const internalArrayStore = getFieldStore(internalFormStore, config.path) as
+    | InternalArrayStore
+    | undefined;
+  if (internalArrayStore) {
+    // Walk path and mark all parents as having input
+    let internalFieldStore: InternalFieldStore = internalFormStore;
+    for (let index = 0; index < config.path.length - 1; index++) {
+      // @ts-expect-error
+      internalFieldStore = internalFieldStore.children[config.path[index]];
       internalFieldStore.input.value = true;
     }
-  }
 
-  // Last internal field store of path is array store
-  const internalArrayStore = internalFieldStore as InternalArrayStore;
+    // Get current items of field array
+    const items = untrack(() => internalArrayStore.items.value);
 
-  // Get current items of field array
-  const items = untrack(() => internalArrayStore.items.value);
+    // Determine insertion index (default to end of array)
+    const insertIndex = config.at === undefined ? items.length : config.at;
 
-  // Determine insertion index (default to end of array)
-  const insertIndex = config.at === undefined ? items.length : config.at;
+    // Continue if insertion index is valid
+    if (insertIndex >= 0 && insertIndex <= items.length) {
+      batch(() => {
+        // Insert new item ID at the specified index
+        const newItems = [...items];
+        newItems.splice(insertIndex, 0, createId());
+        internalArrayStore.items.value = newItems;
 
-  // Continue if insertion index is valid
-  if (insertIndex >= 0 && insertIndex <= items.length) {
-    batch(() => {
-      // Insert new item ID at the specified index
-      const newItems = [...items];
-      newItems.splice(insertIndex, 0, createId());
-      internalArrayStore.items.value = newItems;
-
-      // Move all child stores after the insertion point one index up
-      for (let index = items.length; index > insertIndex; index--) {
-        if (!internalArrayStore.children[index]) {
-          // @ts-expect-error
-          internalArrayStore.children[index] = {};
-          initializeFieldStore(
-            internalFormStore,
-            internalArrayStore.children[index],
+        // Move all child stores after the insertion point one index up
+        for (let index = items.length; index > insertIndex; index--) {
+          if (!internalArrayStore.children[index]) {
             // @ts-expect-error
-            internalArrayStore.schema.item,
-            undefined,
-            [...internalArrayStore.path, index]
+            internalArrayStore.children[index] = {};
+            initializeFieldStore(
+              internalFormStore,
+              internalArrayStore.children[index],
+              // @ts-expect-error
+              internalArrayStore.schema.item,
+              undefined,
+              [...internalArrayStore.path, index]
+            );
+          }
+          copyItemState(
+            internalFormStore,
+            internalArrayStore.children[index - 1],
+            internalArrayStore.children[index]
           );
         }
-        copyItemState(
-          internalFormStore,
-          internalArrayStore.children[index - 1],
-          internalArrayStore.children[index]
-        );
-      }
 
-      if (!internalArrayStore.children[insertIndex]) {
-        // @ts-expect-error
-        internalArrayStore.children[insertIndex] = {};
-        initializeFieldStore(
-          internalFormStore,
-          internalArrayStore.children[insertIndex],
+        if (!internalArrayStore.children[insertIndex]) {
           // @ts-expect-error
-          internalArrayStore.schema.item,
-          config.initialInput,
-          [...internalArrayStore.path, insertIndex]
-        );
-      } else {
-        resetItemState(
-          internalFormStore,
-          internalArrayStore.children[insertIndex],
-          config.initialInput
-        );
-      }
+          internalArrayStore.children[insertIndex] = {};
+          initializeFieldStore(
+            internalFormStore,
+            internalArrayStore.children[insertIndex],
+            // @ts-expect-error
+            internalArrayStore.schema.item,
+            config.initialInput,
+            [...internalArrayStore.path, insertIndex]
+          );
+        } else {
+          resetItemState(
+            internalFormStore,
+            internalArrayStore.children[insertIndex],
+            config.initialInput
+          );
+        }
 
-      // Mark array input as present in children
-      internalArrayStore.input.value = true;
+        // Mark array input as present in children
+        internalArrayStore.input.value = true;
 
-      // Mark field array as touched, edited and dirty
-      internalArrayStore.isTouched.value = true;
-      internalArrayStore.isEdited.value = true;
-      internalArrayStore.isDirty.value = true;
+        // Mark field array as touched, edited and dirty
+        internalArrayStore.isTouched.value = true;
+        internalArrayStore.isEdited.value = true;
+        internalArrayStore.isDirty.value = true;
 
-      // Validate if required
-      // TODO: Should we validate on touch, change and blur too?
-      validateIfRequired(internalFormStore, internalArrayStore, 'input');
-    });
+        // Validate if required
+        // TODO: Should we validate on touch, change and blur too?
+        validateIfRequired(internalFormStore, internalArrayStore, 'input');
+      });
+    }
   }
 }

--- a/packages/methods/src/isDirty/isDirty.ts
+++ b/packages/methods/src/isDirty/isDirty.ts
@@ -70,8 +70,10 @@ export function isDirty(
   form: BaseFormStore,
   config?: IsFormDirtyConfig | IsFieldDirtyConfig<FormSchema, RequiredPath>
 ): boolean {
-  return getFieldBool(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    'isDirty'
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return internalFieldStore
+    ? getFieldBool(internalFieldStore, 'isDirty')
+    : false;
 }

--- a/packages/methods/src/isEdited/isEdited.ts
+++ b/packages/methods/src/isEdited/isEdited.ts
@@ -70,8 +70,10 @@ export function isEdited(
   form: BaseFormStore,
   config?: IsFormEditedConfig | IsFieldEditedConfig<FormSchema, RequiredPath>
 ): boolean {
-  return getFieldBool(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    'isEdited'
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return internalFieldStore
+    ? getFieldBool(internalFieldStore, 'isEdited')
+    : false;
 }

--- a/packages/methods/src/isTouched/isTouched.ts
+++ b/packages/methods/src/isTouched/isTouched.ts
@@ -70,8 +70,10 @@ export function isTouched(
   form: BaseFormStore,
   config?: IsFormTouchedConfig | IsFieldTouchedConfig<FormSchema, RequiredPath>
 ): boolean {
-  return getFieldBool(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    'isTouched'
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return internalFieldStore
+    ? getFieldBool(internalFieldStore, 'isTouched')
+    : false;
 }

--- a/packages/methods/src/isValid/isValid.ts
+++ b/packages/methods/src/isValid/isValid.ts
@@ -72,8 +72,8 @@ export function isValid(
   form: BaseFormStore,
   config?: IsFormValidConfig | IsFieldValidConfig<FormSchema, RequiredPath>
 ): boolean {
-  return !getFieldBool(
-    config?.path ? getFieldStore(form[INTERNAL], config.path) : form[INTERNAL],
-    'errors'
-  );
+  const internalFieldStore = config?.path
+    ? getFieldStore(form[INTERNAL], config.path)
+    : form[INTERNAL];
+  return !internalFieldStore || !getFieldBool(internalFieldStore, 'errors');
 }

--- a/packages/methods/src/move/move.ts
+++ b/packages/methods/src/move/move.ts
@@ -52,82 +52,82 @@ export function move<
 ): void {
   // Get internal form and array store
   const internalFormStore = form[INTERNAL];
-  const internalArrayStore = getFieldStore(
-    internalFormStore,
-    config.path
-  ) as InternalArrayStore;
+  const internalArrayStore = getFieldStore(internalFormStore, config.path) as
+    | InternalArrayStore
+    | undefined;
+  if (internalArrayStore) {
+    // Get current items of field array
+    const items = untrack(() => internalArrayStore.items.value);
 
-  // Get current items of field array
-  const items = untrack(() => internalArrayStore.items.value);
+    // Continue if both indices are valid and different
+    if (
+      config.from >= 0 &&
+      config.from <= items.length - 1 &&
+      config.to >= 0 &&
+      config.to <= items.length - 1 &&
+      config.from !== config.to
+    ) {
+      batch(() => {
+        // Move item ID in the items array
+        const newItems = [...items];
+        newItems.splice(config.to, 0, newItems.splice(config.from, 1)[0]);
+        internalArrayStore.items.value = newItems;
 
-  // Continue if both indices are valid and different
-  if (
-    config.from >= 0 &&
-    config.from <= items.length - 1 &&
-    config.to >= 0 &&
-    config.to <= items.length - 1 &&
-    config.from !== config.to
-  ) {
-    batch(() => {
-      // Move item ID in the items array
-      const newItems = [...items];
-      newItems.splice(config.to, 0, newItems.splice(config.from, 1)[0]);
-      internalArrayStore.items.value = newItems;
+        // Create temporary internal field store
+        const tempInternalFieldStore = {} as InternalFieldStore;
+        initializeFieldStore(
+          internalFormStore,
+          tempInternalFieldStore,
+          // @ts-expect-error
+          internalArrayStore.schema.item,
+          undefined,
+          []
+        );
 
-      // Create temporary internal field store
-      const tempInternalFieldStore = {} as InternalFieldStore;
-      initializeFieldStore(
-        internalFormStore,
-        tempInternalFieldStore,
-        // @ts-expect-error
-        internalArrayStore.schema.item,
-        undefined,
-        []
-      );
+        // Copy item state that gets overwritten to temporary store
+        copyItemState(
+          internalFormStore,
+          internalArrayStore.children[config.from],
+          tempInternalFieldStore
+        );
 
-      // Copy item state that gets overwritten to temporary store
-      copyItemState(
-        internalFormStore,
-        internalArrayStore.children[config.from],
-        tempInternalFieldStore
-      );
-
-      if (config.from < config.to) {
-        // Move child stores between 'from' and 'to' one index down
-        for (let index = config.from; index < config.to; index++) {
-          copyItemState(
-            internalFormStore,
-            internalArrayStore.children[index + 1],
-            internalArrayStore.children[index]
-          );
+        if (config.from < config.to) {
+          // Move child stores between 'from' and 'to' one index down
+          for (let index = config.from; index < config.to; index++) {
+            copyItemState(
+              internalFormStore,
+              internalArrayStore.children[index + 1],
+              internalArrayStore.children[index]
+            );
+          }
+        } else {
+          // Move child stores between 'to' and 'from' one index up
+          for (let index = config.from; index > config.to; index--) {
+            copyItemState(
+              internalFormStore,
+              internalArrayStore.children[index - 1],
+              internalArrayStore.children[index]
+            );
+          }
         }
-      } else {
-        // Move child stores between 'to' and 'from' one index up
-        for (let index = config.from; index > config.to; index--) {
-          copyItemState(
-            internalFormStore,
-            internalArrayStore.children[index - 1],
-            internalArrayStore.children[index]
-          );
-        }
-      }
 
-      // Copy item state from temporary store to new position
-      copyItemState(
-        internalFormStore,
-        tempInternalFieldStore,
-        internalArrayStore.children[config.to]
-      );
+        // Copy item state from temporary store to new position
+        copyItemState(
+          internalFormStore,
+          tempInternalFieldStore,
+          internalArrayStore.children[config.to]
+        );
 
-      // Mark field array as touched and edited and update dirty state
-      internalArrayStore.isTouched.value = true;
-      internalArrayStore.isEdited.value = true;
-      internalArrayStore.isDirty.value =
-        internalArrayStore.startItems.value.join() !== newItems.join();
+        // Mark field array as touched and edited and update dirty state
+        internalArrayStore.isTouched.value = true;
+        internalArrayStore.isEdited.value = true;
+        internalArrayStore.isDirty.value =
+          internalArrayStore.startItems.value.join() !== newItems.join();
 
-      // Validate if required
-      // TODO: Should we validate on touch, change and blur too?
-      validateIfRequired(internalFormStore, internalArrayStore, 'input');
-    });
+        // Validate if required
+        // TODO: Should we validate on touch, change and blur too?
+        validateIfRequired(internalFormStore, internalArrayStore, 'input');
+      });
+    }
   }
 }

--- a/packages/methods/src/remove/remove.ts
+++ b/packages/methods/src/remove/remove.ts
@@ -46,40 +46,40 @@ export function remove<
 ): void {
   // Get internal form and array store
   const internalFormStore = form[INTERNAL];
-  const internalArrayStore = getFieldStore(
-    internalFormStore,
-    config.path
-  ) as InternalArrayStore;
+  const internalArrayStore = getFieldStore(internalFormStore, config.path) as
+    | InternalArrayStore
+    | undefined;
+  if (internalArrayStore) {
+    // Get current items of field array
+    const items = untrack(() => internalArrayStore.items.value);
 
-  // Get current items of field array
-  const items = untrack(() => internalArrayStore.items.value);
+    // Continue if specified index is valid
+    if (config.at >= 0 && config.at <= items.length - 1) {
+      batch(() => {
+        // Remove item ID from the items array
+        const newItems = [...items];
+        newItems.splice(config.at, 1);
+        internalArrayStore.items.value = newItems;
 
-  // Continue if specified index is valid
-  if (config.at >= 0 && config.at <= items.length - 1) {
-    batch(() => {
-      // Remove item ID from the items array
-      const newItems = [...items];
-      newItems.splice(config.at, 1);
-      internalArrayStore.items.value = newItems;
+        // Move all child stores after the removed item one index down
+        for (let index = config.at; index < items.length - 1; index++) {
+          copyItemState(
+            internalFormStore,
+            internalArrayStore.children[index + 1],
+            internalArrayStore.children[index]
+          );
+        }
 
-      // Move all child stores after the removed item one index down
-      for (let index = config.at; index < items.length - 1; index++) {
-        copyItemState(
-          internalFormStore,
-          internalArrayStore.children[index + 1],
-          internalArrayStore.children[index]
-        );
-      }
+        // Mark field array as touched and edited and update dirty state
+        internalArrayStore.isTouched.value = true;
+        internalArrayStore.isEdited.value = true;
+        internalArrayStore.isDirty.value =
+          internalArrayStore.startItems.value.join() !== newItems.join();
 
-      // Mark field array as touched and edited and update dirty state
-      internalArrayStore.isTouched.value = true;
-      internalArrayStore.isEdited.value = true;
-      internalArrayStore.isDirty.value =
-        internalArrayStore.startItems.value.join() !== newItems.join();
-
-      // Validate if required
-      // TODO: Should we validate on touch, change and blur too?
-      validateIfRequired(internalFormStore, internalArrayStore, 'input');
-    });
+        // Validate if required
+        // TODO: Should we validate on touch, change and blur too?
+        validateIfRequired(internalFormStore, internalArrayStore, 'input');
+      });
+    }
   }
 }

--- a/packages/methods/src/replace/replace.ts
+++ b/packages/methods/src/replace/replace.ts
@@ -56,37 +56,37 @@ export function replace<
 ): void {
   // Get internal form and array store
   const internalFormStore = form[INTERNAL];
-  const internalArrayStore = getFieldStore(
-    internalFormStore,
-    config.path
-  ) as InternalArrayStore;
+  const internalArrayStore = getFieldStore(internalFormStore, config.path) as
+    | InternalArrayStore
+    | undefined;
+  if (internalArrayStore) {
+    // Get current items of field array
+    const items = untrack(() => internalArrayStore.items.value);
 
-  // Get current items of field array
-  const items = untrack(() => internalArrayStore.items.value);
+    // Continue if specified index is valid
+    if (config.at >= 0 && config.at <= items.length - 1) {
+      batch(() => {
+        // Replace item ID to trigger reactivity
+        const newItems = [...items];
+        newItems[config.at] = createId();
+        internalArrayStore.items.value = newItems;
 
-  // Continue if specified index is valid
-  if (config.at >= 0 && config.at <= items.length - 1) {
-    batch(() => {
-      // Replace item ID to trigger reactivity
-      const newItems = [...items];
-      newItems[config.at] = createId();
-      internalArrayStore.items.value = newItems;
+        // Replace input of field array item
+        resetItemState(
+          internalFormStore,
+          internalArrayStore.children[config.at],
+          config.initialInput
+        );
 
-      // Replace input of field array item
-      resetItemState(
-        internalFormStore,
-        internalArrayStore.children[config.at],
-        config.initialInput
-      );
+        // Mark field array as touched, edited and dirty
+        internalArrayStore.isTouched.value = true;
+        internalArrayStore.isEdited.value = true;
+        internalArrayStore.isDirty.value = true;
 
-      // Mark field array as touched, edited and dirty
-      internalArrayStore.isTouched.value = true;
-      internalArrayStore.isEdited.value = true;
-      internalArrayStore.isDirty.value = true;
-
-      // Validate if required
-      // TODO: Should we validate on touch, change and blur too?
-      validateIfRequired(internalFormStore, internalArrayStore, 'input');
-    });
+        // Validate if required
+        // TODO: Should we validate on touch, change and blur too?
+        validateIfRequired(internalFormStore, internalArrayStore, 'input');
+      });
+    }
   }
 }

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -117,115 +117,116 @@ export function reset(
       const internalFieldStore = config?.path
         ? getFieldStore(internalFormStore, config.path)
         : internalFormStore;
-
-      // If initial input is provided, set it
-      if (config && 'initialInput' in config) {
-        setInitialFieldInput(
-          internalFormStore,
-          internalFieldStore,
-          config.initialInput
-        );
-      }
-
-      // Reset state of fields by walking field store
-      walkFieldStore(internalFieldStore, (internalFieldStore) => {
-        // Reset elements to initial elements
-        // Hint: `copyItemState` and `swapItemState` move elements between field
-        // stores during array methods, so this restores each field's original
-        // element. Without it, focus and file reset target the wrong element
-        // after a reorder followed by a reset.
-        internalFieldStore.elements = internalFieldStore.initialElements;
-
-        // Reset errors if it is not to be kept
-        if (!config?.keepErrors) {
-          internalFieldStore.errors.value = null;
+      if (internalFieldStore) {
+        // If initial input is provided, set it
+        if (config && 'initialInput' in config) {
+          setInitialFieldInput(
+            internalFormStore,
+            internalFieldStore,
+            config.initialInput
+          );
         }
 
-        // Reset is touched if it is not to be kept
-        if (!config?.keepTouched) {
-          internalFieldStore.isTouched.value = false;
-        }
+        // Reset state of fields by walking field store
+        walkFieldStore(internalFieldStore, (internalFieldStore) => {
+          // Reset elements to initial elements
+          // Hint: `copyItemState` and `swapItemState` move elements between field
+          // stores during array methods, so this restores each field's original
+          // element. Without it, focus and file reset target the wrong element
+          // after a reorder followed by a reset.
+          internalFieldStore.elements = internalFieldStore.initialElements;
 
-        // Reset is edited if it is not to be kept
-        if (!config?.keepEdited) {
-          internalFieldStore.isEdited.value = false;
-        }
-
-        // Reset start input to initial input
-        internalFieldStore.startInput.value =
-          internalFieldStore.initialInput.value;
-
-        // Reset input if it is not to be kept
-        if (!config?.keepInput) {
-          internalFieldStore.input.value =
-            internalFieldStore.initialInput.value;
-        }
-
-        // If it is an array, reset array specific state
-        if (internalFieldStore.kind === 'array') {
-          // Reset start items to initial items
-          internalFieldStore.startItems.value =
-            internalFieldStore.initialItems.value;
-
-          // Reset items if it is not to be kept
-          if (
-            !config?.keepInput ||
-            // Hint: The array items are just an internal concept used to
-            // store and track changes. We reset anyway if the lengths are
-            // equal because otherwise, the field may be in a dirty state
-            // even though there is no visible change for the end user.
-            internalFieldStore.startItems.value.length ===
-              internalFieldStore.items.value.length
-          ) {
-            internalFieldStore.items.value =
-              internalFieldStore.initialItems.value;
+          // Reset errors if it is not to be kept
+          if (!config?.keepErrors) {
+            internalFieldStore.errors.value = null;
           }
 
-          // Update is dirty to reflect changes
-          internalFieldStore.isDirty.value =
-            internalFieldStore.startInput.value !==
-              internalFieldStore.input.value ||
-            internalFieldStore.startItems.value !==
-              internalFieldStore.items.value;
+          // Reset is touched if it is not to be kept
+          if (!config?.keepTouched) {
+            internalFieldStore.isTouched.value = false;
+          }
 
-          // If it is an object, reset object specific state
-        } else if (internalFieldStore.kind === 'object') {
-          // Update is dirty to reflect changes
-          internalFieldStore.isDirty.value =
-            internalFieldStore.startInput.value !==
-            internalFieldStore.input.value;
+          // Reset is edited if it is not to be kept
+          if (!config?.keepEdited) {
+            internalFieldStore.isEdited.value = false;
+          }
 
-          // If it is a value, reset value specific state
-        } else {
-          // Update is dirty to reflect changes
-          // TODO: Should we add support for Dates and Files?
-          const startInput = internalFieldStore.startInput.value;
-          const input = internalFieldStore.input.value;
-          internalFieldStore.isDirty.value =
-            startInput !== input &&
-            // Hint: This check ensures that an empty string or `NaN` does not mark
-            // the field as dirty if the start input was `undefined` or `null`.
-            (startInput != null || (input !== '' && !Number.isNaN(input)));
+          // Reset start input to initial input
+          internalFieldStore.startInput.value =
+            internalFieldStore.initialInput.value;
 
-          // Reset file inputs as they can't be controlled
-          for (const element of internalFieldStore.elements) {
-            if (element.type === 'file') {
-              element.value = '';
+          // Reset input if it is not to be kept
+          if (!config?.keepInput) {
+            internalFieldStore.input.value =
+              internalFieldStore.initialInput.value;
+          }
+
+          // If it is an array, reset array specific state
+          if (internalFieldStore.kind === 'array') {
+            // Reset start items to initial items
+            internalFieldStore.startItems.value =
+              internalFieldStore.initialItems.value;
+
+            // Reset items if it is not to be kept
+            if (
+              !config?.keepInput ||
+              // Hint: The array items are just an internal concept used to
+              // store and track changes. We reset anyway if the lengths are
+              // equal because otherwise, the field may be in a dirty state
+              // even though there is no visible change for the end user.
+              internalFieldStore.startItems.value.length ===
+                internalFieldStore.items.value.length
+            ) {
+              internalFieldStore.items.value =
+                internalFieldStore.initialItems.value;
+            }
+
+            // Update is dirty to reflect changes
+            internalFieldStore.isDirty.value =
+              internalFieldStore.startInput.value !==
+                internalFieldStore.input.value ||
+              internalFieldStore.startItems.value !==
+                internalFieldStore.items.value;
+
+            // If it is an object, reset object specific state
+          } else if (internalFieldStore.kind === 'object') {
+            // Update is dirty to reflect changes
+            internalFieldStore.isDirty.value =
+              internalFieldStore.startInput.value !==
+              internalFieldStore.input.value;
+
+            // If it is a value, reset value specific state
+          } else {
+            // Update is dirty to reflect changes
+            // TODO: Should we add support for Dates and Files?
+            const startInput = internalFieldStore.startInput.value;
+            const input = internalFieldStore.input.value;
+            internalFieldStore.isDirty.value =
+              startInput !== input &&
+              // Hint: This check ensures that an empty string or `NaN` does not mark
+              // the field as dirty if the start input was `undefined` or `null`.
+              (startInput != null || (input !== '' && !Number.isNaN(input)));
+
+            // Reset file inputs as they can't be controlled
+            for (const element of internalFieldStore.elements) {
+              if (element.type === 'file') {
+                element.value = '';
+              }
             }
           }
-        }
-      });
+        });
 
-      // If path is not defined, reset form specific state
-      if (!config?.path) {
-        // Reset is submitted if it is not to be kept
-        if (!config?.keepSubmitted) {
-          internalFormStore.isSubmitted.value = false;
-        }
+        // If path is not defined, reset form specific state
+        if (!config?.path) {
+          // Reset is submitted if it is not to be kept
+          if (!config?.keepSubmitted) {
+            internalFormStore.isSubmitted.value = false;
+          }
 
-        // Validate form input if configured
-        if (internalFormStore.validate === 'initial') {
-          validateFormInput(internalFormStore);
+          // Validate form input if configured
+          if (internalFormStore.validate === 'initial') {
+            validateFormInput(internalFormStore);
+          }
         }
       }
     });

--- a/packages/methods/src/setErrors/setErrors.ts
+++ b/packages/methods/src/setErrors/setErrors.ts
@@ -61,8 +61,10 @@ export function setErrors(
   form: BaseFormStore,
   config: SetFormErrorsConfig | SetFieldErrorsConfig<FormSchema, RequiredPath>
 ): void {
-  (config.path
+  const internalFieldStore = config.path
     ? getFieldStore(form[INTERNAL], config.path)
-    : form[INTERNAL]
-  ).errors.value = config.errors;
+    : form[INTERNAL];
+  if (internalFieldStore) {
+    internalFieldStore.errors.value = config.errors;
+  }
 }

--- a/packages/methods/src/setInput/setInput.react-native.ts
+++ b/packages/methods/src/setInput/setInput.react-native.ts
@@ -54,11 +54,13 @@ export function setInput(
 ): void {
   batch(() => {
     const internalFormStore = form[INTERNAL];
-    setFieldInput(internalFormStore, config.path ?? [], config.input);
     const fieldOrFormStore = config.path
       ? getFieldStore(internalFormStore, config.path)
       : internalFormStore;
-    validateIfRequired(internalFormStore, fieldOrFormStore, 'input');
-    validateIfRequired(internalFormStore, fieldOrFormStore, 'change');
+    if (fieldOrFormStore) {
+      setFieldInput(internalFormStore, config.path ?? [], config.input);
+      validateIfRequired(internalFormStore, fieldOrFormStore, 'input');
+      validateIfRequired(internalFormStore, fieldOrFormStore, 'change');
+    }
   });
 }

--- a/packages/methods/src/setInput/setInput.react.ts
+++ b/packages/methods/src/setInput/setInput.react.ts
@@ -54,11 +54,13 @@ export function setInput(
 ): void {
   batch(() => {
     const internalFormStore = form[INTERNAL];
-    setFieldInput(internalFormStore, config.path ?? [], config.input);
     const fieldOrFormStore = config.path
       ? getFieldStore(internalFormStore, config.path)
       : internalFormStore;
-    validateIfRequired(internalFormStore, fieldOrFormStore, 'input');
-    validateIfRequired(internalFormStore, fieldOrFormStore, 'change');
+    if (fieldOrFormStore) {
+      setFieldInput(internalFormStore, config.path ?? [], config.input);
+      validateIfRequired(internalFormStore, fieldOrFormStore, 'input');
+      validateIfRequired(internalFormStore, fieldOrFormStore, 'change');
+    }
   });
 }

--- a/packages/methods/src/setInput/setInput.test.ts
+++ b/packages/methods/src/setInput/setInput.test.ts
@@ -71,6 +71,13 @@ describe('setInput', () => {
     expect(() =>
       setInput(store, { path: ['items', 0, 'name'], input: 'foo' })
     ).not.toThrow();
+
+    const itemsStore = store.children.items;
+    expect(itemsStore.kind).toBe('array');
+    if (itemsStore.kind === 'array') {
+      expect(itemsStore.items.value).toEqual([]);
+      expect(itemsStore.isDirty.value).toBe(false);
+    }
   });
 
   test('should set full form input', () => {

--- a/packages/methods/src/setInput/setInput.test.ts
+++ b/packages/methods/src/setInput/setInput.test.ts
@@ -62,6 +62,17 @@ describe('setInput', () => {
     }
   });
 
+  test('should ignore missing dynamic array item path', () => {
+    const store = createTestStore(
+      v.object({ items: v.array(v.object({ name: v.string() })) }),
+      { initialInput: { items: [] } }
+    );
+
+    expect(() =>
+      setInput(store, { path: ['items', 0, 'name'], input: 'foo' })
+    ).not.toThrow();
+  });
+
   test('should set full form input', () => {
     const store = createTestStore(
       v.object({ name: v.string(), age: v.number() }),

--- a/packages/methods/src/setInput/setInput.ts
+++ b/packages/methods/src/setInput/setInput.ts
@@ -82,14 +82,13 @@ export function setInput(
 ): void {
   batch(() => {
     const internalFormStore = form[INTERNAL];
-    setFieldInput(internalFormStore, config.path ?? [], config.input);
-    // TODO: Should we validate on touch, change and blur too?
-    validateIfRequired(
-      internalFormStore,
-      config.path
-        ? getFieldStore(internalFormStore, config.path)
-        : internalFormStore,
-      'input'
-    );
+    const internalFieldStore = config.path
+      ? getFieldStore(internalFormStore, config.path)
+      : internalFormStore;
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path ?? [], config.input);
+      // TODO: Should we validate on touch, change and blur too?
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
   });
 }

--- a/packages/methods/src/swap/swap.ts
+++ b/packages/methods/src/swap/swap.ts
@@ -49,46 +49,46 @@ export function swap<
 ): void {
   // Get internal form and array store
   const internalFormStore = form[INTERNAL];
-  const internalArrayStore = getFieldStore(
-    internalFormStore,
-    config.path
-  ) as InternalArrayStore;
+  const internalArrayStore = getFieldStore(internalFormStore, config.path) as
+    | InternalArrayStore
+    | undefined;
+  if (internalArrayStore) {
+    // Get current items of field array
+    const items = untrack(() => internalArrayStore.items.value);
 
-  // Get current items of field array
-  const items = untrack(() => internalArrayStore.items.value);
+    // Continue if both specified indices are valid
+    if (
+      config.at >= 0 &&
+      config.at <= items.length - 1 &&
+      config.and >= 0 &&
+      config.and <= items.length - 1 &&
+      config.at !== config.and
+    ) {
+      batch(() => {
+        // Swap item IDs in items array
+        const newItems = [...items];
+        const tempItemId = newItems[config.at];
+        newItems[config.at] = newItems[config.and];
+        newItems[config.and] = tempItemId;
+        internalArrayStore.items.value = newItems;
 
-  // Continue if both specified indices are valid
-  if (
-    config.at >= 0 &&
-    config.at <= items.length - 1 &&
-    config.and >= 0 &&
-    config.and <= items.length - 1 &&
-    config.at !== config.and
-  ) {
-    batch(() => {
-      // Swap item IDs in items array
-      const newItems = [...items];
-      const tempItemId = newItems[config.at];
-      newItems[config.at] = newItems[config.and];
-      newItems[config.and] = tempItemId;
-      internalArrayStore.items.value = newItems;
+        // Swap child stores directly
+        swapItemState(
+          internalFormStore,
+          internalArrayStore.children[config.at],
+          internalArrayStore.children[config.and]
+        );
 
-      // Swap child stores directly
-      swapItemState(
-        internalFormStore,
-        internalArrayStore.children[config.at],
-        internalArrayStore.children[config.and]
-      );
+        // Mark field array as touched and edited and update dirty state
+        internalArrayStore.isTouched.value = true;
+        internalArrayStore.isEdited.value = true;
+        internalArrayStore.isDirty.value =
+          internalArrayStore.startItems.value.join() !== newItems.join();
 
-      // Mark field array as touched and edited and update dirty state
-      internalArrayStore.isTouched.value = true;
-      internalArrayStore.isEdited.value = true;
-      internalArrayStore.isDirty.value =
-        internalArrayStore.startItems.value.join() !== newItems.join();
-
-      // Validate if required
-      // TODO: Should we validate on touch, change and blur too?
-      validateIfRequired(internalFormStore, internalArrayStore, 'input');
-    });
+        // Validate if required
+        // TODO: Should we validate on touch, change and blur too?
+        validateIfRequired(internalFormStore, internalArrayStore, 'input');
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary

- return `undefined` when `getFieldStore` encounters an inactive dynamic array item
- make field methods return their neutral value or skip mutations for stale dynamic array paths
- keep statically valid framework field paths non-optional and preserve the existing public `getInput` return type
- avoid reactive subscriptions when checking active array item IDs

## Root cause

Dynamic array child stores are retained for reuse, while `items` represents the currently active entries. `getFieldStore` previously traversed `children` without checking `items`, so a stale or not-yet-created array index could return a cached store or continue through `undefined` and throw.

## Impact

Methods now handle stale runtime array paths without throwing. Structurally invalid paths remain a TypeScript concern and do not add extra runtime validation.

## Validation

- `@formisch/core`: 464 tests passed; ESLint and TypeScript passed
- `@formisch/methods`: 247 tests passed; ESLint and TypeScript passed
- core and methods builds passed
- Prettier and `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when accessing, updating, resetting, validating, or querying fields inside dynamic array items that no longer exist.
  * Array operations such as insert, move, remove, replace, and swap now safely ignore unavailable targets.
  * Error and state helpers return safe results when a field path cannot be resolved.
  * Focusing a missing field no longer triggers an invalid focus attempt.
  * Improved Vue handling to avoid unnecessary tracking of dynamic array items.
* **Tests**
  * Added regression coverage for missing dynamic array items across field and form operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->