### PR TITLE
Fix stale async validation results after a full form reset

### DIFF
--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix full form reset to discard pending validation results and clear the validating state (issue #210, pull request #211)
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/packages/methods/src/reset/reset.test.ts
+++ b/packages/methods/src/reset/reset.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import * as v from 'valibot';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+import { setInput } from '../setInput/setInput.ts';
+import { validate } from '../validate/validate.ts';
 import { createTestStore } from '../vitest/index.ts';
 import { reset } from './reset.ts';
 
@@ -417,6 +419,232 @@ describe('reset', () => {
       // Form should trigger validation on initial mode
       // The parse function is called during validation
       expect(store.isSubmitted.value).toBe(false);
+    });
+  });
+
+  describe('reset while an async validation is pending', () => {
+    test('should not apply a stale validation result for input replaced by reset', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('Name is required')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+
+      // Manually controlled parse result so the test decides exactly when
+      // the async validation resolves, instead of relying on real timers.
+      let resolveValidation: (value: ParseResult) => void;
+      const pendingParse = new Promise<ParseResult>((resolve) => {
+        resolveValidation = resolve;
+      });
+
+      const store = createTestStore(schema, { initialInput: { name: 'John' } });
+      const parse = vi.fn().mockReturnValue(pendingParse);
+      store.parse = parse;
+
+      // Enter an invalid value for the field
+      setInput(store, { path: ['name'], input: '' });
+
+      // Start async validation for the invalid input and keep it pending.
+      // `validate` is the public method that mirrors what a framework
+      // wrapper triggers when validation runs (e.g. on blur).
+      const pendingValidation = validate(store);
+      expect(parse).toHaveBeenCalledWith({ name: '' });
+      expect(store.isValidating.value).toBe(true);
+
+      // Reset the form while the validation above is still in flight
+      reset(store);
+
+      // A: reset immediately restores the valid initial input, clears
+      // errors, and does not leave the form stuck in a validating state
+      // since no new validation was started (`validate` is not 'initial')
+      expect(store.children.name.input.value).toBe('John');
+      expect(store.children.name.errors.value).toBeNull();
+      expect(store.isValidating.value).toBe(false);
+
+      // Complete the pending validation with a real error result for the
+      // input that was actually validated (before reset replaced it)
+      const staleResult = v.safeParse(schema, { name: '' });
+      expect(staleResult.success).toBe(false);
+      resolveValidation!(staleResult);
+      await pendingValidation;
+
+      // B: the stale validation result must not reintroduce errors for
+      // input that no longer exists after reset, and must not resurrect
+      // the validating state either
+      expect(store.children.name.input.value).toBe('John');
+      expect(store.children.name.errors.value).toBeNull();
+      expect(store.isValidating.value).toBe(false);
+    });
+
+    test('should keep isValidating true until the new validation started by reset completes, even if the stale validation resolves first', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('Name is required')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+
+      let resolveOldValidation: (value: ParseResult) => void;
+      const pendingOldParse = new Promise<ParseResult>((resolve) => {
+        resolveOldValidation = resolve;
+      });
+      let resolveNewValidation: (value: ParseResult) => void;
+      const pendingNewParse = new Promise<ParseResult>((resolve) => {
+        resolveNewValidation = resolve;
+      });
+
+      // The initial input is invalid so the validation reset('initial')
+      // starts has a genuine error to report once it resolves.
+      const store = createTestStore(schema, {
+        validate: 'initial',
+        initialInput: { name: '' },
+      });
+      const parse = vi
+        .fn()
+        .mockReturnValueOnce(pendingOldParse)
+        .mockReturnValueOnce(pendingNewParse);
+      store.parse = parse;
+
+      // Set the input directly, bypassing `setInput`'s own validation
+      // trigger (which would fire an extra time here since `validate:
+      // 'initial'` falls back to `revalidate` for input-change events), so
+      // the explicit `validate(store)` call below is the only thing that
+      // starts the "old" validation.
+      store.children.name.input.value = 'temporary';
+      const oldValidation = validate(store);
+      expect(store.isValidating.value).toBe(true);
+
+      // Reset while the old validation is still in flight. Since `validate`
+      // is 'initial', reset starts a brand new validation for the restored
+      // (invalid) initial input.
+      reset(store);
+      expect(parse).toHaveBeenCalledTimes(2);
+      expect(store.isValidating.value).toBe(true);
+
+      // Resolve the OLD validation first, with a real (but now irrelevant)
+      // success result for the input it actually validated ('temporary' is
+      // non-empty, so it passes). Using a success result here specifically
+      // checks that the stale validation is discarded outright rather than
+      // merely failing to overwrite an error: if it were still processed, it
+      // would incorrectly clear `isValidating` early, even though it reports
+      // no error of its own.
+      const staleResult = v.safeParse(schema, { name: 'temporary' });
+      expect(staleResult.success).toBe(true);
+      resolveOldValidation!(staleResult);
+      await oldValidation;
+
+      // The new validation triggered by reset has not resolved yet, so the
+      // form must still report as validating, and the stale (successful)
+      // result must not have been applied either.
+      expect(store.isValidating.value).toBe(true);
+      expect(store.children.name.errors.value).toBeNull();
+
+      // Resolve the NEW validation with the genuine result for the reset
+      // (invalid) initial input.
+      const newResult = v.safeParse(schema, { name: '' });
+      expect(newResult.success).toBe(false);
+      resolveNewValidation!(newResult);
+      await pendingNewParse;
+
+      expect(store.isValidating.value).toBe(false);
+      expect(store.children.name.errors.value).toEqual(['Name is required']);
+    });
+  });
+
+  describe('reset with keepErrors while an async validation is pending', () => {
+    test('should not let a stale validation result overwrite errors kept by keepErrors', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('Name is required')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+
+      let resolveValidation: (value: ParseResult) => void;
+      const pendingParse = new Promise<ParseResult>((resolve) => {
+        resolveValidation = resolve;
+      });
+
+      const store = createTestStore(schema, { initialInput: { name: 'John' } });
+      const parse = vi.fn().mockReturnValue(pendingParse);
+      store.parse = parse;
+
+      // Give the field a pre-existing error that keepErrors should preserve.
+      store.children.name.errors.value = ['Existing error'];
+
+      setInput(store, { path: ['name'], input: '' });
+      const pendingValidation = validate(store);
+      expect(store.isValidating.value).toBe(true);
+
+      reset(store, { keepErrors: true });
+
+      // keepErrors preserves the pre-existing error, and the pending
+      // validation is still invalidated like in a regular reset.
+      expect(store.children.name.input.value).toBe('John');
+      expect(store.children.name.errors.value).toEqual(['Existing error']);
+      expect(store.isValidating.value).toBe(false);
+
+      const staleResult = v.safeParse(schema, { name: '' });
+      resolveValidation!(staleResult);
+      await pendingValidation;
+
+      // The stale validation must not overwrite the kept error either.
+      expect(store.children.name.errors.value).toEqual(['Existing error']);
+      expect(store.isValidating.value).toBe(false);
+    });
+  });
+
+  describe('reset with keepInput while an async validation is pending', () => {
+    test('should discard the stale validation and reset error/validating state even though keepInput preserves the input it was validating', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('Name is required')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+
+      let resolveValidation: (value: ParseResult) => void;
+      const pendingParse = new Promise<ParseResult>((resolve) => {
+        resolveValidation = resolve;
+      });
+
+      // `validate: 'submit'` is used so that entering the invalid value via
+      // the public `setInput` API does not itself trigger a validation
+      // (submit-mode only auto-validates once the form has been submitted),
+      // leaving `validate(store)` below as the sole trigger.
+      const store = createTestStore(schema, {
+        validate: 'submit',
+        initialInput: { name: 'John' },
+      });
+      const parse = vi.fn().mockReturnValue(pendingParse);
+      store.parse = parse;
+
+      // Enter a value different from the initial input that fails validation.
+      setInput(store, { path: ['name'], input: '' });
+
+      // Start async validation for the current (invalid) input via the
+      // public API and keep it pending.
+      const pendingValidation = validate(store);
+      expect(parse).toHaveBeenCalledWith({ name: '' });
+      expect(store.isValidating.value).toBe(true);
+
+      // Reset while that validation is still in flight, keeping the current
+      // input instead of reverting to the initial value.
+      reset(store, { keepInput: true });
+
+      // `keepInput` preserves the input, but reset still invalidates pending
+      // validation and clears the validating state. Errors are cleared unless
+      // `keepErrors` is also enabled.
+      expect(store.children.name.input.value).toBe('');
+      expect(store.children.name.errors.value).toBeNull();
+      expect(store.isValidating.value).toBe(false);
+
+      // Complete the pre-reset validation with a real error result for the
+      // input it actually validated, which - because of keepInput - is
+      // still the field's current input.
+      const staleResult = v.safeParse(schema, { name: '' });
+      expect(staleResult.success).toBe(false);
+      resolveValidation!(staleResult);
+      await pendingValidation;
+
+      // The stale result must still not be applied, even though it was
+      // validating the exact value keepInput preserved.
+      expect(store.children.name.input.value).toBe('');
+      expect(store.children.name.errors.value).toBeNull();
+      expect(store.isValidating.value).toBe(false);
     });
   });
 

--- a/packages/methods/src/reset/reset.test.ts
+++ b/packages/methods/src/reset/reset.test.ts
@@ -422,15 +422,14 @@ describe('reset', () => {
     });
   });
 
-  describe('reset while an async validation is pending', () => {
-    test('should not apply a stale validation result for input replaced by reset', async () => {
+  describe('pending async validation', () => {
+    test('should discard pending validation after reset', async () => {
       const schema = v.object({
         name: v.pipe(v.string(), v.nonEmpty('Name is required')),
       });
       type ParseResult = v.SafeParseResult<typeof schema>;
 
-      // Manually controlled parse result so the test decides exactly when
-      // the async validation resolves, instead of relying on real timers.
+      // Control completion explicitly to reproduce the race without timers.
       let resolveValidation: (value: ParseResult) => void;
       const pendingParse = new Promise<ParseResult>((resolve) => {
         resolveValidation = resolve;
@@ -440,42 +439,29 @@ describe('reset', () => {
       const parse = vi.fn().mockReturnValue(pendingParse);
       store.parse = parse;
 
-      // Enter an invalid value for the field
       setInput(store, { path: ['name'], input: '' });
 
-      // Start async validation for the invalid input and keep it pending.
-      // `validate` is the public method that mirrors what a framework
-      // wrapper triggers when validation runs (e.g. on blur).
       const pendingValidation = validate(store);
       expect(parse).toHaveBeenCalledWith({ name: '' });
       expect(store.isValidating.value).toBe(true);
 
-      // Reset the form while the validation above is still in flight
       reset(store);
 
-      // A: reset immediately restores the valid initial input, clears
-      // errors, and does not leave the form stuck in a validating state
-      // since no new validation was started (`validate` is not 'initial')
       expect(store.children.name.input.value).toBe('John');
       expect(store.children.name.errors.value).toBeNull();
       expect(store.isValidating.value).toBe(false);
 
-      // Complete the pending validation with a real error result for the
-      // input that was actually validated (before reset replaced it)
       const staleResult = v.safeParse(schema, { name: '' });
       expect(staleResult.success).toBe(false);
       resolveValidation!(staleResult);
       await pendingValidation;
 
-      // B: the stale validation result must not reintroduce errors for
-      // input that no longer exists after reset, and must not resurrect
-      // the validating state either
       expect(store.children.name.input.value).toBe('John');
       expect(store.children.name.errors.value).toBeNull();
       expect(store.isValidating.value).toBe(false);
     });
 
-    test('should keep isValidating true until the new validation started by reset completes, even if the stale validation resolves first', async () => {
+    test('should keep reset-triggered validation active when an older validation completes', async () => {
       const schema = v.object({
         name: v.pipe(v.string(), v.nonEmpty('Name is required')),
       });
@@ -490,8 +476,6 @@ describe('reset', () => {
         resolveNewValidation = resolve;
       });
 
-      // The initial input is invalid so the validation reset('initial')
-      // starts has a genuine error to report once it resolves.
       const store = createTestStore(schema, {
         validate: 'initial',
         initialInput: { name: '' },
@@ -502,42 +486,26 @@ describe('reset', () => {
         .mockReturnValueOnce(pendingNewParse);
       store.parse = parse;
 
-      // Set the input directly, bypassing `setInput`'s own validation
-      // trigger (which would fire an extra time here since `validate:
-      // 'initial'` falls back to `revalidate` for input-change events), so
-      // the explicit `validate(store)` call below is the only thing that
-      // starts the "old" validation.
+      // Set input directly so input revalidation does not start an extra parse.
       store.children.name.input.value = 'temporary';
       const oldValidation = validate(store);
       expect(store.isValidating.value).toBe(true);
 
-      // Reset while the old validation is still in flight. Since `validate`
-      // is 'initial', reset starts a brand new validation for the restored
-      // (invalid) initial input.
       reset(store);
       expect(parse).toHaveBeenCalledTimes(2);
+      expect(parse).toHaveBeenNthCalledWith(1, { name: 'temporary' });
+      expect(parse).toHaveBeenNthCalledWith(2, { name: '' });
       expect(store.isValidating.value).toBe(true);
 
-      // Resolve the OLD validation first, with a real (but now irrelevant)
-      // success result for the input it actually validated ('temporary' is
-      // non-empty, so it passes). Using a success result here specifically
-      // checks that the stale validation is discarded outright rather than
-      // merely failing to overwrite an error: if it were still processed, it
-      // would incorrectly clear `isValidating` early, even though it reports
-      // no error of its own.
+      // Even a successful stale result must not clear the new validating state.
       const staleResult = v.safeParse(schema, { name: 'temporary' });
       expect(staleResult.success).toBe(true);
       resolveOldValidation!(staleResult);
       await oldValidation;
 
-      // The new validation triggered by reset has not resolved yet, so the
-      // form must still report as validating, and the stale (successful)
-      // result must not have been applied either.
       expect(store.isValidating.value).toBe(true);
       expect(store.children.name.errors.value).toBeNull();
 
-      // Resolve the NEW validation with the genuine result for the reset
-      // (invalid) initial input.
       const newResult = v.safeParse(schema, { name: '' });
       expect(newResult.success).toBe(false);
       resolveNewValidation!(newResult);
@@ -546,10 +514,8 @@ describe('reset', () => {
       expect(store.isValidating.value).toBe(false);
       expect(store.children.name.errors.value).toEqual(['Name is required']);
     });
-  });
 
-  describe('reset with keepErrors while an async validation is pending', () => {
-    test('should not let a stale validation result overwrite errors kept by keepErrors', async () => {
+    test('should preserve kept errors when pending validation completes', async () => {
       const schema = v.object({
         name: v.pipe(v.string(), v.nonEmpty('Name is required')),
       });
@@ -564,7 +530,6 @@ describe('reset', () => {
       const parse = vi.fn().mockReturnValue(pendingParse);
       store.parse = parse;
 
-      // Give the field a pre-existing error that keepErrors should preserve.
       store.children.name.errors.value = ['Existing error'];
 
       setInput(store, { path: ['name'], input: '' });
@@ -573,8 +538,6 @@ describe('reset', () => {
 
       reset(store, { keepErrors: true });
 
-      // keepErrors preserves the pre-existing error, and the pending
-      // validation is still invalidated like in a regular reset.
       expect(store.children.name.input.value).toBe('John');
       expect(store.children.name.errors.value).toEqual(['Existing error']);
       expect(store.isValidating.value).toBe(false);
@@ -583,14 +546,11 @@ describe('reset', () => {
       resolveValidation!(staleResult);
       await pendingValidation;
 
-      // The stale validation must not overwrite the kept error either.
       expect(store.children.name.errors.value).toEqual(['Existing error']);
       expect(store.isValidating.value).toBe(false);
     });
-  });
 
-  describe('reset with keepInput while an async validation is pending', () => {
-    test('should discard the stale validation and reset error/validating state even though keepInput preserves the input it was validating', async () => {
+    test('should discard pending validation when input is kept', async () => {
       const schema = v.object({
         name: v.pipe(v.string(), v.nonEmpty('Name is required')),
       });
@@ -601,10 +561,6 @@ describe('reset', () => {
         resolveValidation = resolve;
       });
 
-      // `validate: 'submit'` is used so that entering the invalid value via
-      // the public `setInput` API does not itself trigger a validation
-      // (submit-mode only auto-validates once the form has been submitted),
-      // leaving `validate(store)` below as the sole trigger.
       const store = createTestStore(schema, {
         validate: 'submit',
         initialInput: { name: 'John' },
@@ -612,36 +568,23 @@ describe('reset', () => {
       const parse = vi.fn().mockReturnValue(pendingParse);
       store.parse = parse;
 
-      // Enter a value different from the initial input that fails validation.
       setInput(store, { path: ['name'], input: '' });
 
-      // Start async validation for the current (invalid) input via the
-      // public API and keep it pending.
       const pendingValidation = validate(store);
       expect(parse).toHaveBeenCalledWith({ name: '' });
       expect(store.isValidating.value).toBe(true);
 
-      // Reset while that validation is still in flight, keeping the current
-      // input instead of reverting to the initial value.
       reset(store, { keepInput: true });
 
-      // `keepInput` preserves the input, but reset still invalidates pending
-      // validation and clears the validating state. Errors are cleared unless
-      // `keepErrors` is also enabled.
       expect(store.children.name.input.value).toBe('');
       expect(store.children.name.errors.value).toBeNull();
       expect(store.isValidating.value).toBe(false);
 
-      // Complete the pre-reset validation with a real error result for the
-      // input it actually validated, which - because of keepInput - is
-      // still the field's current input.
       const staleResult = v.safeParse(schema, { name: '' });
       expect(staleResult.success).toBe(false);
       resolveValidation!(staleResult);
       await pendingValidation;
 
-      // The stale result must still not be applied, even though it was
-      // validating the exact value keepInput preserved.
       expect(store.children.name.input.value).toBe('');
       expect(store.children.name.errors.value).toBeNull();
       expect(store.isValidating.value).toBe(false);

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -218,6 +218,18 @@ export function reset(
 
         // If path is not defined, reset form specific state
         if (!config?.path) {
+          // Invalidate any validation that is still pending from before the
+          // reset so its result cannot be applied to the state below once it
+          // settles.
+          // Hint: `validateFormInput` only writes its result when its captured
+          // ID still matches `internalFormStore.validationId`, so bumping it
+          // here makes that check fail for the outdated validation. Since that
+          // validation will now skip its own cleanup, `isValidating` is reset
+          // here as well. If `validate` is `'initial'`, it is set back to
+          // `true` below by the new validation this method starts.
+          internalFormStore.validationId++;
+          internalFormStore.isValidating.value = false;
+
           // Reset is submitted if it is not to be kept
           if (!config?.keepSubmitted) {
             internalFormStore.isSubmitted.value = false;


### PR DESCRIPTION
Fixes #210

A pending async validation could restore errors after `reset()` had already restored the initial input and cleared errors.

Invalidate pending validations during a full form reset and clear `isValidating`. When `validate: 'initial'` starts a new validation, earlier results cannot clear its validating state or replace its results.

Field-specific reset behavior is unchanged.

### Tests

Added coverage for:
- Pending validation completing after a full reset.
- An older validation completing while reset-triggered validation is pending.
- Preserving errors with `keepErrors`.
- Preserving input while discarding pending results with `keepInput`.

### Validation

- Regression test failed on unmodified upstream main with the previous input's error after reset, then passed with the fix.
- `pnpm -C packages/methods test`: 251 passed, no type errors.
- `pnpm -C packages/methods lint`: passed.
- Changed-file Prettier check and `git diff --check`: passed.
- React browser reproduction manually verified before and after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form reset behavior while validation is pending.
  * Prevented stale validation results from restoring errors or changing validation status after a reset.
  * Ensured new validation remains active until it completes, including when previous validation finishes first.
  * Preserved kept errors correctly and maintained input when configured, while still clearing outdated validation state.
  * Improved consistency when resetting forms during asynchronous validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->