### PR TITLE
Fix stale validation after input changes and submission races

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Fix field input updates to discard pending validation results for previous input
-- Add internal submission ID to track current submission state
+- Fix submission tracking for concurrent submissions and full form resets
 - Fix missing `Framework` export warning when building React Native declarations
 
 ## v1.0.0 (August 20, 2026)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the library will be documented in this file.
 
 ## vX.X.X (Month DD, YYYY)
 
+- Fix field input updates to discard pending validation results for previous input
+- Add internal submission ID to track current submission state
 - Fix missing `Framework` export warning when building React Native declarations
 
 ## v1.0.0 (August 20, 2026)

--- a/packages/core/src/field/setFieldInput/setFieldInput.test.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.test.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot';
 import { describe, expect, test } from 'vitest';
+import { validateFormInput } from '../../form/validateFormInput/validateFormInput.ts';
 import { createTestStore } from '../../vitest/index.ts';
 import { getFieldBool } from '../getFieldBool/getFieldBool.ts';
 import { getFieldInput } from '../getFieldInput/getFieldInput.ts';
@@ -330,5 +331,27 @@ describe('setFieldInput', () => {
       setFieldInput(store, ['user'], null);
       expect(store.children.user.isDirty.value).toBe(true);
     });
+  });
+
+  test('should discard pending validation when input changes', async () => {
+    const schema = v.object({
+      name: v.pipe(v.string(), v.nonEmpty('Required')),
+    });
+    type ParseResult = v.SafeParseResult<typeof schema>;
+    let resolveParse: (value: ParseResult) => void;
+    const pendingParse = new Promise<ParseResult>((resolve) => {
+      resolveParse = resolve;
+    });
+    const store = createTestStore(schema, { initialInput: { name: '' } });
+    store.parse = () => pendingParse;
+    const pendingValidation = validateFormInput(store);
+
+    setFieldInput(store, ['name'], 'John');
+    expect(store.isValidating.value).toBe(false);
+
+    resolveParse!(v.safeParse(schema, { name: '' }));
+    await pendingValidation;
+    expect(store.children.name.input.value).toBe('John');
+    expect(store.children.name.errors.value).toBeNull();
   });
 });

--- a/packages/core/src/field/setFieldInput/setFieldInput.ts
+++ b/packages/core/src/field/setFieldInput/setFieldInput.ts
@@ -190,6 +190,10 @@ export function setFieldInput(
         }
       }
 
+      // Invalidate validation of previous input
+      internalFormStore.validationId++;
+      internalFormStore.isValidating.value = false;
+
       // Set nested input on target field
       setNestedInput(internalFormStore, internalFieldStore, input);
     });

--- a/packages/core/src/form/createFormStore/createFormStore.test.ts
+++ b/packages/core/src/form/createFormStore/createFormStore.test.ts
@@ -13,12 +13,13 @@ describe('createFormStore', () => {
       expect(store.revalidate).toBe('input');
     });
 
-    test('should initialize validation ID to 0', () => {
+    test('should initialize validation and submission IDs to 0', () => {
       const schema = v.object({ name: v.string() });
       const parse = vi.fn();
       const store = createFormStore({ schema }, parse);
 
       expect(store.validationId).toBe(0);
+      expect(store.submissionId).toBe(0);
     });
 
     test('should initialize all boolean signals to false', () => {

--- a/packages/core/src/form/createFormStore/createFormStore.ts
+++ b/packages/core/src/form/createFormStore/createFormStore.ts
@@ -38,6 +38,7 @@ export function createFormStore(
 
   // Set form config and validation
   store.validationId = 0;
+  store.submissionId = 0;
   store.validate = config.validate ?? 'submit';
   store.revalidate = config.revalidate ?? 'input';
   store.parse = parse;

--- a/packages/core/src/form/validateFormInput/validateFormInput.ts
+++ b/packages/core/src/form/validateFormInput/validateFormInput.ts
@@ -41,11 +41,10 @@ export async function validateFormInput(
       untrack(() => getFieldInput(internalFormStore))
     );
 
-    // Return outdated result without processing it if a newer validation was
-    // started in the meantime
-    // Hint: Only the newest validation may write errors or reset the validating
-    // state, so an older async result that settles late cannot overwrite the
-    // state of a newer validation.
+    // Return outdated result without processing it
+    // Hint: Input changes and resets also invalidate pending results without
+    // starting a new validation. Only the current validation may write errors
+    // or reset the validating state.
     if (internalFormStore.validationId !== validationId) {
       return result;
     }

--- a/packages/core/src/types/form/form.qwik.ts
+++ b/packages/core/src/types/form/form.qwik.ts
@@ -54,6 +54,10 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
    */
   validationId: number;
   /**
+   * The ID of the latest submission. Incremented by full form resets as well.
+   */
+  submissionId: number;
+  /**
    * The resolved empty input of the form, keyed by field type.
    */
   emptyInput: EmptyInput;

--- a/packages/core/src/types/form/form.qwik.ts
+++ b/packages/core/src/types/form/form.qwik.ts
@@ -50,7 +50,8 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
   element?: HTMLFormElement | undefined;
 
   /**
-   * The ID of the latest validation.
+   * The validation ID, incremented when validation starts or pending results
+   * are invalidated.
    */
   validationId: number;
   /**

--- a/packages/core/src/types/form/form.react-native.ts
+++ b/packages/core/src/types/form/form.react-native.ts
@@ -21,6 +21,10 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
    */
   validationId: number;
   /**
+   * The ID of the latest submission. Incremented by full form resets as well.
+   */
+  submissionId: number;
+  /**
    * The resolved empty input of the form, keyed by field type.
    */
   emptyInput: EmptyInput;

--- a/packages/core/src/types/form/form.react-native.ts
+++ b/packages/core/src/types/form/form.react-native.ts
@@ -17,7 +17,8 @@ import type {
 export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
   extends InternalObjectStore {
   /**
-   * The ID of the latest validation.
+   * The validation ID, incremented when validation starts or pending results
+   * are invalidated.
    */
   validationId: number;
   /**

--- a/packages/core/src/types/form/form.ts
+++ b/packages/core/src/types/form/form.ts
@@ -83,7 +83,8 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
   element?: HTMLFormElement | undefined;
 
   /**
-   * The ID of the latest validation.
+   * The validation ID, incremented when validation starts or pending results
+   * are invalidated.
    */
   validationId: number;
   /**

--- a/packages/core/src/types/form/form.ts
+++ b/packages/core/src/types/form/form.ts
@@ -87,6 +87,10 @@ export interface InternalFormStore<TSchema extends FormSchema = FormSchema>
    */
   validationId: number;
   /**
+   * The ID of the latest submission. Incremented by full form resets as well.
+   */
+  submissionId: number;
+  /**
    * The resolved empty input of the form, keyed by field type.
    */
   emptyInput: EmptyInput;

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Fix full form reset to discard pending validation results and clear the validating state (issue #210, pull request #211)
+- Fix field resets and array mutations to discard pending validation results for previous input
+- Fix submissions to ignore validation results superseded by input changes, full resets, or newer submissions
+- Fix older submission handlers to preserve current errors and submitting state after full resets or newer submissions
 
 ## v1.0.0 (August 20, 2026)
 

--- a/packages/methods/src/handleSubmit/handleSubmit.test.ts
+++ b/packages/methods/src/handleSubmit/handleSubmit.test.ts
@@ -2,6 +2,8 @@
 import type { SubmitEventHandler, SubmitHandler } from '@formisch/core';
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
+import { reset } from '../reset/reset.ts';
+import { setInput } from '../setInput/setInput.ts';
 import { createTestStore } from '../vitest/index.ts';
 import { handleSubmit } from './handleSubmit.ts';
 
@@ -185,5 +187,144 @@ describe('handleSubmit', () => {
 
     expect(handler).toHaveBeenCalledOnce();
     expect(store.isSubmitting.value).toBe(false);
+  });
+
+  describe('superseded submissions', () => {
+    test.each([
+      { action: 'reset', rejects: false },
+      { action: 'reset', rejects: true },
+      { action: 'setInput', rejects: false },
+      { action: 'setInput', rejects: true },
+      { action: 'submit', rejects: false },
+      { action: 'submit', rejects: true },
+    ])(
+      'should discard pending validation after $action (rejects: $rejects)',
+      async ({ action, rejects }) => {
+        type ParseResult = v.SafeParseResult<Schema>;
+        let resolveParse: (value: ParseResult) => void;
+        let rejectParse: (error: Error) => void;
+        const pendingParse = new Promise<ParseResult>((resolve, reject) => {
+          resolveParse = resolve;
+          rejectParse = reject;
+        });
+        const store = createTestStore(schema, {
+          initialInput: { name: 'John' },
+          revalidate: 'blur',
+        });
+        store.parse = vi
+          .fn()
+          .mockReturnValueOnce(pendingParse)
+          .mockImplementation((input: unknown) =>
+            Promise.resolve(v.safeParse(schema, input))
+          );
+        const oldHandler = vi.fn();
+        const pendingSubmission = handleSubmit(store, oldHandler)();
+
+        if (action === 'reset') {
+          reset(store);
+          expect(store.isSubmitting.value).toBe(false);
+        } else if (action === 'setInput') {
+          setInput(store, { path: ['name'], input: 'Jane' });
+        } else {
+          const newHandler = vi.fn();
+          await handleSubmit(store, newHandler)();
+          expect(newHandler).toHaveBeenCalledOnce();
+        }
+
+        if (rejects) {
+          rejectParse!(new Error('Old validation failed'));
+        } else {
+          resolveParse!(v.safeParse(schema, { name: 'John' }));
+        }
+        await pendingSubmission;
+
+        expect(oldHandler).not.toHaveBeenCalled();
+        expect(store.errors.value).toBeNull();
+        expect(store.isSubmitting.value).toBe(false);
+      }
+    );
+
+    test.each([false, true])(
+      'should preserve newer submission state when an old handler finishes (reset: %s)',
+      async (shouldReset) => {
+        let rejectOldHandler: (error: Error) => void;
+        const oldResult = new Promise<void>((_, reject) => {
+          rejectOldHandler = reject;
+        });
+        let resolveOldStarted: () => void;
+        const oldStarted = new Promise<void>((resolve) => {
+          resolveOldStarted = resolve;
+        });
+        let resolveNewHandler: () => void;
+        const newResult = new Promise<void>((resolve) => {
+          resolveNewHandler = resolve;
+        });
+        let resolveNewStarted: () => void;
+        const newStarted = new Promise<void>((resolve) => {
+          resolveNewStarted = resolve;
+        });
+        const store = createTestStore(schema, {
+          initialInput: { name: 'John' },
+        });
+        const oldSubmission = handleSubmit(store, () => {
+          resolveOldStarted!();
+          return oldResult;
+        })();
+        await oldStarted;
+
+        if (shouldReset) {
+          reset(store);
+          expect(store.isSubmitting.value).toBe(false);
+        }
+        const newSubmission = handleSubmit(store, () => {
+          resolveNewStarted!();
+          return newResult;
+        })();
+        await newStarted;
+
+        rejectOldHandler!(new Error('Old request failed'));
+        await oldSubmission;
+        expect(store.isSubmitting.value).toBe(true);
+        expect(store.errors.value).toBeNull();
+
+        resolveNewHandler!();
+        await newSubmission;
+        expect(store.isSubmitting.value).toBe(false);
+      }
+    );
+
+    test.each(['setInput', 'reset'])(
+      'should handle late handler errors after %s',
+      async (action) => {
+        let rejectHandler: (error: Error) => void;
+        const pendingResult = new Promise<void>((_, reject) => {
+          rejectHandler = reject;
+        });
+        let resolveStarted: () => void;
+        const started = new Promise<void>((resolve) => {
+          resolveStarted = resolve;
+        });
+        const store = createTestStore(schema, {
+          initialInput: { name: 'John' },
+        });
+        const submission = handleSubmit(store, () => {
+          resolveStarted!();
+          return pendingResult;
+        })();
+        await started;
+
+        if (action === 'setInput') {
+          setInput(store, { path: ['name'], input: 'Jane' });
+        } else {
+          reset(store);
+        }
+        rejectHandler!(new Error('Request failed'));
+        await submission;
+        expect(store.errors.value).toEqual(
+          action === 'setInput' ? ['Request failed'] : null
+        );
+        expect(store.isSubmitting.value).toBe(false);
+      }
+    );
   });
 });

--- a/packages/methods/src/handleSubmit/handleSubmit.ts
+++ b/packages/methods/src/handleSubmit/handleSubmit.ts
@@ -57,6 +57,7 @@ export function handleSubmit(
     internalFormStore.isSubmitted.value = true;
     internalFormStore.isSubmitting.value = true;
 
+    // Hint: Capture this call's ID before parsing can invalidate its input.
     const validationId = internalFormStore.validationId + 1;
 
     // Try to run submit actions if form is valid
@@ -65,15 +66,12 @@ export function handleSubmit(
         shouldFocus: true,
       });
 
-      // Discard submissions superseded during validation
+      // Run handler only for current successful validation
       if (
-        internalFormStore.submissionId !== submissionId ||
-        internalFormStore.validationId !== validationId
+        result.success &&
+        internalFormStore.submissionId === submissionId &&
+        internalFormStore.validationId === validationId
       ) {
-        return;
-      }
-
-      if (result.success) {
         isHandlingSubmit = true;
         // @ts-expect-error - union of SubmitHandler and SubmitEventHandler
         await handler(result.output, event);

--- a/packages/methods/src/handleSubmit/handleSubmit.ts
+++ b/packages/methods/src/handleSubmit/handleSubmit.ts
@@ -49,9 +49,15 @@ export function handleSubmit(
     // Get internal form store
     const internalFormStore = form[INTERNAL];
 
+    // Record submission order
+    const submissionId = ++internalFormStore.submissionId;
+    let isHandlingSubmit = false;
+
     // Mark form as submitted and submitting
     internalFormStore.isSubmitted.value = true;
     internalFormStore.isSubmitting.value = true;
+
+    const validationId = internalFormStore.validationId + 1;
 
     // Try to run submit actions if form is valid
     try {
@@ -59,25 +65,43 @@ export function handleSubmit(
         shouldFocus: true,
       });
 
+      // Discard submissions superseded during validation
+      if (
+        internalFormStore.submissionId !== submissionId ||
+        internalFormStore.validationId !== validationId
+      ) {
+        return;
+      }
+
       if (result.success) {
+        isHandlingSubmit = true;
         // @ts-expect-error - union of SubmitHandler and SubmitEventHandler
         await handler(result.output, event);
       }
 
       // If an error occurred, set form errors
     } catch (error: unknown) {
-      internalFormStore.errors.value = [
-        error &&
-        typeof error === 'object' &&
-        'message' in error &&
-        typeof error.message === 'string'
-          ? error.message
-          : 'An unknown error has occurred.',
-      ];
+      // Hint: Once the handler starts, input changes must not hide its errors.
+      // A newer submission or full reset still takes precedence.
+      if (
+        internalFormStore.submissionId === submissionId &&
+        (isHandlingSubmit || internalFormStore.validationId === validationId)
+      ) {
+        internalFormStore.errors.value = [
+          error &&
+          typeof error === 'object' &&
+          'message' in error &&
+          typeof error.message === 'string'
+            ? error.message
+            : 'An unknown error has occurred.',
+        ];
+      }
 
       // Finally reset submitting state
     } finally {
-      internalFormStore.isSubmitting.value = false;
+      if (internalFormStore.submissionId === submissionId) {
+        internalFormStore.isSubmitting.value = false;
+      }
     }
   };
 }

--- a/packages/methods/src/insert/insert.ts
+++ b/packages/methods/src/insert/insert.ts
@@ -83,6 +83,10 @@ export function insert<
     // Continue if insertion index is valid
     if (insertIndex >= 0 && insertIndex <= items.length) {
       batch(() => {
+        // Invalidate validation of previous array input
+        internalFormStore.validationId++;
+        internalFormStore.isValidating.value = false;
+
         // Insert new item ID at the specified index
         const newItems = [...items];
         newItems.splice(insertIndex, 0, createId());

--- a/packages/methods/src/move/move.ts
+++ b/packages/methods/src/move/move.ts
@@ -68,6 +68,10 @@ export function move<
       config.from !== config.to
     ) {
       batch(() => {
+        // Invalidate validation of previous array input
+        internalFormStore.validationId++;
+        internalFormStore.isValidating.value = false;
+
         // Move item ID in the items array
         const newItems = [...items];
         newItems.splice(config.to, 0, newItems.splice(config.from, 1)[0]);

--- a/packages/methods/src/remove/remove.ts
+++ b/packages/methods/src/remove/remove.ts
@@ -56,6 +56,10 @@ export function remove<
     // Continue if specified index is valid
     if (config.at >= 0 && config.at <= items.length - 1) {
       batch(() => {
+        // Invalidate validation of previous array input
+        internalFormStore.validationId++;
+        internalFormStore.isValidating.value = false;
+
         // Remove item ID from the items array
         const newItems = [...items];
         newItems.splice(config.at, 1);

--- a/packages/methods/src/replace/replace.ts
+++ b/packages/methods/src/replace/replace.ts
@@ -66,6 +66,10 @@ export function replace<
     // Continue if specified index is valid
     if (config.at >= 0 && config.at <= items.length - 1) {
       batch(() => {
+        // Invalidate validation of previous array input
+        internalFormStore.validationId++;
+        internalFormStore.isValidating.value = false;
+
         // Replace item ID to trigger reactivity
         const newItems = [...items];
         newItems[config.at] = createId();

--- a/packages/methods/src/reset/reset.ts
+++ b/packages/methods/src/reset/reset.ts
@@ -118,6 +118,11 @@ export function reset(
         ? getFieldStore(internalFormStore, config.path)
         : internalFormStore;
       if (internalFieldStore) {
+        // Invalidate pending validation before resetting field state
+        // Hint: Stale results skip cleanup, so clear the validating state here.
+        internalFormStore.validationId++;
+        internalFormStore.isValidating.value = false;
+
         // If initial input is provided, set it
         if (config && 'initialInput' in config) {
           setInitialFieldInput(
@@ -218,17 +223,9 @@ export function reset(
 
         // If path is not defined, reset form specific state
         if (!config?.path) {
-          // Invalidate any validation that is still pending from before the
-          // reset so its result cannot be applied to the state below once it
-          // settles.
-          // Hint: `validateFormInput` only writes its result when its captured
-          // ID still matches `internalFormStore.validationId`, so bumping it
-          // here makes that check fail for the outdated validation. Since that
-          // validation will now skip its own cleanup, `isValidating` is reset
-          // here as well. If `validate` is `'initial'`, it is set back to
-          // `true` below by the new validation this method starts.
-          internalFormStore.validationId++;
-          internalFormStore.isValidating.value = false;
+          // Discard pending submissions
+          internalFormStore.submissionId++;
+          internalFormStore.isSubmitting.value = false;
 
           // Reset is submitted if it is not to be kept
           if (!config?.keepSubmitted) {

--- a/packages/methods/src/setInput/setInput.test.ts
+++ b/packages/methods/src/setInput/setInput.test.ts
@@ -101,8 +101,7 @@ describe('setInput', () => {
 
     setInput(store, { path: ['name'], input: 'John' });
 
-    // Check that validation ID increased, indicating validation was triggered
-    expect(store.validationId).toBe(1);
+    expect(store.parse).toHaveBeenCalledExactlyOnceWith({ name: 'John' });
   });
 
   test('should keep dirty state from swap when setting nested field', () => {

--- a/packages/methods/src/swap/swap.ts
+++ b/packages/methods/src/swap/swap.ts
@@ -65,6 +65,10 @@ export function swap<
       config.at !== config.and
     ) {
       batch(() => {
+        // Invalidate validation of previous array input
+        internalFormStore.validationId++;
+        internalFormStore.isValidating.value = false;
+
         // Swap item IDs in items array
         const newItems = [...items];
         const tempItemId = newItems[config.at];

--- a/packages/methods/src/validate/validate.test.ts
+++ b/packages/methods/src/validate/validate.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
+import { getErrors } from '../getErrors/getErrors.ts';
+import { getInput } from '../getInput/getInput.ts';
+import { insert } from '../insert/insert.ts';
+import { move } from '../move/move.ts';
+import { remove } from '../remove/remove.ts';
+import { replace } from '../replace/replace.ts';
+import { reset } from '../reset/reset.ts';
+import { setInput } from '../setInput/setInput.ts';
+import { swap } from '../swap/swap.ts';
 import { createTestStore } from '../vitest/index.ts';
 import { validate } from './validate.ts';
 
@@ -104,5 +113,135 @@ describe('validate', () => {
     await validate(store, { shouldFocus: false });
 
     expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  describe('input changes during validation', () => {
+    test.each<'blur' | 'input'>(['blur', 'input'])(
+      'should discard old errors after setInput in %s mode',
+      async (mode) => {
+        const schema = v.object({
+          name: v.pipe(v.string(), v.nonEmpty('Required')),
+        });
+        type ParseResult = v.SafeParseResult<typeof schema>;
+        let resolveParse: (value: ParseResult) => void;
+        const pendingParse = new Promise<ParseResult>((resolve) => {
+          resolveParse = resolve;
+        });
+        const store = createTestStore(schema, {
+          validate: mode,
+          initialInput: { name: '' },
+        });
+        store.parse = vi
+          .fn()
+          .mockReturnValueOnce(pendingParse)
+          .mockResolvedValue(v.safeParse(schema, { name: 'John' }));
+        const pendingValidation = validate(store);
+
+        setInput(store, { path: ['name'], input: 'John' });
+        resolveParse!(v.safeParse(schema, { name: '' }));
+        await pendingValidation;
+
+        expect(store.children.name.errors.value).toBeNull();
+        expect(store.isValidating.value).toBe(false);
+      }
+    );
+
+    test('should discard old errors after a field reset', async () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.nonEmpty('Required')),
+      });
+      type ParseResult = v.SafeParseResult<typeof schema>;
+      let resolveParse: (value: ParseResult) => void;
+      const pendingParse = new Promise<ParseResult>((resolve) => {
+        resolveParse = resolve;
+      });
+      const store = createTestStore(schema, { initialInput: { name: 'John' } });
+      store.parse = () => pendingParse;
+      setInput(store, { path: ['name'], input: '' });
+      const pendingValidation = validate(store);
+
+      reset(store, { path: ['name'] });
+      expect(store.isValidating.value).toBe(false);
+      resolveParse!(v.safeParse(schema, { name: '' }));
+      await pendingValidation;
+
+      expect(store.children.name.input.value).toBe('John');
+      expect(store.children.name.errors.value).toBeNull();
+    });
+
+    test.each(['insert', 'remove', 'replace', 'move', 'swap'])(
+      'should not apply errors to a different array item after %s',
+      async (method) => {
+        const schema = v.object({
+          names: v.array(v.pipe(v.string(), v.nonEmpty('Required'))),
+        });
+        type ParseResult = v.SafeParseResult<typeof schema>;
+        let resolveParse: (value: ParseResult) => void;
+        const pendingParse = new Promise<ParseResult>((resolve) => {
+          resolveParse = resolve;
+        });
+        const store = createTestStore(schema, {
+          validate: 'blur',
+          initialInput: { names: ['', 'John'] },
+        });
+        store.parse = () => pendingParse;
+        const pendingValidation = validate(store);
+
+        if (method === 'insert') {
+          insert(store, { path: ['names'], at: 0, initialInput: 'Jane' });
+        } else if (method === 'remove') {
+          remove(store, { path: ['names'], at: 0 });
+        } else if (method === 'replace') {
+          replace(store, { path: ['names'], at: 0, initialInput: 'Jane' });
+        } else if (method === 'move') {
+          move(store, { path: ['names'], from: 0, to: 1 });
+        } else {
+          swap(store, { path: ['names'], at: 0, and: 1 });
+        }
+
+        expect(store.isValidating.value).toBe(false);
+        resolveParse!(v.safeParse(schema, { names: ['', 'John'] }));
+        await pendingValidation;
+
+        expect(getInput(store, { path: ['names', 0] })).not.toBe('');
+        expect(getErrors(store, { path: ['names', 0] })).toBeNull();
+      }
+    );
+
+    test.each(['insert', 'remove', 'replace', 'move', 'swap'])(
+      'should preserve pending validation when %s is ignored',
+      async (method) => {
+        const schema = v.object({
+          names: v.array(v.pipe(v.string(), v.nonEmpty('Required'))),
+        });
+        type ParseResult = v.SafeParseResult<typeof schema>;
+        let resolveParse: (value: ParseResult) => void;
+        const pendingParse = new Promise<ParseResult>((resolve) => {
+          resolveParse = resolve;
+        });
+        const store = createTestStore(schema, {
+          initialInput: { names: [''] },
+        });
+        store.parse = () => pendingParse;
+        const pendingValidation = validate(store);
+
+        if (method === 'insert') {
+          insert(store, { path: ['names'], at: -1 });
+        } else if (method === 'remove') {
+          remove(store, { path: ['names'], at: -1 });
+        } else if (method === 'replace') {
+          replace(store, { path: ['names'], at: -1 });
+        } else if (method === 'move') {
+          move(store, { path: ['names'], from: 0, to: 0 });
+        } else {
+          swap(store, { path: ['names'], at: 0, and: 0 });
+        }
+
+        expect(store.isValidating.value).toBe(true);
+        resolveParse!(v.safeParse(schema, { names: [''] }));
+        await pendingValidation;
+        expect(getErrors(store, { path: ['names', 0] })).toEqual(['Required']);
+      }
+    );
   });
 });

--- a/website/src/routes/(docs)/methods/api/(methods)/handleSubmit/index.mdx
+++ b/website/src/routes/(docs)/methods/api/(methods)/handleSubmit/index.mdx
@@ -32,6 +32,10 @@ const result = handleSubmit<TSchema>(form, handler);
 
 The `form` parameter is the form store to handle submission for. The `handler` parameter can be a `SubmitHandler` (no event) or, in the frameworks that submit through a form element, a `SubmitEventHandler` (with event) that gets called with the validated form output if validation succeeds. In React Native only `SubmitHandler` applies, as there is no submit event.
 
+If the input changes, the form is fully reset, or a newer validation or submission starts before validation finishes, the outdated submission does not call its handler.
+
+A newer submission or full form reset also prevents an older handler from changing form errors or `isSubmitting` when it finishes. This does not abort a handler or network request that has already started.
+
 ## Returns
 
 - `result` <Property {...properties.result} />

--- a/website/src/routes/(docs)/methods/api/(methods)/reset/index.mdx
+++ b/website/src/routes/(docs)/methods/api/(methods)/reset/index.mdx
@@ -34,6 +34,10 @@ When called without a config or with `path` set to `undefined`, the entire form 
 
 By default, the form resets to its original initial input. However, you can pass a new `initialInput` in the config to update the form's baseline data. This is useful when remote data has changed and the form needs to reflect the updated values. Combined with `keepInput`, `keepTouched`, `keepEdited`, `keepErrors`, and `keepSubmitted`, you can update the initial state without overwriting the user's current edits.
 
+Resetting a field discards pending validation of the previous form input, including results for other fields. Existing errors on unrelated fields are preserved. Call <Link href="../validate/">`validate`</Link> if you need fresh results immediately after a field reset.
+
+A full form reset clears `isSubmitting`. Pending submissions no longer call their handlers after validation finishes, and late exceptions from their validations or handlers do not update form errors. Resetting does not abort a handler or network request that has already started.
+
 #### More context on dirty tracking
 
 Formisch distinguishes between two concepts:

--- a/website/src/routes/(docs)/methods/api/(methods)/setInput/index.mdx
+++ b/website/src/routes/(docs)/methods/api/(methods)/setInput/index.mdx
@@ -34,6 +34,8 @@ The `form` parameter is the form store to set input on. The `config` parameter s
 
 > `setInput` updates the **current input** (what the user is editing), but it does not change the **initial input** (the baseline used for `isDirty`). If your baseline data changes (e.g. after refetching from the server), prefer <Link href="../reset/">`reset`</Link> with a new `initialInput`.
 
+Updating input discards pending validation results for the previous input. A new validation only starts when required by the form's validation mode.
+
 ## Related
 
 ### Primitives


### PR DESCRIPTION
Pending validation could apply errors for previous input after a field edit, field reset, or array mutation. Moving or removing an array item could put those errors on a different item. Overlapping submissions could also let an older attempt overwrite errors or clear `isSubmitting` while the newer attempt was pending.

Invalidate pending validation when input changes, including the shared field-input path used by framework event handlers. Track submission order so outdated validation cannot invoke a submit handler, and older handlers cannot overwrite current submission state after a newer submit or full reset. Handlers and network requests that already started are not aborted.

Includes deterministic regressions, coverage for ignored array operations, API documentation, and core/methods changelog entries. Builds on the merged full-reset fix in #211.

Validation: 465 core, 274 methods, 59 React, and 56 React Native tests passed (854 total), with no type errors. Core and methods ESLint/TypeScript checks, package builds, changed-file Prettier, and `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated validation results from overwriting errors after input changes, resets, or field-array updates.
  - Improved submission handling so superseded submissions no longer apply stale errors or incorrectly change submitting status.
  - Full form resets now clear pending submission state.
  - Field-array operations consistently trigger validation for the latest input.

- **Documentation**
  - Clarified how input changes, resets, and concurrent submissions affect validation, errors, and submission handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->