### PR TITLE
Add framework internals exports and guides

### DIFF
--- a/frameworks/angular/CHANGELOG.md
+++ b/frameworks/angular/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/angular/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/angular/package.json
+++ b/frameworks/angular/package.json
@@ -30,6 +30,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/angular/rolldown.config.ts
+++ b/frameworks/angular/rolldown.config.ts
@@ -1,30 +1,54 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'rolldown';
 import { dts } from 'rolldown-plugin-dts';
 
 // The Angular components are first compiled with `ngc` (partial Ivy) into the
 // `tmp` directory, then bundled here into a self-contained package. The
-// internal `@formisch/core` and `@formisch/methods` code is inlined (it has no
-// published framework-specific entry points), while Angular and valibot stay
-// external as peer dependencies.
-const external = [/^@angular\//, /^rxjs(\/|$)/, 'valibot'];
-const resolve = ['@formisch/core/angular', '@formisch/methods/angular'];
+// methods are inlined, while the core is copied to the shared internals entry.
+// Angular and valibot stay external as peer dependencies.
+const external = [
+  /^@angular\//,
+  /^rxjs(\/|$)/,
+  'valibot',
+  '@formisch/core/angular',
+];
+const paths = { '@formisch/core/angular': './internals.js' };
 
 export default defineConfig([
   {
     input: './tmp/index.js',
     external,
+    plugins: [
+      {
+        name: 'copy-core',
+        generateBundle() {
+          for (const extension of ['js', 'd.ts']) {
+            this.emitFile({
+              type: 'asset',
+              fileName: `internals.${extension}`,
+              source: readFileSync(
+                `../../packages/core/dist/index.angular.${extension}`,
+                'utf8'
+              ),
+            });
+          }
+        },
+      },
+    ],
     output: {
       file: 'dist/index.js',
       format: 'es',
+      paths,
     },
   },
   {
     input: './tmp/index.d.ts',
     external,
-    plugins: [dts({ dtsInput: true, resolve })],
+    plugins: [dts({ dtsInput: true, resolve: ['@formisch/methods/angular'] })],
     output: {
       file: 'dist/index.d.ts',
       format: 'es',
+      paths,
     },
   },
 ]);

--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/preact/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/preact/package.json
+++ b/frameworks/preact/package.json
@@ -31,6 +31,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/preact/tsdown.config.ts
+++ b/frameworks/preact/tsdown.config.ts
@@ -2,12 +2,26 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  external: ['@formisch/core/preact'],
   outDir: 'dist',
   outExtensions: () => ({
     js: '.js',
     dts: '.d.ts',
   }),
-  dts: {
-    resolve: ['@formisch/core/preact', '@formisch/methods/preact'],
+  outputOptions: {
+    paths: { '@formisch/core/preact': './internals.js' },
   },
+  dts: {
+    resolve: ['@formisch/methods/preact'],
+  },
+  copy: [
+    {
+      from: '../../packages/core/dist/index.preact.js',
+      to: 'dist/internals.js',
+    },
+    {
+      from: '../../packages/core/dist/index.preact.d.ts',
+      to: 'dist/internals.d.ts',
+    },
+  ],
 });

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/qwik/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/qwik/package.json
+++ b/frameworks/qwik/package.json
@@ -32,6 +32,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.qwik.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js"
     }
   },
   "files": [

--- a/frameworks/qwik/package.json
+++ b/frameworks/qwik/package.json
@@ -34,8 +34,8 @@
       "import": "./dist/index.qwik.js"
     },
     "./internals": {
-      "types": "./dist/internals.d.ts",
-      "import": "./dist/internals.js"
+      "types": "./dist/internals.qwik.d.ts",
+      "import": "./dist/internals.qwik.js"
     }
   },
   "files": [

--- a/frameworks/qwik/package.json
+++ b/frameworks/qwik/package.json
@@ -27,10 +27,10 @@
   "type": "module",
   "main": "./dist/index.qwik.js",
   "qwik": "./dist/index.qwik.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.qwik.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.qwik.d.ts",
       "import": "./dist/index.qwik.js"
     },
     "./internals": {

--- a/frameworks/qwik/tsdown.config.ts
+++ b/frameworks/qwik/tsdown.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   external: ['@formisch/core/qwik'],
   outDir: 'dist',
   outExtensions: () => ({
-    dts: '.d.ts',
+    dts: '.qwik.d.ts',
     js: '.qwik.js',
   }),
   outputOptions: {

--- a/frameworks/qwik/tsdown.config.ts
+++ b/frameworks/qwik/tsdown.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     js: '.qwik.js',
   }),
   outputOptions: {
-    paths: { '@formisch/core/qwik': './internals.js' },
+    paths: { '@formisch/core/qwik': './internals.qwik.js' },
   },
   dts: {
     resolve: ['@formisch/methods/qwik'],
@@ -17,11 +17,11 @@ export default defineConfig({
   copy: [
     {
       from: '../../packages/core/dist/index.qwik.js',
-      to: 'dist/internals.js',
+      to: 'dist/internals.qwik.js',
     },
     {
       from: '../../packages/core/dist/index.qwik.d.ts',
-      to: 'dist/internals.d.ts',
+      to: 'dist/internals.qwik.d.ts',
     },
   ],
 });

--- a/frameworks/qwik/tsdown.config.ts
+++ b/frameworks/qwik/tsdown.config.ts
@@ -2,12 +2,26 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  external: ['@formisch/core/qwik'],
   outDir: 'dist',
   outExtensions: () => ({
     dts: '.d.ts',
     js: '.qwik.js',
   }),
-  dts: {
-    resolve: ['@formisch/core/qwik', '@formisch/methods/qwik'],
+  outputOptions: {
+    paths: { '@formisch/core/qwik': './internals.js' },
   },
+  dts: {
+    resolve: ['@formisch/methods/qwik'],
+  },
+  copy: [
+    {
+      from: '../../packages/core/dist/index.qwik.js',
+      to: 'dist/internals.js',
+    },
+    {
+      from: '../../packages/core/dist/index.qwik.d.ts',
+      to: 'dist/internals.d.ts',
+    },
+  ],
 });

--- a/frameworks/react-native/CHANGELOG.md
+++ b/frameworks/react-native/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/react-native/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/react-native/package.json
+++ b/frameworks/react-native/package.json
@@ -34,6 +34,12 @@
       "react-native": "./dist/index.js",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "react-native": "./dist/internals.js",
+      "import": "./dist/internals.js",
+      "default": "./dist/internals.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/react-native/tsdown.config.ts
+++ b/frameworks/react-native/tsdown.config.ts
@@ -2,12 +2,26 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  external: ['@formisch/core/react-native'],
   outDir: 'dist',
   outExtensions: () => ({
     js: '.js',
     dts: '.d.ts',
   }),
-  dts: {
-    resolve: ['@formisch/core/react-native', '@formisch/methods/react-native'],
+  outputOptions: {
+    paths: { '@formisch/core/react-native': './internals.js' },
   },
+  dts: {
+    resolve: ['@formisch/methods/react-native'],
+  },
+  copy: [
+    {
+      from: '../../packages/core/dist/index.react-native.js',
+      to: 'dist/internals.js',
+    },
+    {
+      from: '../../packages/core/dist/index.react-native.d.ts',
+      to: 'dist/internals.d.ts',
+    },
+  ],
 });

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/react/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -31,6 +31,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/react/tsdown.config.ts
+++ b/frameworks/react/tsdown.config.ts
@@ -2,12 +2,26 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  external: ['@formisch/core/react'],
   outDir: 'dist',
   outExtensions: () => ({
     js: '.js',
     dts: '.d.ts',
   }),
-  dts: {
-    resolve: ['@formisch/core/react', '@formisch/methods/react'],
+  outputOptions: {
+    paths: { '@formisch/core/react': './internals.js' },
   },
+  dts: {
+    resolve: ['@formisch/methods/react'],
+  },
+  copy: [
+    {
+      from: '../../packages/core/dist/index.react.js',
+      to: 'dist/internals.js',
+    },
+    {
+      from: '../../packages/core/dist/index.react.d.ts',
+      to: 'dist/internals.d.ts',
+    },
+  ],
 });

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/solid/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/solid/package.json
+++ b/frameworks/solid/package.json
@@ -30,19 +30,25 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "solid": {
-      "development": "./dist/dev.jsx",
-      "import": "./dist/index.jsx"
-    },
-    "development": {
+    ".": {
+      "solid": {
+        "development": "./dist/dev.jsx",
+        "import": "./dist/index.jsx"
+      },
+      "development": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/dev.js"
+        }
+      },
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/dev.js"
+        "default": "./dist/index.js"
       }
     },
-    "import": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/solid/tsdown.config.ts
+++ b/frameworks/solid/tsdown.config.ts
@@ -2,13 +2,27 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['./src/index.tsx'],
+  external: ['@formisch/core/solid'],
   outDir: 'dist',
   clean: false,
   outExtensions: () => ({
     dts: '.d.ts',
   }),
+  outputOptions: {
+    paths: { '@formisch/core/solid': './internals.js' },
+  },
   dts: {
     emitDtsOnly: true,
-    resolve: ['@formisch/core/solid', '@formisch/methods/solid'],
+    resolve: ['@formisch/methods/solid'],
   },
+  copy: [
+    {
+      from: '../../packages/core/dist/index.solid.js',
+      to: 'dist/internals.js',
+    },
+    {
+      from: '../../packages/core/dist/index.solid.d.ts',
+      to: 'dist/internals.d.ts',
+    },
+  ],
 });

--- a/frameworks/solid/tsup.config.ts
+++ b/frameworks/solid/tsup.config.ts
@@ -14,6 +14,17 @@ const preset_options: preset.PresetOptions = {
   ],
   // Set to `true` to remove all `console.*` calls and `debugger` statements in prod builds
   drop_console: true,
+  esbuild_plugins: [
+    {
+      name: 'externalize-core',
+      setup(build) {
+        build.onResolve({ filter: /^@formisch\/core\/solid$/ }, () => ({
+          path: './internals.js',
+          external: true,
+        }));
+      },
+    },
+  ],
   // Set to `true` to generate a CommonJS build alongside ESM
   // cjs: true,
 };
@@ -31,6 +42,13 @@ export default defineConfig((config) => {
 
   if (!watching && !CI) {
     const package_fields = preset.generatePackageExports(parsed_options);
+    package_fields.exports = {
+      '.': package_fields.exports,
+      './internals': {
+        types: './dist/internals.d.ts',
+        import: './dist/internals.js',
+      },
+    };
 
     console.log(
       `package.json: \n\n${JSON.stringify(package_fields, null, 2)}\n\n`

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add `@formisch/svelte/internals` to expose the framework-specific core for custom methods and building blocks
-- Fix repeated runs of the build import-rewriting script
 
 ## v1.0.0 (August 20, 2026)
 

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/svelte/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add `@formisch/svelte/internals` to expose the framework-specific core for custom methods and building blocks
+- Fix repeated runs of the build import-rewriting script
 
 ## v1.0.0 (August 20, 2026)
 

--- a/frameworks/svelte/package.json
+++ b/frameworks/svelte/package.json
@@ -32,6 +32,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.svelte.d.ts",
+      "svelte": "./dist/internals.svelte.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/svelte/scripts/rewrite-imports.js
+++ b/frameworks/svelte/scripts/rewrite-imports.js
@@ -13,7 +13,7 @@ const svelteDist = path.join(__dirname, '../dist');
 const methodsDestDir = path.join(svelteDist, 'methods');
 
 // Create destination directories
-fs.mkdirSync(methodsDestDir);
+fs.mkdirSync(methodsDestDir, { recursive: true });
 
 // Copy @formisch/core to dist
 fs.copyFileSync(

--- a/frameworks/svelte/scripts/rewrite-imports.js
+++ b/frameworks/svelte/scripts/rewrite-imports.js
@@ -10,21 +10,19 @@ const __dirname = path.dirname(__filename);
 const coreDist = path.join(__dirname, '../../../packages/core/dist');
 const methodsDist = path.join(__dirname, '../../../packages/methods/dist');
 const svelteDist = path.join(__dirname, '../dist');
-const coreDestDir = path.join(svelteDist, 'core');
 const methodsDestDir = path.join(svelteDist, 'methods');
 
 // Create destination directories
-fs.mkdirSync(coreDestDir);
 fs.mkdirSync(methodsDestDir);
 
 // Copy @formisch/core to dist
 fs.copyFileSync(
   path.join(coreDist, 'index.svelte.js'),
-  path.join(coreDestDir, 'index.svelte.js')
+  path.join(svelteDist, 'internals.svelte.js')
 );
 fs.copyFileSync(
   path.join(coreDist, 'index.svelte.d.ts'),
-  path.join(coreDestDir, 'index.svelte.d.ts')
+  path.join(svelteDist, 'internals.svelte.d.ts')
 );
 console.log('Copied @formisch/core to /dist');
 
@@ -94,11 +92,11 @@ function updateImportPaths(filePath) {
   // Calculate relative paths to core and methods directories
   const relativeToCoreJs = path.relative(
     path.dirname(filePath),
-    path.join(coreDestDir, 'index.svelte.js')
+    path.join(svelteDist, 'internals.svelte.js')
   );
   const relativeToCoreDts = path.relative(
     path.dirname(filePath),
-    path.join(coreDestDir, 'index.svelte.d.ts')
+    path.join(svelteDist, 'internals.svelte.d.ts')
   );
   const relativeToMethodsJs = path.relative(
     path.dirname(filePath),

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `@formisch/vue/internals` to expose the framework-specific core for custom methods and building blocks
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/frameworks/vue/package.json
+++ b/frameworks/vue/package.json
@@ -32,6 +32,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./internals": {
+      "types": "./dist/internals.d.ts",
+      "import": "./dist/internals.js"
     }
   },
   "sideEffects": false,

--- a/frameworks/vue/tsdown.config.ts
+++ b/frameworks/vue/tsdown.config.ts
@@ -3,6 +3,7 @@ import Vue from 'unplugin-vue/rolldown';
 
 export default defineConfig({
   entry: ['./src/index.ts'],
+  external: ['@formisch/core/vue'],
   outDir: 'dist',
   platform: 'neutral',
   outExtensions: () => ({
@@ -10,8 +11,21 @@ export default defineConfig({
     dts: '.d.ts',
   }),
   plugins: [Vue({ isProduction: true })],
+  outputOptions: {
+    paths: { '@formisch/core/vue': './internals.js' },
+  },
   dts: {
     vue: true,
-    resolve: ['@formisch/core/vue', '@formisch/methods/vue'],
+    resolve: ['@formisch/methods/vue'],
   },
+  copy: [
+    {
+      from: '../../packages/core/dist/index.vue.js',
+      to: 'dist/internals.js',
+    },
+    {
+      from: '../../packages/core/dist/index.vue.d.ts',
+      to: 'dist/internals.d.ts',
+    },
+  ],
 });

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix missing `Framework` export warning when building React Native declarations
+
 ## v1.0.0 (August 20, 2026)
 
 - Read the [Formisch v1 release announcement](https://formisch.dev/blog/formisch-v1/)

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -14,6 +14,9 @@ type Framework =
   | 'svelte'
   | 'vue';
 
+const FRAMEWORK_FILE_REGEX =
+  /\.(?:angular|preact|qwik|react|react-native|solid|svelte|vue)(?:\.d)?\.ts$/;
+
 /**
  * Rolldown plugin to rewrite framework-specific imports.
  */
@@ -23,7 +26,7 @@ function rewriteFrameworkImports(framework: Framework): RolldownPluginOption {
 
     // Transform imports of `.d.ts` files to framework-specific files
     transform(code, id) {
-      if (id.endsWith('.d.ts') && !id.endsWith(`.${framework}.d.ts`)) {
+      if (id.endsWith('.d.ts') && !FRAMEWORK_FILE_REGEX.test(id)) {
         // Match all relative import statements
         const imports = code.matchAll(/from "(\.[\w-/.]*\/([\w-]+).ts)";$/gm);
 
@@ -54,8 +57,8 @@ function rewriteFrameworkImports(framework: Framework): RolldownPluginOption {
 
     // Resolve imports of `.ts` files to framework-specific files
     async resolveId(source, importer) {
-      // Skip rewriting if importer is already a framework-specific file
-      if (importer?.endsWith(`.${framework}.ts`)) {
+      // Preserve base imports when an adapter reuses another framework's file
+      if (importer && FRAMEWORK_FILE_REGEX.test(importer)) {
         return null;
       }
 

--- a/website/src/routes/(docs)/angular/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/angular/guides/(advanced-guides)/architecture/index.mdx
@@ -121,7 +121,7 @@ return {
 };
 ```
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## How the directives connect to the DOM
 
@@ -137,6 +137,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly and Angular's reactive graph handles propagation. Updating one field does not invalidate the rest, and no `NgZone` is involved.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs — including the typed template contexts of the structural directives — so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/angular/internals` to access the framework-specific core from your application or library. The <Link href="/angular/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/angular/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/angular/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/angular/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/angular/internals';
+```
+
+This entry point re-exports the entire Angular-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/angular`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/angular` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/angular/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/angular';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/angular/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/angular/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Read signals in a template or Angular reactive context. Follow the existing functions and directives for injection context, element registration and cleanup.
+
+The [Angular binding source](https://github.com/open-circle/formisch/tree/main/frameworks/angular/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/angular/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/angular/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/angular/guides/(get-started)/coding-agents/index.mdx
@@ -7,6 +7,8 @@ contributors:
   - fabian-hiller
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct Angular code with Formisch.
@@ -65,3 +67,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/angular/guides/installation/` becomes [`/angular/guides/installation.md`](/angular/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/angular/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/angular/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/angular/guides/menu.md
+++ b/website/src/routes/(docs)/angular/guides/menu.md
@@ -26,6 +26,7 @@
 - [Field arrays](/angular/guides/field-arrays/)
 - [TypeScript](/angular/guides/typescript/)
 - [Architecture](/angular/guides/architecture/)
+- [Internals](/angular/guides/internals/)
 
 ## Migration guides
 

--- a/website/src/routes/(docs)/preact/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(advanced-guides)/architecture/index.mdx
@@ -122,7 +122,7 @@ At every level, the same four signals are created: `errors`, `isTouched`, `isEdi
 
 The form object the wrapper returns sits on top of that internal store. Form-level signals are exposed directly, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is wrapped in `computed` so it recomputes lazily as the underlying field signals change.
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -132,6 +132,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly and `@preact/signals` handles propagation. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/preact/internals` to access the framework-specific core from your application or library. The <Link href="/preact/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/preact/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/preact/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/preact/internals';
+```
+
+This entry point re-exports the entire Preact-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/preact`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/preact` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/preact/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/preact';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/preact/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/preact/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Read signals during rendering or in a Preact Signals reactive context. Follow the existing hooks for element registration and cleanup.
+
+The [Preact binding source](https://github.com/open-circle/formisch/tree/main/frameworks/preact/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/preact/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/preact/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/preact/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct Preact code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/preact/guides/installation/` becomes [`/preact/guides/installation.md`](/preact/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/preact/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/preact/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/preact/guides/menu.md
+++ b/website/src/routes/(docs)/preact/guides/menu.md
@@ -25,3 +25,4 @@
 - [Field arrays](/preact/guides/field-arrays/)
 - [TypeScript](/preact/guides/typescript/)
 - [Architecture](/preact/guides/architecture/)
+- [Internals](/preact/guides/internals/)

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/architecture/index.mdx
@@ -131,7 +131,7 @@ At every level, the same four signals are created: `errors`, `isTouched`, `isEdi
 
 The form object the wrapper returns sits on top of that internal store. Form-level signals are exposed directly, while derived state like `isTouched`, `isEdited`, `isDirty` and `isValid` is wrapped in `createComputed$` so it recomputes lazily as the underlying field signals change.
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -141,6 +141,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly and Qwik's signals handle propagation. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/qwik/internals` to access the framework-specific core from your application or library. The <Link href="/qwik/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/qwik/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/qwik/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/qwik/internals';
+```
+
+This entry point re-exports the entire Qwik-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/qwik`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/qwik` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/qwik/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/qwik';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/qwik/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/qwik/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Follow the existing hooks for reactive paths, computed signals and tasks. Event handlers and captured state must follow Qwik's serialization and QRL conventions.
+
+The [Qwik binding source](https://github.com/open-circle/formisch/tree/main/frameworks/qwik/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/qwik/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/qwik/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/qwik/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct Qwik code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/qwik/guides/installation/` becomes [`/qwik/guides/installation.md`](/qwik/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/qwik/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/qwik/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/qwik/guides/menu.md
+++ b/website/src/routes/(docs)/qwik/guides/menu.md
@@ -25,6 +25,7 @@
 - [Field arrays](/qwik/guides/field-arrays/)
 - [TypeScript](/qwik/guides/typescript/)
 - [Architecture](/qwik/guides/architecture/)
+- [Internals](/qwik/guides/internals/)
 
 ## Migration guides
 

--- a/website/src/routes/(docs)/react-native/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(advanced-guides)/architecture/index.mdx
@@ -142,7 +142,7 @@ return useMemo(
 
 At the very top of the hook body, before any of this, the wrapper calls `useSignals()` to bridge the signals into React's render cycle: it registers the component as a listener so any signal read by the getters above will trigger a re-render when it changes.
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -152,6 +152,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly, and only the components subscribed to that specific signal re-render. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/react-native/internals` to access the framework-specific core from your application or library. The <Link href="/react-native/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/react-native/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/react-native/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/react-native/internals';
+```
+
+This entry point re-exports the entire React Native-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/react-native`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/react-native` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/react-native/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/react-native';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/react-native/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/react-native/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Reading a core signal alone does not subscribe a React Native component. The existing hooks use the internal `useSignals` hook to manage subscriptions and cleanup. Compose the public hooks where possible, or follow that implementation when building your own subscription layer. Use native input handlers and refs when registering fields.
+
+The [React Native binding source](https://github.com/open-circle/formisch/tree/main/frameworks/react-native/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/react-native/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/react-native/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/react-native/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct React Native code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/react-native/guides/installation/` becomes [`/react-native/guides/installation.md`](/react-native/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/react-native/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/react-native/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/react-native/guides/menu.md
+++ b/website/src/routes/(docs)/react-native/guides/menu.md
@@ -26,6 +26,7 @@
 - [Field arrays](/react-native/guides/field-arrays/)
 - [TypeScript](/react-native/guides/typescript/)
 - [Architecture](/react-native/guides/architecture/)
+- [Internals](/react-native/guides/internals/)
 
 ## Migration guides
 

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/architecture/index.mdx
@@ -142,7 +142,7 @@ return useMemo(
 
 At the very top of the hook body, before any of this, the wrapper calls `useSignals()` to bridge the signals into React's render cycle: it registers the component as a listener so any signal read by the getters above will trigger a re-render when it changes.
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -152,6 +152,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly, and only the components subscribed to that specific signal re-render. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/react/internals` to access the framework-specific core from your application or library. The <Link href="/react/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/react/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/react/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/react/internals';
+```
+
+This entry point re-exports the entire React-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/react`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/react` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/react/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/react';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/react/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/react/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Reading a core signal alone does not subscribe a React component. The existing hooks use the internal `useSignals` hook to manage subscriptions and cleanup. Compose the public hooks where possible, or follow that implementation when building your own subscription layer.
+
+The [React binding source](https://github.com/open-circle/formisch/tree/main/frameworks/react/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/react/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/react/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/react/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct React code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/react/guides/installation/` becomes [`/react/guides/installation.md`](/react/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/react/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/react/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/react/guides/menu.md
+++ b/website/src/routes/(docs)/react/guides/menu.md
@@ -26,6 +26,7 @@
 - [Field arrays](/react/guides/field-arrays/)
 - [TypeScript](/react/guides/typescript/)
 - [Architecture](/react/guides/architecture/)
+- [Internals](/react/guides/internals/)
 
 ## Migration guides
 

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/architecture/index.mdx
@@ -131,7 +131,7 @@ const form = {
 };
 ```
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -141,6 +141,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods mutate `.value` directly and Solid's own reactivity handles propagation. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/solid/internals` to access the framework-specific core from your application or library. The <Link href="/solid/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/solid/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/solid/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/solid/internals';
+```
+
+This entry point re-exports the entire Solid-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/solid`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/solid` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/solid/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/solid';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/solid/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/solid/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Read signals in a Solid reactive context and keep reactive reads inside getters or accessors. Follow the existing primitives for element registration and cleanup.
+
+The [Solid binding source](https://github.com/open-circle/formisch/tree/main/frameworks/solid/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/solid/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/solid/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/solid/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct SolidJS code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/solid/guides/installation/` becomes [`/solid/guides/installation.md`](/solid/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/solid/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/solid/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/solid/guides/menu.md
+++ b/website/src/routes/(docs)/solid/guides/menu.md
@@ -26,6 +26,7 @@
 - [Field arrays](/solid/guides/field-arrays/)
 - [TypeScript](/solid/guides/typescript/)
 - [Architecture](/solid/guides/architecture/)
+- [Internals](/solid/guides/internals/)
 
 ## Migration guides
 

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/architecture/index.mdx
@@ -131,7 +131,7 @@ return {
 };
 ```
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -141,6 +141,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly and Svelte's compiler-driven tracking handles propagation. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/svelte/internals` to access the framework-specific core from your application or library. The <Link href="/svelte/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/svelte/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/svelte/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/svelte/internals';
+```
+
+This entry point re-exports the entire Svelte-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/svelte`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/svelte` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/svelte/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/svelte';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/svelte/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/svelte/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Read signals in a Svelte reactive context. Follow the existing runes for reactive paths, derived state, element registration and cleanup.
+
+The [Svelte binding source](https://github.com/open-circle/formisch/tree/main/frameworks/svelte/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/svelte/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/svelte/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/svelte/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct Svelte code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/svelte/guides/installation/` becomes [`/svelte/guides/installation.md`](/svelte/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/svelte/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/svelte/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/svelte/guides/menu.md
+++ b/website/src/routes/(docs)/svelte/guides/menu.md
@@ -26,6 +26,7 @@
 - [Field arrays](/svelte/guides/field-arrays/)
 - [TypeScript](/svelte/guides/typescript/)
 - [Architecture](/svelte/guides/architecture/)
+- [Internals](/svelte/guides/internals/)
 
 ## Migration guides
 

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/architecture/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/architecture/index.mdx
@@ -123,7 +123,7 @@ return {
 };
 ```
 
-The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) symbol. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while your code only sees the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
+The internal store is tucked away behind the [`INTERNAL`](https://github.com/open-circle/formisch/blob/main/packages/core/src/values.ts) key. Methods like `setInput(form, …)` reach in via `form[INTERNAL]` to mutate signals, while regular form code uses the public form store. This separation is what keeps the public API small and stable even as the internal shape evolves.
 
 ## Why this design pays off
 
@@ -133,6 +133,10 @@ Bundle size is the obvious payoff. The others are why the design is worth talkin
 - **Fine-grained reactivity.** The store shape is pre-allocated at form creation, with one signal per piece of state. Methods write `.value` directly and Vue's reactivity system handles propagation. Updating one field does not invalidate the rest.
 - **Framework portability.** The entire library is parameterized over a four-function adapter. Adding a new framework means writing a small adapter that maps `createSignal`, `batch`, `untrack` and `createId` onto its primitives.
 - **Type safety.** Your Valibot schema is the single source of truth. It drives both runtime parsing and the inferred TypeScript types for paths, inputs and outputs, so there is no second declaration to keep in sync.
+
+## Build on the core
+
+Use `@formisch/vue/internals` to access the framework-specific core from your application or library. The <Link href="/vue/guides/internals/">internals guide</Link> shows how to create custom methods and explains what to consider when building reactive bindings and components.
 
 ## Further reading
 

--- a/website/src/routes/(docs)/vue/guides/(advanced-guides)/internals/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(advanced-guides)/internals/index.mdx
@@ -1,0 +1,96 @@
+---
+title: Internals
+description: >-
+  Build custom methods and framework building blocks with Formisch's
+  framework-specific core exports.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Internals
+
+Formisch exposes its core through `@formisch/vue/internals`. You can use these functions and types to build methods, reactive bindings and components for behavior that Formisch does not provide out of the box. Coding agents can use the same building blocks as the library itself.
+
+## Versioning
+
+**Internals are not covered by Formisch's semantic versioning guarantees.** Breaking changes to their functions, types and store structure can occur in any release, including minor and patch releases. Review your use of internals when upgrading Formisch, and test validation, reactivity and cleanup for the behavior your extension implements.
+
+## Import the core
+
+```ts
+import {
+  type BaseFormStore,
+  getFieldStore,
+  INTERNAL,
+  setFieldInput,
+} from '@formisch/vue/internals';
+```
+
+This entry point re-exports the entire Vue-specific core, including store types, field and array helpers, validation utilities and the reactivity adapter. It is included in `@formisch/vue`, so no additional package is needed. Always use the internals from the same framework package as your form so they share its reactivity implementation.
+
+The regular `@formisch/vue` entry point provides the ready-made methods and framework bindings. The internals entry point gives you access to the lower-level operations and store structure described in the <Link href="/vue/guides/architecture/">architecture guide</Link>.
+
+## Implement a method
+
+The existing <Link href="/methods/api/setInput/">`setInput`</Link> method shows how these building blocks work together. This simplified implementation updates a single field and reuses `SetFieldInputConfig` to infer the path and input types from your schema:
+
+```ts
+import type { SetFieldInputConfig } from '@formisch/vue';
+import {
+  type BaseFormStore,
+  batch,
+  type FormSchema,
+  getFieldStore,
+  INTERNAL,
+  type RequiredPath,
+  setFieldInput,
+  validateIfRequired,
+} from '@formisch/vue/internals';
+
+/**
+ * Sets a field's input and validates it if required.
+ */
+export function setInput<
+  TSchema extends FormSchema,
+  TFieldPath extends RequiredPath,
+>(
+  form: BaseFormStore<TSchema>,
+  config: SetFieldInputConfig<TSchema, TFieldPath>
+): void {
+  batch(() => {
+    const internalFormStore = form[INTERNAL];
+    const internalFieldStore = getFieldStore(internalFormStore, config.path);
+
+    if (internalFieldStore) {
+      setFieldInput(internalFormStore, config.path, config.input);
+      validateIfRequired(internalFormStore, internalFieldStore, 'input');
+    }
+  });
+}
+```
+
+Pass an existing form store, a field path and its new input to this method:
+
+```ts
+setInput(loginForm, { path: ['email'], input: 'jane@example.com' });
+```
+
+`INTERNAL` is the key for accessing the internal store through `form[INTERNAL]`. `getFieldStore` can return `undefined` when a dynamic array item no longer exists, so check the result before updating the field.
+
+`setFieldInput` updates the input and maintains touched, edited and dirty state. Writing directly to an input signal bypasses this bookkeeping. `batch` groups signal updates, and `validateIfRequired` triggers validation only when the form's validation settings require it for an input event.
+
+The [full implementation](https://github.com/open-circle/formisch/blob/main/packages/methods/src/setInput/setInput.ts) also supports setting the entire form input and includes the corresponding type overloads. Use the built-in method in your application; this example is a starting point for understanding the core helpers and building your own methods.
+
+## Build reactive bindings and components
+
+You can also build your own framework bindings on top of the core. These bindings are responsible for subscribing to state changes, registering input elements or refs, handling events and cleaning up when fields unmount. Start with <Link href="/vue/guides/input-components/">input components</Link> if you can compose the existing bindings.
+
+Read signals in a Vue reactive context and keep reactive reads inside computed values or getters. Follow the existing composables for reactive paths, element registration and cleanup.
+
+The [Vue binding source](https://github.com/open-circle/formisch/tree/main/frameworks/vue/src) shows how Formisch handles these responsibilities. The core exposes the helpers those bindings use; it does not automatically supply their framework lifecycle behavior.
+
+## Work with coding agents
+
+Give your agent this guide, your schema and the behavior you want to build. Ask it to inspect the relevant method or framework binding and the installed type declarations, then test the custom behavior with your form. The <Link href="/vue/guides/coding-agents/">coding agents guide</Link> explains how to access the documentation through our skill, MCP server and Markdown files.

--- a/website/src/routes/(docs)/vue/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/(docs)/vue/guides/(get-started)/coding-agents/index.mdx
@@ -8,6 +8,8 @@ contributors:
   - flySewa
 ---
 
+import { Link } from '~/components';
+
 # Coding agents
 
 Formisch is built to be consumed by AI coding agents. This page describes the agent skill, MCP server and Markdown documentation we provide so that your AI tools generate correct Vue code with Formisch.
@@ -66,3 +68,7 @@ We provide several [LLMs.txt](https://llmstxt.org/) files. Use the one that work
 ## Markdown for agents
 
 Every documentation page is available as Markdown. Append `.md` to the URL of a page (e.g. `/vue/guides/installation/` becomes [`/vue/guides/installation.md`](/vue/guides/installation.md)) or request the page with an `Accept: text/markdown` header to receive its Markdown version.
+
+## Custom building blocks
+
+Coding agents can use `@formisch/vue/internals` to build custom methods and framework bindings with the same core helpers as Formisch. See the <Link href="/vue/guides/internals/">internals guide</Link> for a typed example and guidance on reactivity and lifecycle behavior.

--- a/website/src/routes/(docs)/vue/guides/menu.md
+++ b/website/src/routes/(docs)/vue/guides/menu.md
@@ -26,6 +26,7 @@
 - [Field arrays](/vue/guides/field-arrays/)
 - [TypeScript](/vue/guides/typescript/)
 - [Architecture](/vue/guides/architecture/)
+- [Internals](/vue/guides/internals/)
 
 ## Migration guides
 


### PR DESCRIPTION
Expose the framework-specific core through `@formisch/<framework>/internals` in all eight framework packages so users and coding agents can build custom methods and bindings. The public API and internals import the same copied core module, preserving shared subscriptions and batching.

Add an internals guide for each framework with a simplified `setInput` implementation, reactivity guidance, and an explicit warning that internals can break in any release, including minor and patch releases. Link the guides from navigation, architecture, and coding-agent docs, and update the framework changelogs.

Also fix the core build warning when React Native reuses the React adapter, preserve Qwik's optimizer-recognized runtime suffix and matching declaration filename, and make the Svelte import-rewriting step safe to rerun.

Validation:
- Built all eight framework packages and checked exact core copies, export targets, and packaged imports.
- Passed package validation, framework lint/type checks, and type checks for all guide examples.
- Ran runtime interoperability smoke checks across all frameworks, including React and React Native rendering and batching checks.
- Built the website, verified generated documentation indexes, and passed formatting and diff checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added framework-specific `internals` entry points for Angular, Preact, Qwik, React Native, React, Solid, Svelte, and Vue.
  * These entry points support building custom methods, reactive bindings, and framework components.

* **Bug Fixes**
  * Fixed a missing framework export warning when building React Native declarations.
  * Improved framework-specific build import handling across shared framework files.

* **Documentation**
  * Added Internals guides, examples, navigation links, and architecture references across supported frameworks.
  * Documented lifecycle considerations and the lack of standard semantic-versioning guarantees for internals APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
