### PR TITLE
Prepare v1.1.0 framework release

### DIFF
--- a/frameworks/angular/CHANGELOG.md
+++ b/frameworks/angular/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/angular/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/angular/package.json
+++ b/frameworks/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/angular",
   "description": "The lightweight, schema-first, and fully type-safe form library for Angular",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/preact/CHANGELOG.md
+++ b/frameworks/preact/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/preact/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/preact/package.json
+++ b/frameworks/preact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/preact",
   "description": "The lightweight, schema-first, and fully type-safe form library for Preact",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/qwik/CHANGELOG.md
+++ b/frameworks/qwik/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/qwik/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/qwik/package.json
+++ b/frameworks/qwik/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/qwik",
   "description": "The lightweight, schema-first, and fully type-safe form library for Qwik",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/react-native/CHANGELOG.md
+++ b/frameworks/react-native/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/react-native/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/react-native/package.json
+++ b/frameworks/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/react-native",
   "description": "The lightweight, schema-first, and fully type-safe form library for React Native",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/react/CHANGELOG.md
+++ b/frameworks/react/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/react/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/react",
   "description": "The lightweight, schema-first, and fully type-safe form library for React",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/solid/CHANGELOG.md
+++ b/frameworks/solid/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/solid/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/solid/package.json
+++ b/frameworks/solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/solid",
   "description": "The lightweight, schema-first, and fully type-safe form library for SolidJS",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/svelte/CHANGELOG.md
+++ b/frameworks/svelte/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/svelte/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/svelte/package.json
+++ b/frameworks/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/svelte",
   "description": "The lightweight, schema-first, and fully type-safe form library for Svelte",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/frameworks/vue/CHANGELOG.md
+++ b/frameworks/vue/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.1.0 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
+- Change `@formisch/methods` to v1.0.1
 - Add `@formisch/vue/internals` to expose the framework-specific core for custom methods and building blocks
 
 ## v1.0.0 (August 20, 2026)

--- a/frameworks/vue/package.json
+++ b/frameworks/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/vue",
   "description": "The lightweight, schema-first, and fully type-safe form library for Vue",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.0.1 (September 07, 2026)
 
 - Fix field input updates to discard pending validation results for previous input
 - Fix submission tracking for concurrent submissions and full form resets

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/core",
   "description": "The lightweight, schema-first, and fully type-safe form library for React, Solid, Vue, Svelte and more",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",

--- a/packages/methods/CHANGELOG.md
+++ b/packages/methods/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.0.1 (September 07, 2026)
 
+- Change `@formisch/core` to v1.0.1
 - Fix full form reset to discard pending validation results and clear the validating state (issue #210, pull request #211)
 - Fix field resets and array mutations to discard pending validation results for previous input
 - Fix submissions to ignore validation results superseded by input changes, full resets, or newer submissions

--- a/packages/methods/package.json
+++ b/packages/methods/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formisch/methods",
   "description": "The lightweight, schema-first, and fully type-safe form library for React, Solid, Vue, Svelte and more",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://formisch.dev",


### PR DESCRIPTION
Prepare the next release with `@formisch/core` and `@formisch/methods` at **1.0.1** for validation and submission fixes, and all eight framework packages at **1.1.0** for the new `/internals` exports.

Update package versions and changelogs dated September 07, 2026, including bundled dependency updates. Preserve all published changelog history.

Validation: version reporting, manifest/changelog consistency, Prettier checks for all changed files, and `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released `@formisch/core` and `@formisch/methods` version 1.0.1.
  * Released framework integrations for Angular, Preact, Qwik, React Native, React, Solid, Svelte, and Vue as version 1.1.0.

* **Documentation**
  * Updated changelogs with dated release entries.
  * Documented field input updates, submission tracking, and a React Native export fix included in the core release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->